### PR TITLE
[API] add cloud and experimantal badges + new pages

### DIFF
--- a/generator/api.ts
+++ b/generator/api.ts
@@ -49,6 +49,7 @@ export default async function gen(inputFileName: string, outputDir: string) {
 
 type v3OperationWithPath = OpenAPIV3.OperationObject & {
   path: string
+
 }
 
 export type objectRepresentation = {
@@ -104,22 +105,18 @@ async function gen_v3(spec: OpenAPIV3.Document, dest: string) {
         }
       }
 
-      // if(operation.summary == "List all Tokens") {
-      //   console.log(response.example)
-      //   console.log(operation.responses["200"]["content"]["application/json"].schema.items.properties)
-      // }
-
-
       const enriched = {
         ...operation,
         path: key,
         fullPath,
         operationId: slugify(operation.summary!),
-
         responseList: toArrayWithKey(operation.responses!, 'responseCode') || [],
         request: request,
         response: response,
+        // cloud: operation["x-cloud-only"],
+        // experimental: operation["x-experimental"],
       }
+
       let tag = operation.tags.pop()
       let tagOperations = tagGroups.get(tag) ?? []
       tagGroups.set(tag, tagOperations.concat(enriched))

--- a/generator/api.ts
+++ b/generator/api.ts
@@ -113,8 +113,6 @@ async function gen_v3(spec: OpenAPIV3.Document, dest: string) {
         responseList: toArrayWithKey(operation.responses!, 'responseCode') || [],
         request: request,
         response: response,
-        // cloud: operation["x-cloud-only"],
-        // experimental: operation["x-experimental"],
       }
 
       let tag = operation.tags.pop()

--- a/generator/templates/ApiTemplate.ts
+++ b/generator/templates/ApiTemplate.ts
@@ -4,7 +4,7 @@ export const title = '<%- tag %>'
 
 <% operations.forEach(function(operation){ %>
 
-## <%- operation.summary %> {{ tag: '<%- operation.operation.toUpperCase() %>' , label: '<%- operation.path %>' }} <% if(operation.deprecated) { %><Badge status="warning" text="Deprecated" /><% } %>
+## <%- operation.summary %> <% if(operation.deprecated) { %> <Badge status="warning" text="Deprecated" /> <% } %><% if(operation["x-cloud-only"]) { %> <Badge status="cloud-only" text="Cloud-Only" /> <% } %><% if(operation["x-experimental"]) { %> <Badge status="experimental" text="Experimental" /> <% } %> {{ tag: '<%- operation.operation.toUpperCase() %>' , label: '<%- operation.path %>' }}
 
 <Row>
   <Col>

--- a/src/components/Badge.jsx
+++ b/src/components/Badge.jsx
@@ -9,6 +9,10 @@ export function Badge({ status, text }) {
             case 'error':
                 // Never tested colors
                 return 'bg-red-300/30 text-red-400 dark:bg-red-400/10 dark:text-red-400';
+            case 'cloud-only':
+                return 'bg-orange-200/50 text-orange-400 dark:bg-orange-600/20 dark:text-orange-400';
+            case 'experimental':
+                return 'bg-teal-200/50 text-teal-400 dark:bg-teal-500/15 dark:text-teal-400';
             default:
                 return 'bg-gray-500/30 text-gray-600 dark:bg-gray-400/10 dark:text-gray-400';
         }

--- a/src/components/NavigationAPI.jsx
+++ b/src/components/NavigationAPI.jsx
@@ -25,6 +25,7 @@ export const apiNavigation = [
       { title: 'Users', href: '/api/resources/users' },
       { title: 'Tokens', href: '/api/resources/tokens' },
       { title: 'Peers', href: '/api/resources/peers' },
+      { title: 'Ingress Ports', href: '/api/resources/ingress-ports' },
       { title: 'Setup Keys', href: '/api/resources/setup-keys' },
       { title: 'Groups', href: '/api/resources/groups' },
       { title: 'Policies', href: '/api/resources/policies' },

--- a/src/pages/ipa/resources/accounts.mdx
+++ b/src/pages/ipa/resources/accounts.mdx
@@ -2,7 +2,7 @@ export const title = 'Accounts'
 
 
 
-## List all Accounts {{ tag: 'GET' , label: '/api/accounts' }} 
+## List all Accounts  {{ tag: 'GET' , label: '/api/accounts' }}
 
 <Row>
   <Col>
@@ -177,7 +177,9 @@ echo $response;
       ],
       "routing_peer_dns_resolution_enabled": true,
       "extra": {
-        "peer_approval_enabled": true
+        "peer_approval_enabled": true,
+        "network_traffic_logs_enabled": true,
+        "network_traffic_packet_counter_enabled": true
       }
     }
   }
@@ -201,7 +203,9 @@ echo $response;
       ],
       "routing_peer_dns_resolution_enabled": "boolean",
       "extra": {
-        "peer_approval_enabled": "boolean"
+        "peer_approval_enabled": "boolean",
+        "network_traffic_logs_enabled": "boolean",
+        "network_traffic_packet_counter_enabled": "boolean"
       }
     }
   }
@@ -216,7 +220,7 @@ echo $response;
 ---
 
 
-## Delete an Account {{ tag: 'DELETE' , label: '/api/accounts/{accountId}' }} 
+## Delete an Account  {{ tag: 'DELETE' , label: '/api/accounts/{accountId}' }}
 
 <Row>
   <Col>
@@ -380,7 +384,7 @@ echo $response;
 ---
 
 
-## Update an Account {{ tag: 'PUT' , label: '/api/accounts/{accountId}' }} 
+## Update an Account  {{ tag: 'PUT' , label: '/api/accounts/{accountId}' }}
 
 <Row>
   <Col>
@@ -458,9 +462,19 @@ echo $response;
                 <summary>More Information</summary>
                 <Properties>
                 
-                    <Properties><Property name="peer_approval_enabled" type="boolean" required={false}>
+                    <Properties><Property name="peer_approval_enabled" type="boolean" required={true}>
         
             (Cloud only) Enables or disables peer approval globally. If enabled, all peers added will be in pending state until approved by an admin.
+        
+        </Property>
+    <Property name="network_traffic_logs_enabled" type="boolean" required={true}>
+        
+            Enables or disables network traffic logs. If enabled, all network traffic logs from peers will be stored.
+        
+        </Property>
+    <Property name="network_traffic_packet_counter_enabled" type="boolean" required={true}>
+        
+            Enables or disables network traffic packet counter. If enabled, network packets and their size will be counted and reported. (This can have an slight impact on performance)
         
         </Property>
     </Properties>
@@ -502,7 +516,9 @@ curl -X PUT https://api.netbird.io/api/accounts/{accountId} \
     ],
     "routing_peer_dns_resolution_enabled": true,
     "extra": {
-      "peer_approval_enabled": true
+      "peer_approval_enabled": true,
+      "network_traffic_logs_enabled": true,
+      "network_traffic_packet_counter_enabled": true
     }
   }
 }'
@@ -525,7 +541,9 @@ let data = JSON.stringify({
     ],
     "routing_peer_dns_resolution_enabled": true,
     "extra": {
-      "peer_approval_enabled": true
+      "peer_approval_enabled": true,
+      "network_traffic_logs_enabled": true,
+      "network_traffic_packet_counter_enabled": true
     }
   }
 });
@@ -570,7 +588,9 @@ payload = json.dumps({
     ],
     "routing_peer_dns_resolution_enabled": true,
     "extra": {
-      "peer_approval_enabled": true
+      "peer_approval_enabled": true,
+      "network_traffic_logs_enabled": true,
+      "network_traffic_packet_counter_enabled": true
     }
   }
 })
