### PR TITLE
Fix: Typo in selfhosted document

### DIFF
--- a/src/pages/selfhosted/selfhosted-guide.mdx
+++ b/src/pages/selfhosted/selfhosted-guide.mdx
@@ -121,7 +121,7 @@ Make sure all the required properties set in the ```setup.env``` file and run:
 ./configure.sh
 ```
 
-This will export all the properties as environment variables and generate ```artifacts/docker-compose.yml```, ```artifacts/management.json``` and ```artifacts/turnserver.cong``` files substituting required variables.
+This will export all the properties as environment variables and generate ```artifacts/docker-compose.yml```, ```artifacts/management.json``` and ```artifacts/turnserver.conf``` files substituting required variables.
 
 ### Step 6: Run docker compose:
 


### PR DESCRIPTION
- Corrected  typo: `artifacts/turnserver.cong` -> `artifacts/turnserver.conf`