### PR TITLE
Moved `Self-hosted vs. Cloud-hosted NetBird` to `Use Cases` in navigation menu

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -30,7 +30,7 @@ export const docsNavigation = [
         title: 'GET STARTED',
         links: [
             { title: 'Quickstart Guide', href: '/how-to/getting-started' },
-            {title: 'Install NetBird (Client)', href: '/how-to/installation' },
+            {title: 'Install NetBird', href: '/how-to/installation' },
             { title: 'CLI', href: '/how-to/cli' },
            
            /* { title: 'Update NetBird', href: '/how-to/enforce-periodic-user-authentication' },*/
@@ -241,6 +241,7 @@ export const docsNavigation = [
          { title: 'Routing peers and Kubernetes', href: '/how-to/routing-peers-and-kubernetes'},
          { title: 'NetBird Client on AWS ECS', href: '/how-to/examples'},
          { title: 'NetBird on Mikrotik Router', href: '/how-to/client-on-mikrotik-router' },
+         { title: 'Self-hosted vs. Cloud-hosted NetBird', href: '/selfhosted/self-hosted-vs-cloud-netbird' },
      ],
  
  },
@@ -254,7 +255,6 @@ export const docsNavigation = [
       { title: 'Supported IdPs', href: '/selfhosted/identity-providers' },
       { title: 'Management geolocation', href: '/selfhosted/geo-support' },
       { title: 'Troubleshooting', href: '/selfhosted/troubleshooting' },
-      { title: 'Self-hosted vs. Cloud-hosted NetBird', href: '/selfhosted/self-hosted-vs-cloud-netbird' },
   ],
   
   


### PR DESCRIPTION
It makes far more sense to have this under `Use Cases`, IMO.

It's the kind of information a user would like to have upfront and not as an afterthought. Furthermore, comparisons between the two options are typically made far sooner in other projects.

May also consider changing the dir that the `.md` file is in, which also change the URL to `/selfhosted/` from to possibly `how-to`, though that's probably beyond the scope of what I can pull off from my cellphone in bed. :- ) Edits of course welcome re that.