### PR TITLE
Remove Legacy Rules Table from Database

### DIFF
--- a/src/pages/selfhosted/postgres-store.mdx
+++ b/src/pages/selfhosted/postgres-store.mdx
@@ -68,6 +68,10 @@ DELETE FROM routes WHERE routes.account_id NOT IN (SELECT id FROM accounts);
 DELETE FROM name_server_groups WHERE name_server_groups.account_id NOT IN (SELECT id FROM accounts);
 ```
 
+```sql
+DROP TABLE IF EXISTS rules;
+```
+
 4. Enable Postgres by updating the `management.json` file and setting the `Engine` field to `postgres` as the following example:
 ```json
 "StoreConfig": {


### PR DESCRIPTION
Removes the `rules` table, which is a leftover from previous versions of the management. The table is no longer needed, and its presence could cause potential issues during migration to Postgres