### PR TITLE
add device option to docker run

### DIFF
--- a/docs/examples/netbird-docker.md
+++ b/docs/examples/netbird-docker.md
@@ -19,7 +19,7 @@ The setup key could be found in the NetBird Management dashboard under the Setup
 Set the ```NB_SETUP_KEY``` environment variable and run the command. 
 
 ```bash
-docker run --rm --name PEER_NAME --hostname PEER_NAME --cap-add=NET_ADMIN -d -e NB_SETUP_KEY=<SETUP KEY> -v netbird-client:/etc/netbird netbirdio/netbird:latest
+docker run --rm --name PEER_NAME --hostname PEER_NAME --cap-add=NET_ADMIN --device=/dev/net/tun -d -e NB_SETUP_KEY=<SETUP KEY> -v netbird-client:/etc/netbird netbirdio/netbird:latest
 ```
 
 That is it! Enjoy using NetBird.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -216,7 +216,7 @@ Set the ```NB_SETUP_KEY``` environment variable and run the command.
 You can pass other settings as environment variables. See [Environment variables](reference/netbird-commands.md#environment-variables) for details.
 :::
 ```bash
-docker run --rm --name PEER_NAME --hostname PEER_NAME --cap-add=NET_ADMIN -d -e NB_SETUP_KEY=<SETUP KEY> -v netbird-client:/etc/netbird netbirdio/netbird:latest
+docker run --rm --name PEER_NAME --hostname PEER_NAME --cap-add=NET_ADMIN --device=/dev/net/tun -d -e NB_SETUP_KEY=<SETUP KEY> -v netbird-client:/etc/netbird netbirdio/netbird:latest
 ```
 
 See [Docker example](examples/netbird-docker.md) for details.


### PR DESCRIPTION
add the device capability for the docker client to work on `4.19.0-21-amd64 #1 SMP Debian 4.19.249-2 (2022-06-30) x86_64 GNU/Linux`
docker  20.10.17

otherwise I would get errors like:

time="2022-10-19T09:34:25Z" level=info msg="couldn't access device /dev/net/tun, go error stat /dev/net/tun: no such file or directory, will attempt to load tun module, if running on container add flag --cap-add=NET_ADMIN"
time="2022-10-19T09:34:25Z" level=error msg="failed creating tunnel interface wt0: [couldn't check or load tun module]"
time="2022-10-19T09:34:25Z" level=error msg="error while starting Netbird Connection Engine: couldn't check or load tun module"