### PR TITLE
Added relay.env and zdb.env for backup

### DIFF
--- a/src/pages/selfhosted/selfhosted-quickstart.mdx
+++ b/src/pages/selfhosted/selfhosted-quickstart.mdx
@@ -65,7 +65,7 @@ To backup your NetBird installation, you need to copy the configuration files, t
 The configuration files are located in the folder where you ran the installation script. To backup, copy the files to a backup location:
 ```bash
 mkdir backup
-cp docker-compose.yml Caddyfile zitadel.env dashboard.env turnserver.conf management.json backup/
+cp docker-compose.yml Caddyfile zitadel.env dashboard.env turnserver.conf management.json relay.env zdb.env backup/
 ```
 To save the Management service databases, you need to stop the Management service and copy the files from the store directory using a docker compose command as follows:
 ```bash


### PR DESCRIPTION
docker compose can not be spin up if the two configuration file is not being backed up.