### PR TITLE
Authentik: Signing-Key Required

### DIFF
--- a/src/pages/selfhosted/identity-providers.mdx
+++ b/src/pages/selfhosted/identity-providers.mdx
@@ -476,6 +476,7 @@ In this step, we will create OAuth2/OpenID Provider in Authentik.
     - Protocol Settings:
         - Client type: `Public`
         - Redirect URIs/Origins (RegEx): `https://<domain>`, `https://<domain>.*`, `http://localhost:53000` (Each URI should be entered on a new line)
+        - Signing Key: Must be selected! Can be any cert present, e.g. `authentik Self-signed Certificate`
     - Advanced protocol settings:
         - Access code validity: `minutes=10`
         - Subject mode: `Based on the User's ID`


### PR DESCRIPTION
For getting Netbird up and running with Authentik it's required to select a signing-key when creating the provider. The current instructions do not work and will yield an "401: Token Invalid" error.