### PR TITLE
Update installation.mdx for openSUSE

### DIFF
--- a/src/pages/how-to/installation.mdx
+++ b/src/pages/how-to/installation.mdx
@@ -83,6 +83,25 @@ EOF
  sudo dnf install libappindicator-gtk3 libappindicator netbird-ui
 ```
 
+**openSUSE**
+
+1. Add the repository:
+```
+sudo zypper addrepo https://pkgs.netbird.io/yum/ netbird
+```
+2. Install the package / GPG key
+
+* Key Fingerprint: `AA9C 09AA 9DEA 2F58 112B 40DF DFFE AB2F D267 A61F`
+* Key ID: `DFFEAB2FD267A61F`
+* Email: `dev@wiretrustee.com`
+```
+# MicroOS (immutable OS with selinux)
+transactional-update pkg in netbird
+reboot
+
+# Tumbleweed / Leap
+zypper in netbird
+```
 
 **NixOS 22.11+/unstable**
 


### PR DESCRIPTION
* adds instructions for installation to openSUSE Tumbleweed / Leap / MicroOS

---

Working well so far on MicroOS as both an RPM & inside privileged `podman` connecting 2 x clusters / 3 remote sites