### PR TITLE
Explain port needed to connect to self hosted API.

### DIFF
--- a/src/pages/ipa/guides/quickstart.mdx
+++ b/src/pages/ipa/guides/quickstart.mdx
@@ -29,7 +29,7 @@ curl -X GET https://api.netbird.io/api/peers \
 
 </CodeGroup>
 
-NOTE: If you are self-hosting netbird, you will need to use port 33073 with your management URL.
+NOTE: If you are self-hosting netbird, and used the advanced guide, you may need to use port 33073 with your management URL.
 
 <div className="not-prose">
   <Button

--- a/src/pages/ipa/guides/quickstart.mdx
+++ b/src/pages/ipa/guides/quickstart.mdx
@@ -29,6 +29,8 @@ curl -X GET https://api.netbird.io/api/peers \
 
 </CodeGroup>
 
+NOTE: If you are self-hosting netbird, you will need to use port 33073 with your management URL.
+
 <div className="not-prose">
   <Button
     href="/api/resources/peers"


### PR DESCRIPTION
Explain that to connect to the API on a self-hosted system they need to use port 33073.