### PR TITLE
Add backup and upgrade guides

### DIFF
--- a/src/pages/selfhosted/selfhosted-guide.mdx
+++ b/src/pages/selfhosted/selfhosted-guide.mdx
@@ -183,7 +183,7 @@ Make sure your reverse-Proxy is setup to use the HTTP2-Protocol when forwarding.
 </Note>
 
 ## Backup NetBird
-To backup your NetBird installation, you need to copy the configuration files, and the management service databases.
+To backup your NetBird installation, you need to copy the configuration files, and the Management service databases.
 
 The configuration files are located in the folder where you ran the installation script. To backup, copy the files to a backup location:
 ```bash
@@ -191,7 +191,7 @@ cd netbird/infrastructure_files/
 mkdir backup
 cp docker-compose.yml turnserver.conf management.json backup/
 ```
-To save the management service databases, you need to stop the management service and copy the files from the store directory using a docker compose command as follows:
+To save the Management service databases, you need to stop the Management service and copy the files from the store directory using a docker compose command as follows:
 ```bash
 docker compose stop management
 docker compose cp -a management:/var/lib/netbird/ backup/

--- a/src/pages/selfhosted/selfhosted-guide.mdx
+++ b/src/pages/selfhosted/selfhosted-guide.mdx
@@ -81,7 +81,7 @@ This can be any email address. [Let's Encrypt](https://letsencrypt.org/) will cr
 </Note>
 
 <Note>
-    If you want to setup netbird with your own reverse-Proxy and without using the integrated letsencrypt, follow [this step here instead](#advanced-running-netbird-behind-an-existing-reverse-proxy).
+    If you want to setup NetBird with your own reverse-Proxy and without using the integrated letsencrypt, follow [this step here instead](#advanced-running-netbird-behind-an-existing-reverse-proxy).
 </Note>
 
 ### Step 3: Configure Identity Provider (IDP)
@@ -137,15 +137,15 @@ docker-compose logs coturn
 docker-compose logs dashboard
 ```
 
-## Advanced: Running netbird behind an existing reverse-proxy
+## Advanced: Running NetBird behind an existing reverse-proxy
 
