### PR TITLE
Update faq.mdx to reflect relay usage

### DIFF
--- a/src/pages/about-netbird/faq.mdx
+++ b/src/pages/about-netbird/faq.mdx
@@ -36,6 +36,13 @@ Below is the list of NetBird hosted endpoints and ports they listen to:
         * `nslookup turn.netbird.io`
     * In more restricted environments, `netbird status` will show `keepalive ping failed` errors without a firewall rule for TURN
         * Example `nftables` outbound firewall rule: `ip daddr turn.netbird.io tcp dport 443-65535 accept`
+* Relay service:
+  * **Endpoint**: *.relay.netbird.io
+  * **Port**: TCP/443
+  * **IPv4**: The list is dynamic and geo-distributed; When looking at the `netbird status -d` output, you can see which relay you are connecting to.
+  * It is adviced to wildcard `*.relay.netbird.io` when possible, to avoid interrupts.
+
+
 
 ## Why and what are the anonymous usage metrics?
 

--- a/src/pages/about-netbird/faq.mdx
+++ b/src/pages/about-netbird/faq.mdx
@@ -40,7 +40,7 @@ Below is the list of NetBird hosted endpoints and ports they listen to:
   * **Endpoint**: *.relay.netbird.io
   * **Port**: TCP/443
   * **IPv4**: The list is dynamic and geo-distributed; When looking at the `netbird status -d` output, you can see which relay you are connecting to.
-  * It is adviced to wildcard `*.relay.netbird.io` when possible, to avoid interrupts.
+  * It is advised to wildcard `*.relay.netbird.io` when possible, to avoid interrupts.
 
 
 


### PR DESCRIPTION
Updated the Documentation to account for the relay service. May be used in a peer-to-peer setting, where one peer acts as a router.