### PR TITLE
Set default color for code block in lightmode to black

### DIFF
--- a/src/components/Code.jsx
+++ b/src/components/Code.jsx
@@ -127,7 +127,7 @@ function CodePanel({ tag, label, code, children }) {
         label={child.props.label ?? label}
       />
       <div className="relative">
-        <pre className="overflow-x-auto p-4 text-xs text-white">{children}</pre>
+        <pre className="overflow-x-auto p-4 text-xs dark:text-white text-black">{children}</pre>
         <CopyButton code={child.props.code ?? code} />
       </div>
     </div>

--- a/src/pages/selfhosted/identity-providers.mdx
+++ b/src/pages/selfhosted/identity-providers.mdx
@@ -918,7 +918,7 @@ In this step, we will generate netbird api token in okta for authorizing calls t
 
 
 Your authority OIDC configuration will be available under:
-```
+```bash
 https://< your_okta_organization_url >/.well-known/openid-configuration
 ```
 <Note>

--- a/src/pages/selfhosted/identity-providers.mdx
+++ b/src/pages/selfhosted/identity-providers.mdx
@@ -918,7 +918,7 @@ In this step, we will generate netbird api token in okta for authorizing calls t
 
 
 Your authority OIDC configuration will be available under:
-```bash
+```
 https://< your_okta_organization_url >/.well-known/openid-configuration
 ```
 <Note>


### PR DESCRIPTION
The default color was white what caused the codeblock to be invisible in light mode.