### PR TITLE
Remove trailing whitespace in API examples

### DIFF
--- a/src/pages/ipa/resources/accounts.mdx
+++ b/src/pages/ipa/resources/accounts.mdx
@@ -24,7 +24,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/accounts',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -45,7 +45,7 @@ import json
 
 url = "https://api.netbird.io/api/accounts"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -245,7 +245,7 @@ let config = {
   method: 'delete',
   maxBodyLength: Infinity,
   url: '/api/accounts/{accountId}',
-  headers: {         
+  headers: {
     'Authorization': 'Token <TOKEN>'
   }  
 };
@@ -265,7 +265,7 @@ import json
 
 url = "https://api.netbird.io/api/accounts/{accountId}"
 
-headers = {     
+headers = {
   'Authorization': 'Token <TOKEN>'
 }
 
@@ -533,7 +533,7 @@ let config = {
   method: 'put',
   maxBodyLength: Infinity,
   url: '/api/accounts/{accountId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -574,7 +574,7 @@ payload = json.dumps({
     }
   }
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'

--- a/src/pages/ipa/resources/accounts.mdx
+++ b/src/pages/ipa/resources/accounts.mdx
@@ -557,20 +557,20 @@ import json
 url = "https://api.netbird.io/api/accounts/{accountId}"
 payload = json.dumps({
   "settings": {
-    "peer_login_expiration_enabled": true,
+    "peer_login_expiration_enabled": True,
     "peer_login_expiration": 43200,
-    "peer_inactivity_expiration_enabled": true,
+    "peer_inactivity_expiration_enabled": True,
     "peer_inactivity_expiration": 43200,
-    "regular_users_view_blocked": true,
-    "groups_propagation_enabled": true,
-    "jwt_groups_enabled": true,
+    "regular_users_view_blocked": True,
+    "groups_propagation_enabled": True,
+    "jwt_groups_enabled": True,
     "jwt_groups_claim_name": "roles",
     "jwt_allow_groups": [
       "Administrators"
     ],
-    "routing_peer_dns_resolution_enabled": true,
+    "routing_peer_dns_resolution_enabled": True,
     "extra": {
-      "peer_approval_enabled": true
+      "peer_approval_enabled": True
     }
   }
 })

--- a/src/pages/ipa/resources/dns.mdx
+++ b/src/pages/ipa/resources/dns.mdx
@@ -24,7 +24,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/dns/nameservers',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -45,7 +45,7 @@ import json
 
 url = "https://api.netbird.io/api/dns/nameservers"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -348,7 +348,7 @@ let config = {
   method: 'post',
   maxBodyLength: Infinity,
   url: '/api/dns/nameservers',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -390,7 +390,7 @@ payload = json.dumps({
   ],
   "search_domains_enabled": true
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -674,7 +674,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/dns/nameservers/{nsgroupId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -695,7 +695,7 @@ import json
 
 url = "https://api.netbird.io/api/dns/nameservers/{nsgroupId}"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -1002,7 +1002,7 @@ let config = {
   method: 'put',
   maxBodyLength: Infinity,
   url: '/api/dns/nameservers/{nsgroupId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -1044,7 +1044,7 @@ payload = json.dumps({
   ],
   "search_domains_enabled": true
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -1327,7 +1327,7 @@ let config = {
   method: 'delete',
   maxBodyLength: Infinity,
   url: '/api/dns/nameservers/{nsgroupId}',
-  headers: {         
+  headers: {
     'Authorization': 'Token <TOKEN>'
   }  
 };
@@ -1347,7 +1347,7 @@ import json
 
 url = "https://api.netbird.io/api/dns/nameservers/{nsgroupId}"
 
-headers = {     
+headers = {
   'Authorization': 'Token <TOKEN>'
 }
 
@@ -1484,7 +1484,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/dns/settings',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -1505,7 +1505,7 @@ import json
 
 url = "https://api.netbird.io/api/dns/settings"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -1689,7 +1689,7 @@ let config = {
   method: 'put',
   maxBodyLength: Infinity,
   url: '/api/dns/settings',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -1716,7 +1716,7 @@ payload = json.dumps({
     "ch8i4ug6lnn4g9hqv7m0"
   ]
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'

--- a/src/pages/ipa/resources/dns.mdx
+++ b/src/pages/ipa/resources/dns.mdx
@@ -380,15 +380,15 @@ payload = json.dumps({
       "port": 53
     }
   ],
-  "enabled": true,
+  "enabled": True,
   "groups": [
     "ch8i4ug6lnn4g9hqv7m0"
   ],
-  "primary": true,
+  "primary": True,
   "domains": [
     "example.com"
   ],
-  "search_domains_enabled": true
+  "search_domains_enabled": True
 })
 headers = {
   'Content-Type': 'application/json',  
@@ -1034,15 +1034,15 @@ payload = json.dumps({
       "port": 53
     }
   ],
-  "enabled": true,
+  "enabled": True,
   "groups": [
     "ch8i4ug6lnn4g9hqv7m0"
   ],
-  "primary": true,
+  "primary": True,
   "domains": [
     "example.com"
   ],
-  "search_domains_enabled": true
+  "search_domains_enabled": True
 })
 headers = {
   'Content-Type': 'application/json',  

--- a/src/pages/ipa/resources/events.mdx
+++ b/src/pages/ipa/resources/events.mdx
@@ -24,7 +24,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/events',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -45,7 +45,7 @@ import json
 
 url = "https://api.netbird.io/api/events"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }

--- a/src/pages/ipa/resources/geo-locations.mdx
+++ b/src/pages/ipa/resources/geo-locations.mdx
@@ -24,7 +24,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/locations/countries',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -45,7 +45,7 @@ import json
 
 url = "https://api.netbird.io/api/locations/countries"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -208,7 +208,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/locations/countries/{country}/cities',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -229,7 +229,7 @@ import json
 
 url = "https://api.netbird.io/api/locations/countries/{country}/cities"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }

--- a/src/pages/ipa/resources/groups.mdx
+++ b/src/pages/ipa/resources/groups.mdx
@@ -24,7 +24,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/groups',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -45,7 +45,7 @@ import json
 
 url = "https://api.netbird.io/api/groups"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -298,7 +298,7 @@ let config = {
   method: 'post',
   maxBodyLength: Infinity,
   url: '/api/groups',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -332,7 +332,7 @@ payload = json.dumps({
     }
   ]
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -580,7 +580,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/groups/{groupId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -601,7 +601,7 @@ import json
 
 url = "https://api.netbird.io/api/groups/{groupId}"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -858,7 +858,7 @@ let config = {
   method: 'put',
   maxBodyLength: Infinity,
   url: '/api/groups/{groupId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -892,7 +892,7 @@ payload = json.dumps({
     }
   ]
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -1139,7 +1139,7 @@ let config = {
   method: 'delete',
   maxBodyLength: Infinity,
   url: '/api/groups/{groupId}',
-  headers: {         
+  headers: {
     'Authorization': 'Token <TOKEN>'
   }  
 };
@@ -1159,7 +1159,7 @@ import json
 
 url = "https://api.netbird.io/api/groups/{groupId}"
 
-headers = {     
+headers = {
   'Authorization': 'Token <TOKEN>'
 }
 

--- a/src/pages/ipa/resources/networks.mdx
+++ b/src/pages/ipa/resources/networks.mdx
@@ -24,7 +24,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/networks',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -45,7 +45,7 @@ import json
 
 url = "https://api.netbird.io/api/networks"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -252,7 +252,7 @@ let config = {
   method: 'post',
   maxBodyLength: Infinity,
   url: '/api/networks',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -278,7 +278,7 @@ payload = json.dumps({
   "name": "Remote Network 1",
   "description": "A remote network that needs to be accessed"
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -486,7 +486,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/networks/{networkId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -507,7 +507,7 @@ import json
 
 url = "https://api.netbird.io/api/networks/{networkId}"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -718,7 +718,7 @@ let config = {
   method: 'put',
   maxBodyLength: Infinity,
   url: '/api/networks/{networkId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -744,7 +744,7 @@ payload = json.dumps({
   "name": "Remote Network 1",
   "description": "A remote network that needs to be accessed"
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -951,7 +951,7 @@ let config = {
   method: 'delete',
   maxBodyLength: Infinity,
   url: '/api/networks/{networkId}',
-  headers: {         
+  headers: {
     'Authorization': 'Token <TOKEN>'
   }  
 };
@@ -971,7 +971,7 @@ import json
 
 url = "https://api.netbird.io/api/networks/{networkId}"
 
-headers = {     
+headers = {
   'Authorization': 'Token <TOKEN>'
 }
 
@@ -1116,7 +1116,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/networks/{networkId}/resources',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -1137,7 +1137,7 @@ import json
 
 url = "https://api.netbird.io/api/networks/{networkId}/resources"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -1381,7 +1381,7 @@ let config = {
   method: 'post',
   maxBodyLength: Infinity,
   url: '/api/networks/{networkId}/resources',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -1412,7 +1412,7 @@ payload = json.dumps({
     "chacdk86lnnboviihd70"
   ]
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -1648,7 +1648,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/networks/{networkId}/resources/{resourceId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -1669,7 +1669,7 @@ import json
 
 url = "https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -1913,7 +1913,7 @@ let config = {
   method: 'put',
   maxBodyLength: Infinity,
   url: '/api/networks/{networkId}/resources/{resourceId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -1944,7 +1944,7 @@ payload = json.dumps({
     "chacdk86lnnboviihd70"
   ]
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -2179,7 +2179,7 @@ let config = {
   method: 'delete',
   maxBodyLength: Infinity,
   url: '/api/networks/{networkId}/resources/{resourceId}',
-  headers: {         
+  headers: {
     'Authorization': 'Token <TOKEN>'
   }  
 };
@@ -2199,7 +2199,7 @@ import json
 
 url = "https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}"
 
-headers = {     
+headers = {
   'Authorization': 'Token <TOKEN>'
 }
 
@@ -2344,7 +2344,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/networks/{networkId}/routers',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -2365,7 +2365,7 @@ import json
 
 url = "https://api.netbird.io/api/networks/{networkId}/routers"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -2595,7 +2595,7 @@ let config = {
   method: 'post',
   maxBodyLength: Infinity,
   url: '/api/networks/{networkId}/routers',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -2626,7 +2626,7 @@ payload = json.dumps({
   "masquerade": true,
   "enabled": true
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -2848,7 +2848,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/networks/{networkId}/routers/{routerId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -2869,7 +2869,7 @@ import json
 
 url = "https://api.netbird.io/api/networks/{networkId}/routers/{routerId}"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -3099,7 +3099,7 @@ let config = {
   method: 'put',
   maxBodyLength: Infinity,
   url: '/api/networks/{networkId}/routers/{routerId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -3130,7 +3130,7 @@ payload = json.dumps({
   "masquerade": true,
   "enabled": true
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -3351,7 +3351,7 @@ let config = {
   method: 'delete',
   maxBodyLength: Infinity,
   url: '/api/networks/{networkId}/routers/{routerId}',
-  headers: {         
+  headers: {
     'Authorization': 'Token <TOKEN>'
   }  
 };
@@ -3371,7 +3371,7 @@ import json
 
 url = "https://api.netbird.io/api/networks/{networkId}/routers/{routerId}"
 
-headers = {     
+headers = {
   'Authorization': 'Token <TOKEN>'
 }
 

--- a/src/pages/ipa/resources/networks.mdx
+++ b/src/pages/ipa/resources/networks.mdx
@@ -1407,7 +1407,7 @@ payload = json.dumps({
   "name": "Remote Resource 1",
   "description": "A remote resource inside network 1",
   "address": "1.1.1.1",
-  "enabled": true,
+  "enabled": True,
   "groups": [
     "chacdk86lnnboviihd70"
   ]
@@ -1939,7 +1939,7 @@ payload = json.dumps({
   "name": "Remote Resource 1",
   "description": "A remote resource inside network 1",
   "address": "1.1.1.1",
-  "enabled": true,
+  "enabled": True,
   "groups": [
     "chacdk86lnnboviihd70"
   ]
@@ -2623,8 +2623,8 @@ payload = json.dumps({
     "chacbco6lnnbn6cg5s91"
   ],
   "metric": 9999,
-  "masquerade": true,
-  "enabled": true
+  "masquerade": True,
+  "enabled": True
 })
 headers = {
   'Content-Type': 'application/json',  
@@ -3127,8 +3127,8 @@ payload = json.dumps({
     "chacbco6lnnbn6cg5s91"
   ],
   "metric": 9999,
-  "masquerade": true,
-  "enabled": true
+  "masquerade": True,
+  "enabled": True
 })
 headers = {
   'Content-Type': 'application/json',  

--- a/src/pages/ipa/resources/peers.mdx
+++ b/src/pages/ipa/resources/peers.mdx
@@ -591,10 +591,10 @@ import json
 url = "https://api.netbird.io/api/peers/{peerId}"
 payload = json.dumps({
   "name": "stage-host-1",
-  "ssh_enabled": true,
+  "ssh_enabled": True,
   "login_expiration_enabled": false,
   "inactivity_expiration_enabled": false,
-  "approval_required": true
+  "approval_required": True
 })
 headers = {
   'Content-Type': 'application/json',  

--- a/src/pages/ipa/resources/peers.mdx
+++ b/src/pages/ipa/resources/peers.mdx
@@ -24,7 +24,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/peers',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -45,7 +45,7 @@ import json
 
 url = "https://api.netbird.io/api/peers"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -276,7 +276,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/peers/{peerId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -297,7 +297,7 @@ import json
 
 url = "https://api.netbird.io/api/peers/{peerId}"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -567,7 +567,7 @@ let config = {
   method: 'put',
   maxBodyLength: Infinity,
   url: '/api/peers/{peerId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -596,7 +596,7 @@ payload = json.dumps({
   "inactivity_expiration_enabled": false,
   "approval_required": true
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -853,7 +853,7 @@ let config = {
   method: 'delete',
   maxBodyLength: Infinity,
   url: '/api/peers/{peerId}',
-  headers: {         
+  headers: {
     'Authorization': 'Token <TOKEN>'
   }  
 };
@@ -873,7 +873,7 @@ import json
 
 url = "https://api.netbird.io/api/peers/{peerId}"
 
-headers = {     
+headers = {
   'Authorization': 'Token <TOKEN>'
 }
 
@@ -1018,7 +1018,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/peers/{peerId}/accessible-peers',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -1039,7 +1039,7 @@ import json
 
 url = "https://api.netbird.io/api/peers/{peerId}/accessible-peers"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }

--- a/src/pages/ipa/resources/policies.mdx
+++ b/src/pages/ipa/resources/policies.mdx
@@ -571,7 +571,7 @@ url = "https://api.netbird.io/api/policies"
 payload = json.dumps({
   "name": "ch8i4ug6lnn4g9hqv7mg",
   "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
+  "enabled": True,
   "source_posture_checks": [
     "chacdk86lnnboviihd70"
   ],
@@ -579,9 +579,9 @@ payload = json.dumps({
     {
       "name": "Default",
       "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
+      "enabled": True,
       "action": "accept",
-      "bidirectional": true,
+      "bidirectional": True,
       "protocol": "tcp",
       "ports": [
         "80"
@@ -1601,7 +1601,7 @@ url = "https://api.netbird.io/api/policies/{policyId}"
 payload = json.dumps({
   "name": "ch8i4ug6lnn4g9hqv7mg",
   "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
+  "enabled": True,
   "source_posture_checks": [
     "chacdk86lnnboviihd70"
   ],
@@ -1609,9 +1609,9 @@ payload = json.dumps({
     {
       "name": "Default",
       "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
+      "enabled": True,
       "action": "accept",
-      "bidirectional": true,
+      "bidirectional": True,
       "protocol": "tcp",
       "ports": [
         "80"

--- a/src/pages/ipa/resources/posture-checks.mdx
+++ b/src/pages/ipa/resources/posture-checks.mdx
@@ -24,7 +24,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/posture-checks',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -45,7 +45,7 @@ import json
 
 url = "https://api.netbird.io/api/posture-checks"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -648,7 +648,7 @@ let config = {
   method: 'post',
   maxBodyLength: Infinity,
   url: '/api/posture-checks',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -722,7 +722,7 @@ payload = json.dumps({
     }
   }
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -1196,7 +1196,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/posture-checks/{postureCheckId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -1217,7 +1217,7 @@ import json
 
 url = "https://api.netbird.io/api/posture-checks/{postureCheckId}"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -1824,7 +1824,7 @@ let config = {
   method: 'put',
   maxBodyLength: Infinity,
   url: '/api/posture-checks/{postureCheckId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -1898,7 +1898,7 @@ payload = json.dumps({
     }
   }
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -2371,7 +2371,7 @@ let config = {
   method: 'delete',
   maxBodyLength: Infinity,
   url: '/api/posture-checks/{postureCheckId}',
-  headers: {         
+  headers: {
     'Authorization': 'Token <TOKEN>'
   }  
 };
@@ -2391,7 +2391,7 @@ import json
 
 url = "https://api.netbird.io/api/posture-checks/{postureCheckId}"
 
-headers = {     
+headers = {
   'Authorization': 'Token <TOKEN>'
 }
 

--- a/src/pages/ipa/resources/routes.mdx
+++ b/src/pages/ipa/resources/routes.mdx
@@ -381,7 +381,7 @@ url = "https://api.netbird.io/api/routes"
 payload = json.dumps({
   "description": "My first route",
   "network_id": "Route 1",
-  "enabled": true,
+  "enabled": True,
   "peer": "chacbco6lnnbn6cg5s91",
   "peer_groups": [
     "chacbco6lnnbn6cg5s91"
@@ -391,11 +391,11 @@ payload = json.dumps({
     "example.com"
   ],
   "metric": 9999,
-  "masquerade": true,
+  "masquerade": True,
   "groups": [
     "chacdk86lnnboviihd70"
   ],
-  "keep_route": true,
+  "keep_route": True,
   "access_control_groups": [
     "chacbco6lnnbn6cg5s91"
   ]
@@ -1059,7 +1059,7 @@ url = "https://api.netbird.io/api/routes/{routeId}"
 payload = json.dumps({
   "description": "My first route",
   "network_id": "Route 1",
-  "enabled": true,
+  "enabled": True,
   "peer": "chacbco6lnnbn6cg5s91",
   "peer_groups": [
     "chacbco6lnnbn6cg5s91"
@@ -1069,11 +1069,11 @@ payload = json.dumps({
     "example.com"
   ],
   "metric": 9999,
-  "masquerade": true,
+  "masquerade": True,
   "groups": [
     "chacdk86lnnboviihd70"
   ],
-  "keep_route": true,
+  "keep_route": True,
   "access_control_groups": [
     "chacbco6lnnbn6cg5s91"
   ]

--- a/src/pages/ipa/resources/routes.mdx
+++ b/src/pages/ipa/resources/routes.mdx
@@ -24,7 +24,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/routes',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -45,7 +45,7 @@ import json
 
 url = "https://api.netbird.io/api/routes"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -356,7 +356,7 @@ let config = {
   method: 'post',
   maxBodyLength: Infinity,
   url: '/api/routes',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -400,7 +400,7 @@ payload = json.dumps({
     "chacbco6lnnbn6cg5s91"
   ]
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -698,7 +698,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/routes/{routeId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -719,7 +719,7 @@ import json
 
 url = "https://api.netbird.io/api/routes/{routeId}"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -1034,7 +1034,7 @@ let config = {
   method: 'put',
   maxBodyLength: Infinity,
   url: '/api/routes/{routeId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -1078,7 +1078,7 @@ payload = json.dumps({
     "chacbco6lnnbn6cg5s91"
   ]
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -1375,7 +1375,7 @@ let config = {
   method: 'delete',
   maxBodyLength: Infinity,
   url: '/api/routes/{routeId}',
-  headers: {         
+  headers: {
     'Authorization': 'Token <TOKEN>'
   }  
 };
@@ -1395,7 +1395,7 @@ import json
 
 url = "https://api.netbird.io/api/routes/{routeId}"
 
-headers = {     
+headers = {
   'Authorization': 'Token <TOKEN>'
 }
 

--- a/src/pages/ipa/resources/setup-keys.mdx
+++ b/src/pages/ipa/resources/setup-keys.mdx
@@ -320,7 +320,7 @@ payload = json.dumps({
     "ch8i4ug6lnn4g9hqv7m0"
   ],
   "usage_limit": 0,
-  "ephemeral": true
+  "ephemeral": True
 })
 headers = {
   'Content-Type': 'application/json',  
@@ -825,7 +825,7 @@ import json
 
 url = "https://api.netbird.io/api/setup-keys/{keyId}"
 payload = json.dumps({
-  "revoked": false,
+  "revoked": False,
   "auto_groups": [
     "ch8i4ug6lnn4g9hqv7m0"
   ]

--- a/src/pages/ipa/resources/setup-keys.mdx
+++ b/src/pages/ipa/resources/setup-keys.mdx
@@ -24,7 +24,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/setup-keys',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -45,7 +45,7 @@ import json
 
 url = "https://api.netbird.io/api/setup-keys"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -290,7 +290,7 @@ let config = {
   method: 'post',
   maxBodyLength: Infinity,
   url: '/api/setup-keys',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -322,7 +322,7 @@ payload = json.dumps({
   "usage_limit": 0,
   "ephemeral": true
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -560,7 +560,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/setup-keys/{keyId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -581,7 +581,7 @@ import json
 
 url = "https://api.netbird.io/api/setup-keys/{keyId}"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -802,7 +802,7 @@ let config = {
   method: 'put',
   maxBodyLength: Infinity,
   url: '/api/setup-keys/{keyId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -830,7 +830,7 @@ payload = json.dumps({
     "ch8i4ug6lnn4g9hqv7m0"
   ]
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -1051,7 +1051,7 @@ let config = {
   method: 'delete',
   maxBodyLength: Infinity,
   url: '/api/setup-keys/{keyId}',
-  headers: {         
+  headers: {
     'Authorization': 'Token <TOKEN>'
   }  
 };
@@ -1071,7 +1071,7 @@ import json
 
 url = "https://api.netbird.io/api/setup-keys/{keyId}"
 
-headers = {     
+headers = {
   'Authorization': 'Token <TOKEN>'
 }
 

--- a/src/pages/ipa/resources/tokens.mdx
+++ b/src/pages/ipa/resources/tokens.mdx
@@ -32,7 +32,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/users/{userId}/tokens',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -53,7 +53,7 @@ import json
 
 url = "https://api.netbird.io/api/users/{userId}/tokens"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -254,7 +254,7 @@ let config = {
   method: 'post',
   maxBodyLength: Infinity,
   url: '/api/users/{userId}/tokens',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -280,7 +280,7 @@ payload = json.dumps({
   "name": "My first token",
   "expires_in": 30
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -484,7 +484,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/users/{userId}/tokens/{tokenId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -505,7 +505,7 @@ import json
 
 url = "https://api.netbird.io/api/users/{userId}/tokens/{tokenId}"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -681,7 +681,7 @@ let config = {
   method: 'delete',
   maxBodyLength: Infinity,
   url: '/api/users/{userId}/tokens/{tokenId}',
-  headers: {         
+  headers: {
     'Authorization': 'Token <TOKEN>'
   }  
 };
@@ -701,7 +701,7 @@ import json
 
 url = "https://api.netbird.io/api/users/{userId}/tokens/{tokenId}"
 
-headers = {     
+headers = {
   'Authorization': 'Token <TOKEN>'
 }
 

--- a/src/pages/ipa/resources/users.mdx
+++ b/src/pages/ipa/resources/users.mdx
@@ -320,7 +320,7 @@ payload = json.dumps({
   "auto_groups": [
     "ch8i4ug6lnn4g9hqv7m0"
   ],
-  "is_service_user": false
+  "is_service_user": False
 })
 headers = {
   'Content-Type': 'application/json',  
@@ -618,7 +618,7 @@ payload = json.dumps({
   "auto_groups": [
     "ch8i4ug6lnn4g9hqv7m0"
   ],
-  "is_blocked": false
+  "is_blocked": False
 })
 headers = {
   'Content-Type': 'application/json',  

--- a/src/pages/ipa/resources/users.mdx
+++ b/src/pages/ipa/resources/users.mdx
@@ -32,7 +32,7 @@ let config = {
   method: 'get',
   maxBodyLength: Infinity,
   url: '/api/users',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
   }  
@@ -53,7 +53,7 @@ import json
 
 url = "https://api.netbird.io/api/users"
 
-headers = {     
+headers = {
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
 }
@@ -291,7 +291,7 @@ let config = {
   method: 'post',
   maxBodyLength: Infinity,
   url: '/api/users',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -322,7 +322,7 @@ payload = json.dumps({
   ],
   "is_service_user": false
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -591,7 +591,7 @@ let config = {
   method: 'put',
   maxBodyLength: Infinity,
   url: '/api/users/{userId}',
-  headers: {     
+  headers: {
     'Accept': 'application/json',    
     'Content-Type': 'application/json',
     'Authorization': 'Token <TOKEN>'
@@ -620,7 +620,7 @@ payload = json.dumps({
   ],
   "is_blocked": false
 })
-headers = {   
+headers = {
   'Content-Type': 'application/json',  
   'Accept': 'application/json',
   'Authorization': 'Token <TOKEN>'
@@ -845,7 +845,7 @@ let config = {
   method: 'delete',
   maxBodyLength: Infinity,
   url: '/api/users/{userId}',
-  headers: {         
+  headers: {
     'Authorization': 'Token <TOKEN>'
   }  
 };
@@ -865,7 +865,7 @@ import json
 
 url = "https://api.netbird.io/api/users/{userId}"
 
-headers = {     
+headers = {
   'Authorization': 'Token <TOKEN>'
 }
 
@@ -1009,7 +1009,7 @@ let config = {
   method: 'post',
   maxBodyLength: Infinity,
   url: '/api/users/{userId}/invite',
-  headers: {         
+  headers: {
     'Authorization': 'Token <TOKEN>'
   }  
 };
@@ -1029,7 +1029,7 @@ import json
 
 url = "https://api.netbird.io/api/users/{userId}/invite"
 
-headers = {     
+headers = {
   'Authorization': 'Token <TOKEN>'
 }
 


### PR DESCRIPTION
The API examples for Python contain trailing whitespace in the headers, which this PR removes.