@@ -615,7 +635,9 @@ func main() {
     ],
     "routing_peer_dns_resolution_enabled": true,
     "extra": {
-      "peer_approval_enabled": true
+      "peer_approval_enabled": true,
+      "network_traffic_logs_enabled": true,
+      "network_traffic_packet_counter_enabled": true
     }
   }
 }`)
@@ -678,7 +700,9 @@ request.body = JSON.dump({
     ],
     "routing_peer_dns_resolution_enabled": true,
     "extra": {
-      "peer_approval_enabled": true
+      "peer_approval_enabled": true,
+      "network_traffic_logs_enabled": true,
+      "network_traffic_packet_counter_enabled": true
     }
   }
 })
@@ -705,7 +729,9 @@ RequestBody body = RequestBody.create(mediaType, '{
     ],
     "routing_peer_dns_resolution_enabled": true,
     "extra": {
-      "peer_approval_enabled": true
+      "peer_approval_enabled": true,
+      "network_traffic_logs_enabled": true,
+      "network_traffic_packet_counter_enabled": true
     }
   }
 }');
@@ -748,7 +774,9 @@ curl_setopt_array($curl, array(
     ],
     "routing_peer_dns_resolution_enabled": true,
     "extra": {
-      "peer_approval_enabled": true
+      "peer_approval_enabled": true,
+      "network_traffic_logs_enabled": true,
+      "network_traffic_packet_counter_enabled": true
     }
   }
 }',
@@ -786,7 +814,9 @@ echo $response;
     ],
     "routing_peer_dns_resolution_enabled": true,
     "extra": {
-      "peer_approval_enabled": true
+      "peer_approval_enabled": true,
+      "network_traffic_logs_enabled": true,
+      "network_traffic_packet_counter_enabled": true
     }
   }
 }
@@ -808,7 +838,9 @@ echo $response;
     ],
     "routing_peer_dns_resolution_enabled": "boolean",
     "extra": {
-      "peer_approval_enabled": "boolean"
+      "peer_approval_enabled": "boolean",
+      "network_traffic_logs_enabled": "boolean",
+      "network_traffic_packet_counter_enabled": "boolean"
     }
   }
 }

--- a/src/pages/ipa/resources/dns.mdx
+++ b/src/pages/ipa/resources/dns.mdx
@@ -2,7 +2,7 @@ export const title = 'DNS'
 
 
 
-## List all Nameserver Groups {{ tag: 'GET' , label: '/api/dns/nameservers' }} 
+## List all Nameserver Groups  {{ tag: 'GET' , label: '/api/dns/nameservers' }}
 
 <Row>
   <Col>
@@ -218,7 +218,7 @@ echo $response;
 ---
 
 
-## Create a Nameserver Group {{ tag: 'POST' , label: '/api/dns/nameservers' }} 
+## Create a Nameserver Group  {{ tag: 'POST' , label: '/api/dns/nameservers' }}
 
 <Row>
   <Col>
@@ -644,7 +644,7 @@ echo $response;
 ---
 
 
-## Retrieve a Nameserver Group {{ tag: 'GET' , label: '/api/dns/nameservers/{nsgroupId}' }} 
+## Retrieve a Nameserver Group  {{ tag: 'GET' , label: '/api/dns/nameservers/{nsgroupId}' }}
 
 <Row>
   <Col>
@@ -864,7 +864,7 @@ echo $response;
 ---
 
 
-## Update a Nameserver Group {{ tag: 'PUT' , label: '/api/dns/nameservers/{nsgroupId}' }} 
+## Update a Nameserver Group  {{ tag: 'PUT' , label: '/api/dns/nameservers/{nsgroupId}' }}
 
 <Row>
   <Col>
@@ -1298,7 +1298,7 @@ echo $response;
 ---
 
 
-## Delete a Nameserver Group {{ tag: 'DELETE' , label: '/api/dns/nameservers/{nsgroupId}' }} 
+## Delete a Nameserver Group  {{ tag: 'DELETE' , label: '/api/dns/nameservers/{nsgroupId}' }}
 
 <Row>
   <Col>
@@ -1462,7 +1462,7 @@ echo $response;
 ---
 
 
-## Retrieve DNS settings {{ tag: 'GET' , label: '/api/dns/settings' }} 
+## Retrieve DNS settings  {{ tag: 'GET' , label: '/api/dns/settings' }}
 
 <Row>
   <Col>
@@ -1646,7 +1646,7 @@ echo $response;
 ---
 
 
-## Update DNS Settings {{ tag: 'PUT' , label: '/api/dns/settings' }} 
+## Update DNS Settings  {{ tag: 'PUT' , label: '/api/dns/settings' }}
 
 <Row>
   <Col>

--- a/src/pages/ipa/resources/events.mdx
+++ b/src/pages/ipa/resources/events.mdx
@@ -2,17 +2,17 @@ export const title = 'Events'
 
 
 
-## List all Events {{ tag: 'GET' , label: '/api/events' }} 
+## List all Audit Events  {{ tag: 'GET' , label: '/api/events/audit' }}
 
 <Row>
   <Col>
-    Returns a list of all events
+    Returns a list of all audit events
               </Col>
 
   <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/events">
+    <CodeGroup title="Request" tag="GET" label="/api/events/audit">
 ```bash {{ title: 'cURL' }}
