### PR TITLE
Fix: Typo in selfhosted doc

### DIFF
--- a/src/pages/how-to/enable-post-quantum-cryptography.mdx
+++ b/src/pages/how-to/enable-post-quantum-cryptography.mdx
@@ -4,7 +4,7 @@ import {Note} from "@/components/mdx";
 Post-quantum cryptography aims to mitigate risks associated with quantum computing's potential to undermine existing encryption methods.
 Current concerns include the possibility of bad actors collecting encrypted network traffic to decrypt it once quantum computers become available.
 This 'harvest and decrypt later' strategy threatens the confidentiality of presently secure communications.
-[Rosenpass](https://rosenpass.eu), a post-quantum secure protocol, addresses these concerns by offering advanced cryptographic measures to protect VPN connections against such future threads.
+[Rosenpass](https://rosenpass.eu), a post-quantum secure protocol, addresses these concerns by offering advanced cryptographic measures to protect VPN connections against such future threats.
 
 
 ## About Rosenpass


### PR DESCRIPTION
Corrected Typo: `...future threads.` -> `...future threats.`