### PR TITLE
fixes small typos and URL changes

### DIFF
--- a/src/pages/about-netbird/how-netbird-works.mdx
+++ b/src/pages/about-netbird/how-netbird-works.mdx
@@ -17,7 +17,7 @@ The combination of these elements ensures that direct point-to-point connections
 users (or machines) have access to the resources for which they are authorized.
 
 A **Peer** is a machine or any device that is connected to the network.
-It can be a Linux server running in the cloud or on-premises, a personal laptop, mobile phone, or even a Raspberry PI.
+It can be a Linux server running in the cloud or on-premises, a personal laptop, mobile phone, or even a Raspberry Pi.
 
 <p>
     <img src="/docs-static/img/architecture/high-level-dia.png" alt="high-level-dia" className="imagewrapper-big"/>

--- a/src/pages/selfhosted/identity-providers.mdx
+++ b/src/pages/selfhosted/identity-providers.mdx
@@ -17,7 +17,7 @@ This guide is a part of the [NetBird Self-hosting Guide](/selfhosted/selfhosted-
 
 <Note>
     If you prefer not to self-host an Identity and Access Management solution, then you could use the managed alternative
-    [Zitadel Cloud](https://zitadel.cloud/).
+    [Zitadel Cloud](https://zitadel.com/).
 </Note>
 
 #### Step 1. Create and configure Zitadel application


### PR DESCRIPTION
- Zitadel no longer hosted on zitadel.cloud
- `Raspberry Pi` is a trademark, should be correct now