### PR TITLE
Add documentation for running behind reverse-proxies

### DIFF
--- a/docs/getting-started/self-hosting.md
+++ b/docs/getting-started/self-hosting.md
@@ -138,16 +138,14 @@ Not all reverse-proxies are supported as netbird uses *gRPC* for various compone
 In `setup.env`:
 - Set ```NETBIRD_DOMAIN``` to your domain, e.g.  `demo.netbird.io`
 - Set ```NETBIRD_DISABLE_LETSENCRYPT=true```
+- Add ```NETBIRD_MGMT_API_PORT``` to your reverse-proxy TLS-port (default: 443)
+- Add ```NETBIRD_SIGNAL_PORT``` to your reverse-proxy TLS-port
 
-In `base.env`:
-- Set ```NETBIRD_MGMT_API_PORT``` to your reverse-proxy TLS-port (default: 443)
-- Set ```NETBIRD_SIGNAL_PORT``` to your reverse-proxy TLS-port
-
-If required, change/remove the port-mappings for `dasbhoard`, `signal` and `management`-services in `docker-compose.yml.tmpl`.
+Optional:
+- Add ```TURN_MIN_PORT``` and ```TURN_MAX_PORT``` to configure the port-range used by the Turn-server
 
 :::tip info
-The `coturn`-service still needs to be directly accessible under your set-domain as it uses UDP for communication.  
-It uses Port 3478 and `TURN_MIN_PORT` to `TURN_MAX_PORT` specified in `base.setup.env`.
+The `coturn`-service still needs to be directly accessible under your set-domain as it uses UDP for communication.
 :::
 
 Now you can continue with [Step 3](#step-3-configure-identity-provider).

--- a/docs/getting-started/self-hosting.md
+++ b/docs/getting-started/self-hosting.md
@@ -165,6 +165,8 @@ Endpoint                        | Protocol  | Target service and internal-port
 /api                            | HTTP      | management:443
 /management.ManagementService/  | gRPC      | management:443
 
+Make sure your reverse-Proxy is setup to use the HTTP2-Protocol when forwarding.
+
 :::tip
 You can find helpful templates with the reverse-proxy-name as suffix (e.g. `docker-compose.yml.tmpl.traefik`)  
 Simply replace the file `docker-compose.yml.tmpl` with the chosen version.

--- a/docs/getting-started/self-hosting.md
+++ b/docs/getting-started/self-hosting.md
@@ -165,6 +165,11 @@ Endpoint                        | Protocol  | Target service and internal-port
 /api                            | HTTP      | management:443
 /management.ManagementService/  | gRPC      | management:443
 
+:::tip
+You can find helpful templates with the reverse-proxy-name as suffix (e.g. `docker-compose.yml.tmpl.traefik`)  
+Simply replace the file `docker-compose.yml.tmpl` with the chosen version.
+:::
+
 ### Get in touch
 
 Feel free to ping us on [Slack](https://join.slack.com/t/netbirdio/shared_invite/zt-vrahf41g-ik1v7fV8du6t0RwxSrJ96A) if you have any questions


### PR DESCRIPTION
This PR adds documentation for running netbird behind reverse-proxies.

It is directly tied to the integration of the option "disable letsencrypt", but could be made standalone if that PR is not approved.  
https://github.com/netbirdio/netbird/pull/747