### PR TITLE
Remove reference to Let'sEncrypt notifications

### DIFF
--- a/src/pages/selfhosted/selfhosted-guide.mdx
+++ b/src/pages/selfhosted/selfhosted-guide.mdx
@@ -77,7 +77,7 @@ NETBIRD_LETSENCRYPT_EMAIL=""
 This can be any email address. [Let's Encrypt](https://letsencrypt.org/) will create an account while generating a new certificate.
 
 <Note>
-    Let's Encrypt will notify you via this email when certificates are about to expire. NetBird supports automatic renewal by default.
+    NetBird supports automatic renewal by default when using Let's Encrypt.
 </Note>
 
 <Note>


### PR DESCRIPTION
Remove reference to Let'sEncrypt notifications

Source: 
https://letsencrypt.org/2025/01/22/ending-expiration-emails/