### PR TITLE
docs: add note for NixOS installation

### DIFF
--- a/src/pages/how-to/installation.mdx
+++ b/src/pages/how-to/installation.mdx
@@ -93,6 +93,14 @@ EOF
  {
    services.netbird.enable = true; # for netbird service & CLI
    environment.systemPackages = [ pkgs.netbird-ui ]; # for GUI
+
+   # NOTE: If you have enabled firewall on nixos:
+   #  networking.firewall.enable = true;
+   # You will need to use nftables instead of iptables.
+   # This prevents an issue where the netbird route table is
+   # removed from ip rule list on resuming from suspend.
+   # This can be skipped if the firewall is not enabled.
+   networking.nftables.enable = true;
  }
 ```
 2. Build and apply new configuration


### PR DESCRIPTION
`networking.firewall.enable = true;` in NixOS enables the firewall, which uses `iptables` by default along with the `nixos-firewall-tool`. 

Netbird uses `nf_tables` kernel module to set up IP rules, while the system uses `iptables` for firewall. This causes an issue where the Netbird routing table is removed from the rule list after resuming the system from suspend.

I have confirmed that switching to `nftables` for firewall fixes the issue, while having no side-effects with the NixOS firewall setup.