-If you want to run netbird behind your own reverse-proxy, some additional configuration-steps have to be taken to [Step 2](#step-2--prepare-configuration-files).
+If you want to run NetBird behind your own reverse-proxy, some additional configuration-steps have to be taken to [Step 2](#step-2--prepare-configuration-files).
 
 <Note>
-    Not all reverse-proxies are supported as netbird uses *gRPC* for various components.
+    Not all reverse-proxies are supported as NetBird uses *gRPC* for various components.
 </Note>
 
-### Configuration for netbird
+### Configuration for NetBird
 
 In `setup.env`:
 - Set ```NETBIRD_DOMAIN``` to your domain, e.g.  `demo.netbird.io`
@@ -182,7 +182,7 @@ Make sure your reverse-Proxy is setup to use the HTTP2-Protocol when forwarding.
     Simply replace the file `docker-compose.yml.tmpl` with the chosen version.
 </Note>
 
-## Backup NetBird
+## Backup
 To backup your NetBird installation, you need to copy the configuration files, and the Management service databases.
 
 The configuration files are located in the folder where you ran the installation script. To backup, copy the files to a backup location:
@@ -198,9 +198,9 @@ docker compose cp -a management:/var/lib/netbird/ backup/
 docker compose start management
 ```
 
-## Upgrading NetBird
+## Upgrade
 To upgrade NetBird to the latest version, you need to review the [release notes](https://github.com/netbirdio/netbird/releases) for any breaking changes and follow the upgrade steps below:
-1. Run the backup steps described in the [Backup NetBird](#backup-net-bird) section.
+1. Run the backup steps described in the [backup](#backup-net-bird) section.
 2. Pull the latest NetBird docker images:
    ```bash
    cd netbird/infrastructure_files/

--- a/src/pages/selfhosted/selfhosted-guide.mdx
+++ b/src/pages/selfhosted/selfhosted-guide.mdx
@@ -182,6 +182,35 @@ Make sure your reverse-Proxy is setup to use the HTTP2-Protocol when forwarding.
     Simply replace the file `docker-compose.yml.tmpl` with the chosen version.
 </Note>
 
+## Backup NetBird
+To backup your NetBird installation, you need to copy the configuration files, and the management service databases.
+
+The configuration files are located in the folder where you ran the installation script. To backup, copy the files to a backup location:
+```bash
+cd netbird/infrastructure_files/
+mkdir backup
+cp docker-compose.yml turnserver.conf management.json backup/
+```
+To save the management service databases, you need to stop the management service and copy the files from the store directory using a docker compose command as follows:
+```bash
+docker compose stop management
+docker compose cp -a management:/var/lib/netbird/ backup/
+docker compose start management
+```
+
+## Upgrading NetBird
+To upgrade NetBird to the latest version, you need to review the [release notes](https://github.com/netbirdio/netbird/releases) for any breaking changes and follow the upgrade steps below:
+1. Run the backup steps described in the [Backup NetBird](#backup-net-bird) section.
+2. Pull the latest NetBird docker images:
+   ```bash
+   cd netbird/infrastructure_files/
+   docker compose pull
+    ```
+3. Restart the NetBird containers with the new images:
+   ```bash
+   docker compose up -d --force-recreate
+    ```
+
 ## Get in touch
 
 Feel free to ping us on [Slack](https://join.slack.com/t/netbirdio/shared_invite/zt-vrahf41g-ik1v7fV8du6t0RwxSrJ96A) if you have any questions

--- a/src/pages/selfhosted/selfhosted-quickstart.mdx
+++ b/src/pages/selfhosted/selfhosted-quickstart.mdx
@@ -60,20 +60,20 @@ If you want to add additional users, you can access Zitadel's management console
 from Zitadel to add additional local users or integrate Zitadel with your existing identity provider by following the guide [Configure identity providers](https://zitadel.com/docs/guides/integrate/identity-providers).
 
 ### Backup NetBird
-To backup your NetBird installation, you need to copy the configuration files, the management service databases, and Zitadel's database.
+To backup your NetBird installation, you need to copy the configuration files, the Management service databases, and Zitadel's database.
 
 The configuration files are located in the folder where you ran the installation script. To backup, copy the files to a backup location:
 ```bash
 mkdir backup
 cp docker-compose.yml Caddyfile zitadel.env dashboard.env turnserver.conf management.json backup/
 ```
-To save the management service databases, you need to stop the management service and copy the files from the store directory using a docker compose command as follows:
+To save the Management service databases, you need to stop the Management service and copy the files from the store directory using a docker compose command as follows:
 ```bash
 docker compose stop management
 docker compose cp -a management:/var/lib/netbird/ backup/
 docker compose start management
 ```
-You can follow the [Cockroach backup guide](https://www.cockroachlabs.com/docs/stable/backup) to backup Zitadel's database.
+You can follow the [Cockroach backup guide](https://www.cockroachlabs.com/docs/stable/backup) to backup Zitadel's database, which holds user information.
 
 ### Upgrading NetBird
 To upgrade NetBird to the latest version, you need to review the [release notes](https://github.com/netbirdio/netbird/releases) for any breaking changes and follow the upgrade steps below:

--- a/src/pages/selfhosted/selfhosted-quickstart.mdx
+++ b/src/pages/selfhosted/selfhosted-quickstart.mdx
@@ -55,11 +55,11 @@ bash getting-started-with-zitadel.sh
 </Note>
 Once the script execution is complete, you can access your netbird instance via the URL `https://netbird.example.com` using the credentials displayed in your terminal.
 
-### Creating users
+### Add users
 If you want to add additional users, you can access Zitadel's management console via the URL `https://netbird.example.com/ui/console` with the same credentials. Follow the [Users guide](https://zitadel.com/docs/guides/manage/console/users)
 from Zitadel to add additional local users or integrate Zitadel with your existing identity provider by following the guide [Configure identity providers](https://zitadel.com/docs/guides/integrate/identity-providers).
 
-### Backup NetBird
+### Backup
 To backup your NetBird installation, you need to copy the configuration files, the Management service databases, and Zitadel's database.
 
 The configuration files are located in the folder where you ran the installation script. To backup, copy the files to a backup location:
@@ -75,9 +75,9 @@ docker compose start management
 ```
 You can follow the [Cockroach backup guide](https://www.cockroachlabs.com/docs/stable/backup) to backup Zitadel's database, which holds user information.
 
-### Upgrading NetBird
+### Upgrade
 To upgrade NetBird to the latest version, you need to review the [release notes](https://github.com/netbirdio/netbird/releases) for any breaking changes and follow the upgrade steps below:
-1. Run the backup steps described in the [Backup NetBird](#backup-net-bird) section.
+1. Run the backup steps described in the [backup](#backup) section.
 2. Pull the latest NetBird docker images:
     ```bash
     docker compose pull management dashboard signal
@@ -87,7 +87,7 @@ To upgrade NetBird to the latest version, you need to review the [release notes]
     docker compose up -d --force-recreate management dashboard signal
     ```
 
-### Remove NetBird
+### Remove
 To remove the NetBird installation and all related data from your server, run these commands from the folder where you installed NetBird:
 ```bash
 # remove all NetBird-related containers and volumes (data)
@@ -96,9 +96,17 @@ docker compose down --volumes
 rm -f docker-compose.yml Caddyfile zitadel.env dashboard.env machinekey/zitadel-admin-sa.token turnserver.conf management.json
 ```
 
-### Troubleshooting
+### Troubleshoot
 
 - I'm trying to register a user but I didn't receive a verification code. Whats is the problem?
 
     The NetBird quickstart script generates a user name and a password for the administrator. This should be enough to login and manage your network.
     If you want to register a new user and invite them via email, you need to configure a SMTP server in Zitadel. See [this guide](https://zitadel.com/docs/guides/manage/console/instance-settings#smtp) or details.
+
+## Get in touch
+
+Feel free to ping us on [Slack](https://join.slack.com/t/netbirdio/shared_invite/zt-vrahf41g-ik1v7fV8du6t0RwxSrJ96A) if you have any questions
+
+- NetBird managed version: [https://app.netbird.io](https://app.netbird.io)
+- Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
+- Follow us [on Twitter](https://twitter.com/netbird)

--- a/src/pages/selfhosted/selfhosted-quickstart.mdx
+++ b/src/pages/selfhosted/selfhosted-quickstart.mdx
@@ -59,6 +59,34 @@ Once the script execution is complete, you can access your netbird instance via 
 If you want to add additional users, you can access Zitadel's management console via the URL `https://netbird.example.com/ui/console` with the same credentials. Follow the [Users guide](https://zitadel.com/docs/guides/manage/console/users)
 from Zitadel to add additional local users or integrate Zitadel with your existing identity provider by following the guide [Configure identity providers](https://zitadel.com/docs/guides/integrate/identity-providers).
 
+### Backup NetBird
+To backup your NetBird installation, you need to copy the configuration files, the management service databases, and Zitadel's database.
+
+The configuration files are located in the folder where you ran the installation script. To backup, copy the files to a backup location:
+```bash
+mkdir backup
+cp docker-compose.yml Caddyfile zitadel.env dashboard.env turnserver.conf management.json backup/
+```
+To save the management service databases, you need to stop the management service and copy the files from the store directory using a docker compose command as follows:
+```bash
+docker compose stop management
+docker compose cp -a management:/var/lib/netbird/ backup/
+docker compose start management
+```
+You can follow the [Cockroach backup guide](https://www.cockroachlabs.com/docs/stable/backup) to backup Zitadel's database.
+
+### Upgrading NetBird
+To upgrade NetBird to the latest version, you need to review the [release notes](https://github.com/netbirdio/netbird/releases) for any breaking changes and follow the upgrade steps below:
+1. Run the backup steps described in the [Backup NetBird](#backup-net-bird) section.
+2. Pull the latest NetBird docker images:
+    ```bash
+    docker compose pull management dashboard signal
+    ```
+3. Restart the NetBird containers with the new images:
+    ```bash
+    docker compose up -d --force-recreate management dashboard signal
+    ```
+
 ### Remove NetBird
 To remove the NetBird installation and all related data from your server, run these commands from the folder where you installed NetBird:
 ```bash


### PR DESCRIPTION
Added backup and upgrade guides for self-hosted deployments.

Quick guide:
Backup:
<img width="1093" alt="image" src="https://github.com/netbirdio/docs/assets/7747744/82c0a65f-6d28-49ba-af1e-fbe9de93c519">
Upgrade:
<img width="1033" alt="image" src="https://github.com/netbirdio/docs/assets/7747744/e3b7ec53-ab25-40fd-a4c5-f5f99347c3fc">


Advance guide:
Backup:
<img width="785" alt="image" src="https://github.com/netbirdio/docs/assets/7747744/ceff1116-672b-46d4-b48a-336f18ecd508">
Upgrade:
<img width="1145" alt="image" src="https://github.com/netbirdio/docs/assets/7747744/f8cce1ad-d22a-48bc-94a1-8c186c266b9a">
