### PR TITLE
API generation early example handling

### DIFF
--- a/generator/api.ts
+++ b/generator/api.ts
@@ -161,6 +161,9 @@ function extractInfo(obj, mode = 'example') {
     if (obj.items.hasOwnProperty('properties')) {
       return [extractInfo(obj.items.properties, mode)];
     } else {
+      if (mode === 'example' && obj.hasOwnProperty('example')) {
+        return obj.example;
+      }
       return [extractInfo(obj.items, mode)];
     }
   }


### PR DESCRIPTION
This PR adds support to add examples already early in the tree and not only in leafs.
Before the generator was only able to handle examples on the leaf level like this:
```
    PeerNetworkRangeCheck:
      description: Posture check for allow or deny access based on peer local network addresses
      type: object
      properties:
        ranges:
          description: List of peer network ranges in CIDR notation
          type: array
          items:
            type: string
            example: "192.168.1.0/24"
```
This was making it impossible to have multiple examples in an array for example.
The added changes will now support constructs where the example is set anywhere within the tree. For this specific case it will now support cases like:
```
    PeerNetworkRangeCheck:
      description: Posture check for allow or deny access based on peer local network addresses
      type: object
      properties:
        ranges:
          description: List of peer network ranges in CIDR notation
          type: array
          items:
            type: string
          example: ["192.168.1.0/24", "10.0.0.0/8", "2001:db8:1234:1a00::/56"]
```
while keeping the schema structure as is:
```
 "peer_network_range_check": {
        "ranges": [
          "string"
        ],
        "action": "string"
      },
```