-curl -X GET https://api.netbird.io/api/events \
+curl -X GET https://api.netbird.io/api/events/audit \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
@@ -23,7 +23,7 @@ const axios = require('axios');
 let config = {
   method: 'get',
   maxBodyLength: Infinity,
-  url: '/api/events',
+  url: '/api/events/audit',
   headers: {     
     'Accept': 'application/json',    
     'Authorization': 'Token <TOKEN>'
@@ -43,7 +43,7 @@ axios(config)
 import requests
 import json
 
-url = "https://api.netbird.io/api/events"
+url = "https://api.netbird.io/api/events/audit"
 
 headers = {     
   'Accept': 'application/json',
@@ -67,7 +67,7 @@ import (
 
 func main() {
 
-  url := "https://api.netbird.io/api/events"
+  url := "https://api.netbird.io/api/events/audit"
   method := "GET"
   
   client := &http.Client {
@@ -103,7 +103,7 @@ require "uri"
 require "json"
 require "net/http"
 
-url = URI("https://api.netbird.io/api/events")
+url = URI("https://api.netbird.io/api/events/audit")
 
 https = Net::HTTP.new(url.host, url.port)
 https.use_ssl = true
@@ -121,7 +121,7 @@ OkHttpClient client = new OkHttpClient().newBuilder()
   .build();
 
 Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/events")
+  .url("https://api.netbird.io/api/events/audit")
   .method("GET")    
   .addHeader("Accept", "application/json")
   .addHeader("Authorization: Token <TOKEN>")
@@ -135,7 +135,7 @@ Response response = client.newCall(request).execute();
 $curl = curl_init();
 
 curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/events',
+  CURLOPT_URL => 'https://api.netbird.io/api/events/audit',
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => '',
   CURLOPT_MAXREDIRS => 10,
@@ -199,6 +199,268 @@ echo $response;
         "peer_id": "chacbco6lnnbn6cg5s91"
       }
     }
+  }
+]
+```
+    </CodeGroup>
+    
+ 
+  </Col>
+</Row>
+
+---
+
+
+## List all Network Traffic Events  <Badge status="cloud-only" text="Cloud-Only" />  <Badge status="experimental" text="Experimental" />  {{ tag: 'GET' , label: '/api/events/network-traffic' }}
+
+<Row>
+  <Col>
+    Returns a list of all network traffic events
+              </Col>
+
+  <Col sticky>
+    <CodeGroup title="Request" tag="GET" label="/api/events/network-traffic">
+```bash {{ title: 'cURL' }}
+curl -X GET https://api.netbird.io/api/events/network-traffic \
+-H 'Accept: application/json' \
+-H 'Authorization: Token <TOKEN>' 
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: '/api/events/network-traffic',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+import json
+
+url = "https://api.netbird.io/api/events/network-traffic"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/events/network-traffic"
+  method := "GET"
+  
+  client := &http.Client {
+  }
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  {  
+    
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/events/network-traffic")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/events/network-traffic")
+  .method("GET")    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization: Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/events/network-traffic',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
+
+    </CodeGroup>
+    
+    
+    <CodeGroup title="Response">
+```json {{ title: 'Example' }}
+[
+  {
+    "id": "18e204d6-f7c6-405d-8025-70becb216add",
+    "flow_id": "61092452-b17c-4b14-b7cf-a2158c549826",
+    "reporter_id": "ch8i4ug6lnn4g9hqv7m0",
+    "timestamp": "2025-03-20T16:23:58.125397Z",
+    "source": {
+      "id": "ch8i4ug6lnn4g9hqv7m0",
+      "type": "PEER",
+      "name": "My Peer",
+      "geo_location": {
+        "city_name": "Berlin",
+        "country_code": "DE"
+      },
+      "os": "Linux",
+      "address": "100.64.0.10:51820",
+      "dns_label": "*.mydomain.com"
+    },
+    "user_id": "google-oauth2|123456789012345678901",
+    "user_email": "alice@netbird.io",
+    "user_name": "Alice Smith",
+    "destination": {
+      "id": "ch8i4ug6lnn4g9hqv7m0",
+      "type": "PEER",
+      "name": "My Peer",
+      "geo_location": {
+        "city_name": "Berlin",
+        "country_code": "DE"
+      },
+      "os": "Linux",
+      "address": "100.64.0.10:51820",
+      "dns_label": "*.mydomain.com"
+    },
+    "protocol": 6,
+    "type": "TYPE_START",
+    "direction": "INGRESS",
+    "rx_bytes": 1234,
+    "rx_packets": 5,
+    "tx_bytes": 1234,
+    "tx_packets": 5,
+    "policy_id": "ch8i4ug6lnn4g9hqv7m0",
+    "policy_name": "All to All",
+    "icmp_type": 8,
+    "icmp_code": 0
+  }
+]
+```
+```json {{ title: 'Schema' }}
+[
+  {
+    "id": "string",
+    "flow_id": "string",
+    "reporter_id": "string",
+    "timestamp": "string",
+    "source": {
+      "id": "string",
+      "type": "string",
+      "name": "string",
+      "geo_location": {
+        "city_name": "string",
+        "country_code": "string"
+      },
+      "os": "string",
+      "address": "string",
+      "dns_label": "string"
+    },
+    "user_id": "string",
+    "user_email": "string",
+    "user_name": "string",
+    "destination": {
+      "id": "string",
+      "type": "string",
+      "name": "string",
+      "geo_location": {
+        "city_name": "string",
+        "country_code": "string"
+      },
+      "os": "string",
+      "address": "string",
+      "dns_label": "string"
+    },
+    "protocol": "integer",
+    "type": "string",
+    "direction": "string",
+    "rx_bytes": "integer",
+    "rx_packets": "integer",
+    "tx_bytes": "integer",
+    "tx_packets": "integer",
+    "policy_id": "string",
+    "policy_name": "string",
+    "icmp_type": "integer",
+    "icmp_code": "integer"
   }
 ]
 ```

--- a/src/pages/ipa/resources/geo-locations.mdx
+++ b/src/pages/ipa/resources/geo-locations.mdx
@@ -2,7 +2,7 @@ export const title = 'Geo Locations'
 
 
 
-## List all country codes {{ tag: 'GET' , label: '/api/locations/countries' }} 
+## List all country codes  {{ tag: 'GET' , label: '/api/locations/countries' }}
 
 <Row>
   <Col>
@@ -178,7 +178,7 @@ echo $response;
 ---
 
 
-## List all city names by country {{ tag: 'GET' , label: '/api/locations/countries/{country}/cities' }} 
+## List all city names by country  {{ tag: 'GET' , label: '/api/locations/countries/{country}/cities' }}
 
 <Row>
   <Col>

--- a/src/pages/ipa/resources/groups.mdx
+++ b/src/pages/ipa/resources/groups.mdx
@@ -2,7 +2,7 @@ export const title = 'Groups'
 
 
 
-## List all Groups {{ tag: 'GET' , label: '/api/groups' }} 
+## List all Groups  {{ tag: 'GET' , label: '/api/groups' }}
 
 <Row>
   <Col>
@@ -214,7 +214,7 @@ echo $response;
 ---
 
 
-## Create a Group {{ tag: 'POST' , label: '/api/groups' }} 
+## Create a Group  {{ tag: 'POST' , label: '/api/groups' }}
 
 <Row>
   <Col>
@@ -550,7 +550,7 @@ echo $response;
 ---
 
 
-## Retrieve a Group {{ tag: 'GET' , label: '/api/groups/{groupId}' }} 
+## Retrieve a Group  {{ tag: 'GET' , label: '/api/groups/{groupId}' }}
 
 <Row>
   <Col>
@@ -766,7 +766,7 @@ echo $response;
 ---
 
 
-## Update a Group {{ tag: 'PUT' , label: '/api/groups/{groupId}' }} 
+## Update a Group  {{ tag: 'PUT' , label: '/api/groups/{groupId}' }}
 
 <Row>
   <Col>
@@ -1110,7 +1110,7 @@ echo $response;
 ---
 
 
-## Delete a Group {{ tag: 'DELETE' , label: '/api/groups/{groupId}' }} 
+## Delete a Group  {{ tag: 'DELETE' , label: '/api/groups/{groupId}' }}
 
 <Row>
   <Col>

--- a/src/pages/ipa/resources/ingress-ports.mdx
+++ b/src/pages/ipa/resources/ingress-ports.mdx
@@ -1,0 +1,2470 @@
+export const title = 'Ingress Ports'
+
+
+
+## List all Port Allocations  <Badge status="cloud-only" text="Cloud-Only" />  {{ tag: 'GET' , label: '/api/peers/{peerId}/ingress/ports' }}
+
+<Row>
+  <Col>
+    Returns a list of all ingress port allocations for a peer
+    
+    ### Path Parameters
+    <Properties>
+        
+          <Property name="peerId" type="string" required={true}> 
+            The unique identifier of a peer
+          </Property>   
+            </Properties>
+        
+    ### Query Parameters
+    <Properties>
+        
+            <Property name="name" type="string" required={false}>
+              Filters ingress port allocations by name
+            </Property>
+            </Properties>
+          </Col>
+
+  <Col sticky>
+    <CodeGroup title="Request" tag="GET" label="/api/peers/{peerId}/ingress/ports">
+```bash {{ title: 'cURL' }}
+curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports \
+-H 'Accept: application/json' \
+-H 'Authorization: Token <TOKEN>' 
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: '/api/peers/{peerId}/ingress/ports',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+import json
+
+url = "https://api.netbird.io/api/peers/{peerId}/ingress/ports"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/peers/{peerId}/ingress/ports"
+  method := "GET"
+  
+  client := &http.Client {
+  }
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  {  
+    
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/peers/{peerId}/ingress/ports")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/peers/{peerId}/ingress/ports")
+  .method("GET")    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization: Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/ingress/ports',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
+
+    </CodeGroup>
+    
+    
+    <CodeGroup title="Response">
+```json {{ title: 'Example' }}
+[
+  {
+    "id": "ch8i4ug6lnn4g9hqv7m0",
+    "name": "Ingress Peer Allocation 1",
+    "ingress_peer_id": "x7p3kqf2rdd8j5zxw4n9",
+    "region": "germany",
+    "enabled": true,
+    "ingress_ip": "192.34.0.123",
+    "port_range_mappings": [
+      {
+        "translated_start": 80,
+        "translated_end": 320,
+        "ingress_start": 1080,
+        "ingress_end": 1320,
+        "protocol": "tcp"
+      }
+    ]
+  }
+]
+```
+```json {{ title: 'Schema' }}
+[
+  {
+    "id": "string",
+    "name": "string",
+    "ingress_peer_id": "string",
+    "region": "string",
+    "enabled": "boolean",
+    "ingress_ip": "string",
+    "port_range_mappings": [
+      {
+        "translated_start": "integer",
+        "translated_end": "integer",
+        "ingress_start": "integer",
+        "ingress_end": "integer",
+        "protocol": "string"
+      }
+    ]
+  }
+]
+```
+    </CodeGroup>
+    
+ 
+  </Col>
+</Row>
+
+---
+
+
+## Create a Port Allocation  <Badge status="cloud-only" text="Cloud-Only" />  {{ tag: 'POST' , label: '/api/peers/{peerId}/ingress/ports' }}
+
+<Row>
+  <Col>
+    Creates a new ingress port allocation for a peer
+    
+    ### Path Parameters
+    <Properties>
+        
+          <Property name="peerId" type="string" required={true}> 
+            The unique identifier of a peer
+          </Property>   
+            </Properties>
+            
+    ### Request-Body Parameters
+    
+    <Properties><Property name="name" type="string" required={true}>
+        
+            Name of the ingress port allocation
+        
+        </Property>
+    <Property name="enabled" type="boolean" required={true}>
+        
+            Indicates if an ingress port allocation is enabled
+        
+        </Property>
+    <Property name="port_ranges" type="object[]" required={false}>
+        
+            <details class="custom-details" open>
+                <summary>List of port ranges that are forwarded by the ingress peer</summary>
+                <Properties>
+                
+                    <Properties><Property name="start" type="integer" required={true}>
+        
+            The starting port of the range of forwarded ports
+        
+        </Property>
+    <Property name="end" type="integer" required={true}>
+        
+            The ending port of the range of forwarded ports
+        
+        </Property>
+    <Property name="protocol" type="string" required={true} enumList={["tcp","udp","tcp/udp"]}>
+        
+            The protocol accepted by the port range
+        
+        </Property>
+    </Properties>
+                
+                </Properties>
+            </details>
+        
+        </Property>
+    <Property name="direct_port" type="object" required={false}>
+        
+            <details class="custom-details" open>
+                <summary>More Information</summary>
+                <Properties>
+                
+                    <Properties><Property name="count" type="integer" required={true}>
+        
+            The number of ports to be forwarded
+        
+        </Property>
+    <Property name="protocol" type="string" required={true} enumList={["tcp","udp","tcp/udp"]}>
+        
+            The protocol accepted by the port
+        
+        </Property>
+    </Properties>
+                
+                </Properties>
+            </details>
+        
+        </Property>
+    </Properties>
+
+    
+       </Col>
+
+  <Col sticky>
+    <CodeGroup title="Request" tag="POST" label="/api/peers/{peerId}/ingress/ports">
+```bash {{ title: 'cURL' }}
+curl -X POST https://api.netbird.io/api/peers/{peerId}/ingress/ports \
+-H 'Accept: application/json' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
+--data-raw '{
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+}'
+```
+
+```js
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: '/api/peers/{peerId}/ingress/ports',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+import json
+
+url = "https://api.netbird.io/api/peers/{peerId}/ingress/ports"
+payload = json.dumps({
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/peers/{peerId}/ingress/ports"
+  method := "POST"
+  
+  payload := strings.NewReader(`{
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+}`)
+  client := &http.Client {
+  }
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  {  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/peers/{peerId}/ingress/ports")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/peers/{peerId}/ingress/ports")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization: Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/ingress/ports',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
+
+    </CodeGroup>
+    
+    
+    <CodeGroup title="Response">
+```json {{ title: 'Example' }}
+{
+  "id": "ch8i4ug6lnn4g9hqv7m0",
+  "name": "Ingress Peer Allocation 1",
+  "ingress_peer_id": "x7p3kqf2rdd8j5zxw4n9",
+  "region": "germany",
+  "enabled": true,
+  "ingress_ip": "192.34.0.123",
+  "port_range_mappings": [
+    {
+      "translated_start": 80,
+      "translated_end": 320,
+      "ingress_start": 1080,
+      "ingress_end": 1320,
+      "protocol": "tcp"
+    }
+  ]
+}
+```
+```json {{ title: 'Schema' }}
+{
+  "id": "string",
+  "name": "string",
+  "ingress_peer_id": "string",
+  "region": "string",
+  "enabled": "boolean",
+  "ingress_ip": "string",
+  "port_range_mappings": [
+    {
+      "translated_start": "integer",
+      "translated_end": "integer",
+      "ingress_start": "integer",
+      "ingress_end": "integer",
+      "protocol": "string"
+    }
+  ]
+}
+```
+    </CodeGroup>
+    
+ 
+  </Col>
+</Row>
+
+---
+
+
+## Retrieve a Port Allocation  <Badge status="cloud-only" text="Cloud-Only" />  {{ tag: 'GET' , label: '/api/peers/{peerId}/ingress/ports/{allocationId}' }}
+
+<Row>
+  <Col>
+    Get information about an ingress port allocation
+    
+    ### Path Parameters
+    <Properties>
+        
+          <Property name="peerId" type="string" required={true}> 
+            The unique identifier of a peer
+          </Property>   
+        
+          <Property name="allocationId" type="string" required={true}> 
+            The unique identifier of an ingress port allocation
+          </Property>   
+            </Properties>
+              </Col>
+
+  <Col sticky>
+    <CodeGroup title="Request" tag="GET" label="/api/peers/{peerId}/ingress/ports/{allocationId}">
+```bash {{ title: 'cURL' }}
+curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId} \
+-H 'Accept: application/json' \
+-H 'Authorization: Token <TOKEN>' 
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: '/api/peers/{peerId}/ingress/ports/{allocationId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+import json
+
+url = "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
+  method := "GET"
+  
+  client := &http.Client {
+  }
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  {  
+    
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
+  .method("GET")    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization: Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
+
+    </CodeGroup>
+    
+    
+    <CodeGroup title="Response">
+```json {{ title: 'Example' }}
+{
+  "id": "ch8i4ug6lnn4g9hqv7m0",
+  "name": "Ingress Peer Allocation 1",
+  "ingress_peer_id": "x7p3kqf2rdd8j5zxw4n9",
+  "region": "germany",
+  "enabled": true,
+  "ingress_ip": "192.34.0.123",
+  "port_range_mappings": [
+    {
+      "translated_start": 80,
+      "translated_end": 320,
+      "ingress_start": 1080,
+      "ingress_end": 1320,
+      "protocol": "tcp"
+    }
+  ]
+}
+```
+```json {{ title: 'Schema' }}
+{
+  "id": "string",
+  "name": "string",
+  "ingress_peer_id": "string",
+  "region": "string",
+  "enabled": "boolean",
+  "ingress_ip": "string",
+  "port_range_mappings": [
+    {
+      "translated_start": "integer",
+      "translated_end": "integer",
+      "ingress_start": "integer",
+      "ingress_end": "integer",
+      "protocol": "string"
+    }
+  ]
+}
+```
+    </CodeGroup>
+    
+ 
+  </Col>
+</Row>
+
+---
+
+
+## Update a Port Allocation  <Badge status="cloud-only" text="Cloud-Only" />  {{ tag: 'PUT' , label: '/api/peers/{peerId}/ingress/ports/{allocationId}' }}
+
+<Row>
+  <Col>
+    Update information about an ingress port allocation
+    
+    ### Path Parameters
+    <Properties>
+        
+          <Property name="peerId" type="string" required={true}> 
+            The unique identifier of a peer
+          </Property>   
+        
+          <Property name="allocationId" type="string" required={true}> 
+            The unique identifier of an ingress port allocation
+          </Property>   
+            </Properties>
+            
+    ### Request-Body Parameters
+    
+    <Properties><Property name="name" type="string" required={true}>
+        
+            Name of the ingress port allocation
+        
+        </Property>
+    <Property name="enabled" type="boolean" required={true}>
+        
+            Indicates if an ingress port allocation is enabled
+        
+        </Property>
+    <Property name="port_ranges" type="object[]" required={false}>
+        
+            <details class="custom-details" open>
+                <summary>List of port ranges that are forwarded by the ingress peer</summary>
+                <Properties>
+                
+                    <Properties><Property name="start" type="integer" required={true}>
+        
+            The starting port of the range of forwarded ports
+        
+        </Property>
+    <Property name="end" type="integer" required={true}>
+        
+            The ending port of the range of forwarded ports
+        
+        </Property>
+    <Property name="protocol" type="string" required={true} enumList={["tcp","udp","tcp/udp"]}>
+        
+            The protocol accepted by the port range
+        
+        </Property>
+    </Properties>
+                
+                </Properties>
+            </details>
+        
+        </Property>
+    <Property name="direct_port" type="object" required={false}>
+        
+            <details class="custom-details" open>
+                <summary>More Information</summary>
+                <Properties>
+                
+                    <Properties><Property name="count" type="integer" required={true}>
+        
+            The number of ports to be forwarded
+        
+        </Property>
+    <Property name="protocol" type="string" required={true} enumList={["tcp","udp","tcp/udp"]}>
+        
+            The protocol accepted by the port
+        
+        </Property>
+    </Properties>
+                
+                </Properties>
+            </details>
+        
+        </Property>
+    </Properties>
+
+    
+       </Col>
+
+  <Col sticky>
+    <CodeGroup title="Request" tag="PUT" label="/api/peers/{peerId}/ingress/ports/{allocationId}">
+```bash {{ title: 'cURL' }}
+curl -X PUT https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId} \
+-H 'Accept: application/json' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
+--data-raw '{
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+}'
+```
+
+```js
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: '/api/peers/{peerId}/ingress/ports/{allocationId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+import json
+
+url = "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
+payload = json.dumps({
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
+  method := "PUT"
+  
+  payload := strings.NewReader(`{
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+}`)
+  client := &http.Client {
+  }
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  {  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization: Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
+
+    </CodeGroup>
+    
+    
+    <CodeGroup title="Response">
+```json {{ title: 'Example' }}
+{
+  "id": "ch8i4ug6lnn4g9hqv7m0",
+  "name": "Ingress Peer Allocation 1",
+  "ingress_peer_id": "x7p3kqf2rdd8j5zxw4n9",
+  "region": "germany",
+  "enabled": true,
+  "ingress_ip": "192.34.0.123",
+  "port_range_mappings": [
+    {
+      "translated_start": 80,
+      "translated_end": 320,
+      "ingress_start": 1080,
+      "ingress_end": 1320,
+      "protocol": "tcp"
+    }
+  ]
+}
+```
+```json {{ title: 'Schema' }}
+{
+  "id": "string",
+  "name": "string",
+  "ingress_peer_id": "string",
+  "region": "string",
+  "enabled": "boolean",
+  "ingress_ip": "string",
+  "port_range_mappings": [
+    {
+      "translated_start": "integer",
+      "translated_end": "integer",
+      "ingress_start": "integer",
+      "ingress_end": "integer",
+      "protocol": "string"
+    }
+  ]
+}
+```
+    </CodeGroup>
+    
+ 
+  </Col>
+</Row>
+
+---
+
+
+## Delete a Port Allocation  <Badge status="cloud-only" text="Cloud-Only" />  {{ tag: 'DELETE' , label: '/api/peers/{peerId}/ingress/ports/{allocationId}' }}
+
+<Row>
+  <Col>
+    Delete an ingress port allocation
+    
+    ### Path Parameters
+    <Properties>
+        
+          <Property name="peerId" type="string" required={true}> 
+            The unique identifier of a peer
+          </Property>   
+        
+          <Property name="allocationId" type="string" required={true}> 
+            The unique identifier of an ingress port allocation
+          </Property>   
+            </Properties>
+              </Col>
+
+  <Col sticky>
+    <CodeGroup title="Request" tag="DELETE" label="/api/peers/{peerId}/ingress/ports/{allocationId}">
+```bash {{ title: 'cURL' }}
+curl -X DELETE https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId} \
+-H 'Authorization: Token <TOKEN>' 
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: '/api/peers/{peerId}/ingress/ports/{allocationId}',
+  headers: {         
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+import json
+
+url = "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
+
+headers = {     
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
+  method := "DELETE"
+  
+  client := &http.Client {
+  }
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  {  
+    
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
+  .method("DELETE")    
+  .addHeader("Authorization: Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',  
+  CURLOPT_HTTPHEADER => array(        
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
+
+    </CodeGroup>
+    
+    
+ 
+  </Col>
+</Row>
+
+---
+
+
+## List all Ingress Peers  <Badge status="cloud-only" text="Cloud-Only" />  {{ tag: 'GET' , label: '/api/ingress/peers' }}
+
+<Row>
+  <Col>
+    Returns a list of all ingress peers
+              </Col>
+
+  <Col sticky>
+    <CodeGroup title="Request" tag="GET" label="/api/ingress/peers">
+```bash {{ title: 'cURL' }}
+curl -X GET https://api.netbird.io/api/ingress/peers \
+-H 'Accept: application/json' \
+-H 'Authorization: Token <TOKEN>' 
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: '/api/ingress/peers',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+import json
+
+url = "https://api.netbird.io/api/ingress/peers"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/ingress/peers"
+  method := "GET"
+  
+  client := &http.Client {
+  }
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  {  
+    
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/ingress/peers")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/ingress/peers")
+  .method("GET")    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization: Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/ingress/peers',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
+
+    </CodeGroup>
+    
+    
+    <CodeGroup title="Response">
+```json {{ title: 'Example' }}
+[
+  {
+    "id": "ch8i4ug6lnn4g9hqv7m0",
+    "peer_id": "x7p3kqf2rdd8j5zxw4n9",
+    "ingress_ip": "192.34.0.123",
+    "available_ports": {
+      "tcp": 45765,
+      "udp": 50000
+    },
+    "enabled": true,
+    "connected": true,
+    "fallback": true,
+    "region": "germany"
+  }
+]
+```
+```json {{ title: 'Schema' }}
+[
+  {
+    "id": "string",
+    "peer_id": "string",
+    "ingress_ip": "string",
+    "available_ports": {
+      "tcp": "integer",
+      "udp": "integer"
+    },
+    "enabled": "boolean",
+    "connected": "boolean",
+    "fallback": "boolean",
+    "region": "string"
+  }
+]
+```
+    </CodeGroup>
+    
+ 
+  </Col>
+</Row>
+
+---
+
+
+## Create a Ingress Peer  <Badge status="cloud-only" text="Cloud-Only" />  {{ tag: 'POST' , label: '/api/ingress/peers' }}
+
+<Row>
+  <Col>
+    Creates a new ingress peer
+            
+    ### Request-Body Parameters
+    
+    <Properties><Property name="peer_id" type="string" required={true}>
+        
+            ID of the peer that is used as an ingress peer
+        
+        </Property>
+    <Property name="enabled" type="boolean" required={true}>
+        
+            Defines if an ingress peer is enabled
+        
+        </Property>
+    <Property name="fallback" type="boolean" required={true}>
+        
+            Defines if an ingress peer can be used as a fallback if no ingress peer can be found in the region of the forwarded peer
+        
+        </Property>
+    </Properties>
+
+    
+       </Col>
+
+  <Col sticky>
+    <CodeGroup title="Request" tag="POST" label="/api/ingress/peers">
+```bash {{ title: 'cURL' }}
+curl -X POST https://api.netbird.io/api/ingress/peers \
+-H 'Accept: application/json' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
+--data-raw '{
+  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
+  "enabled": true,
+  "fallback": true
+}'
+```
+
+```js
+const axios = require('axios');
+let data = JSON.stringify({
+  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
+  "enabled": true,
+  "fallback": true
+});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: '/api/ingress/peers',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+import json
+
+url = "https://api.netbird.io/api/ingress/peers"
+payload = json.dumps({
+  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
+  "enabled": true,
+  "fallback": true
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/ingress/peers"
+  method := "POST"
+  
+  payload := strings.NewReader(`{
+  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
+  "enabled": true,
+  "fallback": true
+}`)
+  client := &http.Client {
+  }
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  {  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/ingress/peers")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
+  "enabled": true,
+  "fallback": true
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
+  "enabled": true,
+  "fallback": true
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/ingress/peers")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization: Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/ingress/peers',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{
+  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
+  "enabled": true,
+  "fallback": true
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
+
+    </CodeGroup>
+    
+    
+    <CodeGroup title="Response">
+```json {{ title: 'Example' }}
+{
+  "id": "ch8i4ug6lnn4g9hqv7m0",
+  "peer_id": "x7p3kqf2rdd8j5zxw4n9",
+  "ingress_ip": "192.34.0.123",
+  "available_ports": {
+    "tcp": 45765,
+    "udp": 50000
+  },
+  "enabled": true,
+  "connected": true,
+  "fallback": true,
+  "region": "germany"
+}
+```
+```json {{ title: 'Schema' }}
+{
+  "id": "string",
+  "peer_id": "string",
+  "ingress_ip": "string",
+  "available_ports": {
+    "tcp": "integer",
+    "udp": "integer"
+  },
+  "enabled": "boolean",
+  "connected": "boolean",
+  "fallback": "boolean",
+  "region": "string"
+}
+```
+    </CodeGroup>
+    
+ 
+  </Col>
+</Row>
+
+---
+
+
+## Retrieve a Ingress Peer  <Badge status="cloud-only" text="Cloud-Only" />  {{ tag: 'GET' , label: '/api/ingress/peers/{ingressPeerId}' }}
+
+<Row>
+  <Col>
+    Get information about an ingress peer
+    
+    ### Path Parameters
+    <Properties>
+        
+          <Property name="ingressPeerId" type="string" required={true}> 
+            The unique identifier of an ingress peer
+          </Property>   
+            </Properties>
+              </Col>
+
+  <Col sticky>
+    <CodeGroup title="Request" tag="GET" label="/api/ingress/peers/{ingressPeerId}">
+```bash {{ title: 'cURL' }}
+curl -X GET https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
+-H 'Accept: application/json' \
+-H 'Authorization: Token <TOKEN>' 
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: '/api/ingress/peers/{ingressPeerId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+import json
+
+url = "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
+  method := "GET"
+  
+  client := &http.Client {
+  }
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  {  
+    
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
+  .method("GET")    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization: Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/ingress/peers/{ingressPeerId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
+
+    </CodeGroup>
+    
+    
+    <CodeGroup title="Response">
+```json {{ title: 'Example' }}
+{
+  "id": "ch8i4ug6lnn4g9hqv7m0",
+  "peer_id": "x7p3kqf2rdd8j5zxw4n9",
+  "ingress_ip": "192.34.0.123",
+  "available_ports": {
+    "tcp": 45765,
+    "udp": 50000
+  },
+  "enabled": true,
+  "connected": true,
+  "fallback": true,
+  "region": "germany"
+}
+```
+```json {{ title: 'Schema' }}
+{
+  "id": "string",
+  "peer_id": "string",
+  "ingress_ip": "string",
+  "available_ports": {
+    "tcp": "integer",
+    "udp": "integer"
+  },
+  "enabled": "boolean",
+  "connected": "boolean",
+  "fallback": "boolean",
+  "region": "string"
+}
+```
+    </CodeGroup>
+    
+ 
+  </Col>
+</Row>
+
+---
+
+
+## Update a Ingress Peer  <Badge status="cloud-only" text="Cloud-Only" />  {{ tag: 'PUT' , label: '/api/ingress/peers/{ingressPeerId}' }}
+
+<Row>
+  <Col>
+    Update information about an ingress peer
+    
+    ### Path Parameters
+    <Properties>
+        
+          <Property name="ingressPeerId" type="string" required={true}> 
+            The unique identifier of an ingress peer
+          </Property>   
+            </Properties>
+            
+    ### Request-Body Parameters
+    
+    <Properties><Property name="enabled" type="boolean" required={true}>
+        
+            Defines if an ingress peer is enabled
+        
+        </Property>
+    <Property name="fallback" type="boolean" required={true}>
+        
+            Defines if an ingress peer can be used as a fallback if no ingress peer can be found in the region of the forwarded peer
+        
+        </Property>
+    </Properties>
+
+    
+       </Col>
+
+  <Col sticky>
+    <CodeGroup title="Request" tag="PUT" label="/api/ingress/peers/{ingressPeerId}">
+```bash {{ title: 'cURL' }}
+curl -X PUT https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
+-H 'Accept: application/json' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
+--data-raw '{
+  "enabled": true,
+  "fallback": true
+}'
+```
+
+```js
+const axios = require('axios');
+let data = JSON.stringify({
+  "enabled": true,
+  "fallback": true
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: '/api/ingress/peers/{ingressPeerId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+import json
+
+url = "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
+payload = json.dumps({
+  "enabled": true,
+  "fallback": true
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
+  method := "PUT"
+  
+  payload := strings.NewReader(`{
+  "enabled": true,
+  "fallback": true
+}`)
+  client := &http.Client {
+  }
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  {  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "enabled": true,
+  "fallback": true
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "enabled": true,
+  "fallback": true
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization: Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/ingress/peers/{ingressPeerId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "enabled": true,
+  "fallback": true
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
+
+    </CodeGroup>
+    
+    
+    <CodeGroup title="Response">
+```json {{ title: 'Example' }}
+{
+  "id": "ch8i4ug6lnn4g9hqv7m0",
+  "peer_id": "x7p3kqf2rdd8j5zxw4n9",
+  "ingress_ip": "192.34.0.123",
+  "available_ports": {
+    "tcp": 45765,
+    "udp": 50000
+  },
+  "enabled": true,
+  "connected": true,
+  "fallback": true,
+  "region": "germany"
+}
+```
+```json {{ title: 'Schema' }}
+{
+  "id": "string",
+  "peer_id": "string",
+  "ingress_ip": "string",
+  "available_ports": {
+    "tcp": "integer",
+    "udp": "integer"
+  },
+  "enabled": "boolean",
+  "connected": "boolean",
+  "fallback": "boolean",
+  "region": "string"
+}
+```
+    </CodeGroup>
+    
+ 
+  </Col>
+</Row>
+
+---
+
+
+## Delete a Ingress Peer  <Badge status="cloud-only" text="Cloud-Only" />  {{ tag: 'DELETE' , label: '/api/ingress/peers/{ingressPeerId}' }}
+
+<Row>
+  <Col>
+    Delete an ingress peer
+    
+    ### Path Parameters
+    <Properties>
+        
+          <Property name="ingressPeerId" type="string" required={true}> 
+            The unique identifier of an ingress peer
+          </Property>   
+            </Properties>
+              </Col>
+
+  <Col sticky>
+    <CodeGroup title="Request" tag="DELETE" label="/api/ingress/peers/{ingressPeerId}">
+```bash {{ title: 'cURL' }}
+curl -X DELETE https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
+-H 'Authorization: Token <TOKEN>' 
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: '/api/ingress/peers/{ingressPeerId}',
+  headers: {         
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+import json
+
+url = "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
+
+headers = {     
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
+  method := "DELETE"
+  
+  client := &http.Client {
+  }
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  {  
+    
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
+  .method("DELETE")    
+  .addHeader("Authorization: Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/ingress/peers/{ingressPeerId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',  
+  CURLOPT_HTTPHEADER => array(        
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
+
+    </CodeGroup>
+    
+    
+ 
+  </Col>
+</Row>
+
+---

--- a/src/pages/ipa/resources/networks.mdx
+++ b/src/pages/ipa/resources/networks.mdx
@@ -2,7 +2,7 @@ export const title = 'Networks'
 
 
 
-## List all Networks {{ tag: 'GET' , label: '/api/networks' }} 
+## List all Networks  {{ tag: 'GET' , label: '/api/networks' }}
 
 <Row>
   <Col>
@@ -206,7 +206,7 @@ echo $response;
 ---
 
 
-## Create a Network {{ tag: 'POST' , label: '/api/networks' }} 
+## Create a Network  {{ tag: 'POST' , label: '/api/networks' }}
 
 <Row>
   <Col>
@@ -456,7 +456,7 @@ echo $response;
 ---
 
 
-## Retrieve a Network {{ tag: 'GET' , label: '/api/networks/{networkId}' }} 
+## Retrieve a Network  {{ tag: 'GET' , label: '/api/networks/{networkId}' }}
 
 <Row>
   <Col>
@@ -664,7 +664,7 @@ echo $response;
 ---
 
 
-## Update a Network {{ tag: 'PUT' , label: '/api/networks/{networkId}' }} 
+## Update a Network  {{ tag: 'PUT' , label: '/api/networks/{networkId}' }}
 
 <Row>
   <Col>
@@ -922,7 +922,7 @@ echo $response;
 ---
 
 
-## Delete a Network {{ tag: 'DELETE' , label: '/api/networks/{networkId}' }} 
+## Delete a Network  {{ tag: 'DELETE' , label: '/api/networks/{networkId}' }}
 
 <Row>
   <Col>
@@ -1086,7 +1086,7 @@ echo $response;
 ---
 
 
-## List all Network Resources {{ tag: 'GET' , label: '/api/networks/{networkId}/resources' }} 
+## List all Network Resources  {{ tag: 'GET' , label: '/api/networks/{networkId}/resources' }}
 
 <Row>
   <Col>
@@ -1302,7 +1302,7 @@ echo $response;
 ---
 
 
-## Create a Network Resource {{ tag: 'POST' , label: '/api/networks/{networkId}/resources' }} 
+## Create a Network Resource  {{ tag: 'POST' , label: '/api/networks/{networkId}/resources' }}
 
 <Row>
   <Col>
@@ -1614,7 +1614,7 @@ echo $response;
 ---
 
 
-## Retrieve a Network Resource {{ tag: 'GET' , label: '/api/networks/{networkId}/resources/{resourceId}' }} 
+## Retrieve a Network Resource  {{ tag: 'GET' , label: '/api/networks/{networkId}/resources/{resourceId}' }}
 
 <Row>
   <Col>
@@ -1830,7 +1830,7 @@ echo $response;
 ---
 
 
-## Update a Network Resource {{ tag: 'PUT' , label: '/api/networks/{networkId}/resources/{resourceId}' }} 
+## Update a Network Resource  {{ tag: 'PUT' , label: '/api/networks/{networkId}/resources/{resourceId}' }}
 
 <Row>
   <Col>
@@ -2146,7 +2146,7 @@ echo $response;
 ---
 
 
-## Delete a Network Resource {{ tag: 'DELETE' , label: '/api/networks/{networkId}/resources/{resourceId}' }} 
+## Delete a Network Resource  {{ tag: 'DELETE' , label: '/api/networks/{networkId}/resources/{resourceId}' }}
 
 <Row>
   <Col>
@@ -2314,7 +2314,7 @@ echo $response;
 ---
 
 
-## List all Network Routers {{ tag: 'GET' , label: '/api/networks/{networkId}/routers' }} 
+## List all Network Routers  {{ tag: 'GET' , label: '/api/networks/{networkId}/routers' }}
 
 <Row>
   <Col>
@@ -2516,7 +2516,7 @@ echo $response;
 ---
 
 
-## Create a Network Router {{ tag: 'POST' , label: '/api/networks/{networkId}/routers' }} 
+## Create a Network Router  {{ tag: 'POST' , label: '/api/networks/{networkId}/routers' }}
 
 <Row>
   <Col>
@@ -2814,7 +2814,7 @@ echo $response;
 ---
 
 
-## Retrieve a Network Router {{ tag: 'GET' , label: '/api/networks/{networkId}/routers/{routerId}' }} 
+## Retrieve a Network Router  {{ tag: 'GET' , label: '/api/networks/{networkId}/routers/{routerId}' }}
 
 <Row>
   <Col>
@@ -3016,7 +3016,7 @@ echo $response;
 ---
 
 
-## Update a Network Router {{ tag: 'PUT' , label: '/api/networks/{networkId}/routers/{routerId}' }} 
+## Update a Network Router  {{ tag: 'PUT' , label: '/api/networks/{networkId}/routers/{routerId}' }}
 
 <Row>
   <Col>
@@ -3318,7 +3318,7 @@ echo $response;
 ---
 
 
-## Delete a Network Router {{ tag: 'DELETE' , label: '/api/networks/{networkId}/routers/{routerId}' }} 
+## Delete a Network Router  {{ tag: 'DELETE' , label: '/api/networks/{networkId}/routers/{routerId}' }}
 
 <Row>
   <Col>

--- a/src/pages/ipa/resources/peers.mdx
+++ b/src/pages/ipa/resources/peers.mdx
@@ -2,12 +2,24 @@ export const title = 'Peers'
 
 
 
-## List all Peers {{ tag: 'GET' , label: '/api/peers' }} 
+## List all Peers  {{ tag: 'GET' , label: '/api/peers' }}
 
 <Row>
   <Col>
     Returns a list of all peers
-              </Col>
+        
+    ### Query Parameters
+    <Properties>
+        
+            <Property name="name" type="string" required={false}>
+              Filter peers by name
+            </Property>
+        
+            <Property name="ip" type="string" required={false}>
+              Filter peers by IP address
+            </Property>
+            </Properties>
+          </Col>
 
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/api/peers">
@@ -252,7 +264,7 @@ echo $response;
 ---
 
 
-## Retrieve a Peer {{ tag: 'GET' , label: '/api/peers/{peerId}' }} 
+## Retrieve a Peer  {{ tag: 'GET' , label: '/api/peers/{peerId}' }}
 
 <Row>
   <Col>
@@ -504,7 +516,7 @@ echo $response;
 ---
 
 
-## Update a Peer {{ tag: 'PUT' , label: '/api/peers/{peerId}' }} 
+## Update a Peer  {{ tag: 'PUT' , label: '/api/peers/{peerId}' }}
 
 <Row>
   <Col>
@@ -842,7 +854,7 @@ echo $response;
 ---
 
 
-## Delete a Peer {{ tag: 'DELETE' , label: '/api/peers/{peerId}' }} 
+## Delete a Peer  {{ tag: 'DELETE' , label: '/api/peers/{peerId}' }}
 
 <Row>
   <Col>
@@ -1006,7 +1018,7 @@ echo $response;
 ---
 
 
-## List accessible Peers {{ tag: 'GET' , label: '/api/peers/{peerId}/accessible-peers' }} 
+## List accessible Peers  {{ tag: 'GET' , label: '/api/peers/{peerId}/accessible-peers' }}
 
 <Row>
   <Col>

--- a/src/pages/ipa/resources/policies.mdx
+++ b/src/pages/ipa/resources/policies.mdx
@@ -2,7 +2,7 @@ export const title = 'Policies'
 
 
 
-## List all Policies {{ tag: 'GET' , label: '/api/policies' }} 
+## List all Policies  {{ tag: 'GET' , label: '/api/policies' }}
 
 <Row>
   <Col>
@@ -286,7 +286,7 @@ echo $response;
 ---
 
 
-## Create a Policy {{ tag: 'POST' , label: '/api/policies' }} 
+## Create a Policy  {{ tag: 'POST' , label: '/api/policies' }}
 
 <Row>
   <Col>
@@ -1020,7 +1020,7 @@ echo $response;
 ---
 
 
-## Retrieve a Policy {{ tag: 'GET' , label: '/api/policies/{policyId}' }} 
+## Retrieve a Policy  {{ tag: 'GET' , label: '/api/policies/{policyId}' }}
 
 <Row>
   <Col>
@@ -1308,7 +1308,7 @@ echo $response;
 ---
 
 
-## Update a Policy {{ tag: 'PUT' , label: '/api/policies/{policyId}' }} 
+## Update a Policy  {{ tag: 'PUT' , label: '/api/policies/{policyId}' }}
 
 <Row>
   <Col>
@@ -2050,7 +2050,7 @@ echo $response;
 ---
 
 
-## Delete a Policy {{ tag: 'DELETE' , label: '/api/policies/{policyId}' }} 
+## Delete a Policy  {{ tag: 'DELETE' , label: '/api/policies/{policyId}' }}
 
 <Row>
   <Col>

--- a/src/pages/ipa/resources/posture-checks.mdx
+++ b/src/pages/ipa/resources/posture-checks.mdx
@@ -2,7 +2,7 @@ export const title = 'Posture Checks'
 
 
 
-## List all Posture Checks {{ tag: 'GET' , label: '/api/posture-checks' }} 
+## List all Posture Checks  {{ tag: 'GET' , label: '/api/posture-checks' }}
 
 <Row>
   <Col>
@@ -280,7 +280,7 @@ echo $response;
 ---
 
 
-## Create a Posture Check {{ tag: 'POST' , label: '/api/posture-checks' }} 
+## Create a Posture Check  {{ tag: 'POST' , label: '/api/posture-checks' }}
 
 <Row>
   <Col>
@@ -1166,7 +1166,7 @@ echo $response;
 ---
 
 
-## Retrieve a Posture Check {{ tag: 'GET' , label: '/api/posture-checks/{postureCheckId}' }} 
+## Retrieve a Posture Check  {{ tag: 'GET' , label: '/api/posture-checks/{postureCheckId}' }}
 
 <Row>
   <Col>
@@ -1448,7 +1448,7 @@ echo $response;
 ---
 
 
-## Update a Posture Check {{ tag: 'PUT' , label: '/api/posture-checks/{postureCheckId}' }} 
+## Update a Posture Check  {{ tag: 'PUT' , label: '/api/posture-checks/{postureCheckId}' }}
 
 <Row>
   <Col>
@@ -2342,7 +2342,7 @@ echo $response;
 ---
 
 
-## Delete a Posture Check {{ tag: 'DELETE' , label: '/api/posture-checks/{postureCheckId}' }} 
+## Delete a Posture Check  {{ tag: 'DELETE' , label: '/api/posture-checks/{postureCheckId}' }}
 
 <Row>
   <Col>

--- a/src/pages/ipa/resources/routes.mdx
+++ b/src/pages/ipa/resources/routes.mdx
@@ -2,7 +2,7 @@ export const title = 'Routes'
 
 
 
-## List all Routes {{ tag: 'GET' , label: '/api/routes' }} 
+## List all Routes  {{ tag: 'GET' , label: '/api/routes' }}
 
 <Row>
   <Col>
@@ -224,7 +224,7 @@ echo $response;
 ---
 
 
-## Create a Route {{ tag: 'POST' , label: '/api/routes' }} 
+## Create a Route  {{ tag: 'POST' , label: '/api/routes' }}
 
 <Row>
   <Col>
@@ -668,7 +668,7 @@ echo $response;
 ---
 
 
-## Retrieve a Route {{ tag: 'GET' , label: '/api/routes/{routeId}' }} 
+## Retrieve a Route  {{ tag: 'GET' , label: '/api/routes/{routeId}' }}
 
 <Row>
   <Col>
@@ -894,7 +894,7 @@ echo $response;
 ---
 
 
-## Update a Route {{ tag: 'PUT' , label: '/api/routes/{routeId}' }} 
+## Update a Route  {{ tag: 'PUT' , label: '/api/routes/{routeId}' }}
 
 <Row>
   <Col>
@@ -1346,7 +1346,7 @@ echo $response;
 ---
 
 
-## Delete a Route {{ tag: 'DELETE' , label: '/api/routes/{routeId}' }} 
+## Delete a Route  {{ tag: 'DELETE' , label: '/api/routes/{routeId}' }}
 
 <Row>
   <Col>

--- a/src/pages/ipa/resources/setup-keys.mdx
+++ b/src/pages/ipa/resources/setup-keys.mdx
@@ -2,7 +2,7 @@ export const title = 'Setup Keys'
 
 
 
-## List all Setup Keys {{ tag: 'GET' , label: '/api/setup-keys' }} 
+## List all Setup Keys  {{ tag: 'GET' , label: '/api/setup-keys' }}
 
 <Row>
   <Col>
@@ -214,7 +214,7 @@ echo $response;
 ---
 
 
-## Create a Setup Key {{ tag: 'POST' , label: '/api/setup-keys' }} 
+## Create a Setup Key  {{ tag: 'POST' , label: '/api/setup-keys' }}
 
 <Row>
   <Col>
@@ -546,7 +546,7 @@ echo $response;
 ---
 
 
-## Retrieve a Setup Key {{ tag: 'GET' , label: '/api/setup-keys/{keyId}' }} 
+## Retrieve a Setup Key  {{ tag: 'GET' , label: '/api/setup-keys/{keyId}' }}
 
 <Row>
   <Col>
@@ -762,7 +762,7 @@ echo $response;
 ---
 
 
-## Update a Setup Key {{ tag: 'PUT' , label: '/api/setup-keys/{keyId}' }} 
+## Update a Setup Key  {{ tag: 'PUT' , label: '/api/setup-keys/{keyId}' }}
 
 <Row>
   <Col>
@@ -1042,7 +1042,7 @@ echo $response;
 ---
 
 
-## Delete a Setup Key {{ tag: 'DELETE' , label: '/api/setup-keys/{keyId}' }} 
+## Delete a Setup Key  {{ tag: 'DELETE' , label: '/api/setup-keys/{keyId}' }}
 
 <Row>
   <Col>

--- a/src/pages/ipa/resources/tokens.mdx
+++ b/src/pages/ipa/resources/tokens.mdx
@@ -2,7 +2,7 @@ export const title = 'Tokens'
 
 
 
-## List all Tokens {{ tag: 'GET' , label: '/api/users/{userId}/tokens' }} 
+## List all Tokens  {{ tag: 'GET' , label: '/api/users/{userId}/tokens' }}
 
 <Row>
   <Col>
@@ -200,7 +200,7 @@ echo $response;
 ---
 
 
-## Create a Token {{ tag: 'POST' , label: '/api/users/{userId}/tokens' }} 
+## Create a Token  {{ tag: 'POST' , label: '/api/users/{userId}/tokens' }}
 
 <Row>
   <Col>
@@ -450,7 +450,7 @@ echo $response;
 ---
 
 
-## Retrieve a Token {{ tag: 'GET' , label: '/api/users/{userId}/tokens/{tokenId}' }} 
+## Retrieve a Token  {{ tag: 'GET' , label: '/api/users/{userId}/tokens/{tokenId}' }}
 
 <Row>
   <Col>
@@ -648,7 +648,7 @@ echo $response;
 ---
 
 
-## Delete a Token {{ tag: 'DELETE' , label: '/api/users/{userId}/tokens/{tokenId}' }} 
+## Delete a Token  {{ tag: 'DELETE' , label: '/api/users/{userId}/tokens/{tokenId}' }}
 
 <Row>
   <Col>

--- a/src/pages/ipa/resources/users.mdx
+++ b/src/pages/ipa/resources/users.mdx
@@ -2,7 +2,7 @@ export const title = 'Users'
 
 
 
-## List all Users {{ tag: 'GET' , label: '/api/users' }} 
+## List all Users  {{ tag: 'GET' , label: '/api/users' }}
 
 <Row>
   <Col>
@@ -220,7 +220,7 @@ echo $response;
 ---
 
 
-## Create a User {{ tag: 'POST' , label: '/api/users' }} 
+## Create a User  {{ tag: 'POST' , label: '/api/users' }}
 
 <Row>
   <Col>
@@ -526,7 +526,7 @@ echo $response;
 ---
 
 
-## Update a User {{ tag: 'PUT' , label: '/api/users/{userId}' }} 
+## Update a User  {{ tag: 'PUT' , label: '/api/users/{userId}' }}
 
 <Row>
   <Col>
@@ -816,7 +816,7 @@ echo $response;
 ---
 
 
-## Delete a User {{ tag: 'DELETE' , label: '/api/users/{userId}' }} 
+## Delete a User  {{ tag: 'DELETE' , label: '/api/users/{userId}' }}
 
 <Row>
   <Col>
@@ -980,7 +980,7 @@ echo $response;
 ---
 
 
-## Resend user invitation {{ tag: 'POST' , label: '/api/users/{userId}/invite' }} 
+## Resend user invitation  {{ tag: 'POST' , label: '/api/users/{userId}/invite' }}
 
 <Row>
   <Col>


### PR DESCRIPTION
This PR extends the openapi spec parser to read `x-cloud-only` and `x-experimental` tags form the api specs and parse them into a badge on the API pages. It then takes the newest main and adds the new pages.
<img width="1124" alt="Screenshot 2025-03-20 at 16 58 35" src="https://github.com/user-attachments/assets/231f766c-f3cf-4c4d-a444-285bcf5d08e2" />
