### PR TITLE
add missing H1 header to selfhosted-guide.mdx

### DIFF
--- a/src/pages/selfhosted/selfhosted-guide.mdx
+++ b/src/pages/selfhosted/selfhosted-guide.mdx
@@ -1,4 +1,4 @@
-## Advanced self-hosting guide with a custom identity provider
+# Advanced guide
 
 NetBird is open-source and can be self-hosted on your servers.
 
@@ -14,6 +14,8 @@ If you would like to learn more about the architecture please refer to the [arch
 
 If you are looking for a quick way of trying self-hosted NetBird, please refer to [this guide](/about-netbird/how-netbird-works). Otherwise, continue here to set up
 NetBird with custom IdPs.
+
+## Advanced self-hosting guide with a custom identity provider
 
 ### Requirements
 


### PR DESCRIPTION
I noticed that the browser title-bar shows "undefined" when visiting the corresponding documentation-page.

Which is caused by missing a H1 header in markdown.
Henceforth I quickly modified the file to remedy this.

Adding H1 header, moving idp guide header after the part about trying out the cloud version.