### PR TITLE
Add relay to update steps in docs

### DIFF
--- a/src/pages/selfhosted/selfhosted-quickstart.mdx
+++ b/src/pages/selfhosted/selfhosted-quickstart.mdx
@@ -86,11 +86,11 @@ To upgrade NetBird to the latest version, you need to review the [release notes]
 1. Run the backup steps described in the [backup](#backup) section.
 2. Pull the latest NetBird docker images:
     ```bash
-    docker compose pull management dashboard signal
+    docker compose pull management dashboard signal relay
     ```
 3. Restart the NetBird containers with the new images:
     ```bash
-    docker compose up -d --force-recreate management dashboard signal
+    docker compose up -d --force-recreate management dashboard signal relay
     ```
 
 ### Remove


### PR DESCRIPTION
Update the self-hosting quickstart guide to include the relay service in the upgrade steps.