### PR TITLE
Update docs to be more clear about installing the NetBird client

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -30,7 +30,7 @@ export const docsNavigation = [
         title: 'GET STARTED',
         links: [
             { title: 'Quickstart Guide', href: '/how-to/getting-started' },
-            {title: 'Install NetBird', href: '/how-to/installation' },
+            {title: 'Install NetBird (Client)', href: '/how-to/installation' },
             { title: 'CLI', href: '/how-to/cli' },
            
            /* { title: 'Update NetBird', href: '/how-to/enforce-periodic-user-authentication' },*/


### PR DESCRIPTION
I've seen several people get very confused about setting up NetBird in terms of self-hosting when this is the first thing they see on the docs. Reminds me of the problem with 'Plex Media Server' versus 'Plex' with a lot of people installing the server on their computer instead of the client software.