### PR TITLE
Fix dangerous ownership

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -128,7 +128,8 @@ You need to replace some variables from the URL above:
   ```bash
   tar xcf ./netbird_<VERSION>.tar.gz
   sudo mv netbird /usr/bin/netbird
-  chmod +x /usr/bin/netbird
+  sudo chown root:root /usr/bin/netbird
+  sudo chmod +x /usr/bin/netbird
   ```
 After that you may need to add /usr/bin in your PATH environment variable:
   ````bash


### PR DESCRIPTION
This patch fixes a common mistake with manually installed software, which adds the software, in a system-wide installation path, but leave it owned to the user. If an admin start to execute this binary, it's wonderful privilege escalation vector.

This patch resolves the problem by chowning it first, and therefore require root privileges to manipulate the file, resolving the potential attack vector.