### PR TITLE
Update FAQ with new management endpoint addresses

### DIFF
--- a/src/pages/about-netbird/faq.mdx
+++ b/src/pages/about-netbird/faq.mdx
@@ -16,10 +16,13 @@ Below is the list of NetBird hosted endpoints and ports they listen to:
   * **Endpoint**: api.wiretrustee.com
     * **Port**: TCP/443
     * **IPv4**: 34.240.163.65
+  * **Endpoint**: api.netbird.io `new`
+    * **Port**: TCP/443
+    * **IPv4**: 35.186.199.111
 * Signal service:
   * **Endpoint**: signal2.wiretrustee.com
     * **Port**: TCP/443
-    * **IPv4**: 63.34.141.149
+    * **IPv4**: 35.186.199.111
   * **Endpoint**: signal.netbird.io `new`
     * **Port**: TCP/443
     * **IPv4**: 35.186.199.111


### PR DESCRIPTION
Updated management's new endpoint and signal2.wiretrustee.com IP address

<img width="693" alt="image" src="https://github.com/netbirdio/docs/assets/7747744/a39ea4fe-2986-4757-99de-c318653d09e2">
