### PR TITLE
Updated installation.mdx for DNF5

### DIFF
--- a/src/pages/how-to/installation.mdx
+++ b/src/pages/how-to/installation.mdx
@@ -73,7 +73,10 @@ EOF
 ```
 2. Import the file
 ```bash
+#Fedora 40 or earlier/Amazon Linux 2023** (DNF 4)
  sudo dnf config-manager --add-repo /etc/yum.repos.d/netbird.repo
+#Fedora 41 or later (DNF 5)
+ sudo dnf config-manager addrepo --from-repofile=/etc/yum.repos.d/netbird.repo
 ```
 3. Install the package
 ```bash


### PR DESCRIPTION
Cause: In Fedora 41 the package manager changed from DNF4 to DNF5. 
Effect: Adding a repo now have have different instructions.
Solution: Updated the install instructions to reflect the change in syntax.

ref:
https://docs.fedoraproject.org/en-US/quick-docs/adding-or-removing-software-repositories-in-fedora/