### PR TITLE
update slack url and twitter

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -25,6 +25,11 @@ const nextConfig = {
     redirects: async () => {
         return [
             {
+                source: '/slack-url',
+                destination: 'https://join.slack.com/t/netbirdio/shared_invite/zt-36ckpgzva-_V4OFhWhDA8e2v_Fy6zR3w',
+                permanent: false,
+            },
+            {
                 source: '/how-to/networks-concept',
                 destination: '/how-to/networks',
                 permanent: true,

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -239,7 +239,7 @@ function SmallPrint() {
         <SocialLink href="https://github.com/netbirdio/netbird" icon={GitHubIcon}>
           Follow us on GitHub
         </SocialLink>
-        <SocialLink href="https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g" icon={SlackIcon}>
+        <SocialLink href="/slack-url" icon={SlackIcon}>
           Join us on Slack
         </SocialLink>
       </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -73,7 +73,7 @@ export const Header = forwardRef(function Header({ className }, ref) {
             <TopLevelNavItem href="/api">API</TopLevelNavItem>
             <TopLevelNavItem href="https://netbird.io/knowledge-hub/">Learn</TopLevelNavItem>
             <TopLevelNavItem href="https://github.com/netbirdio/netbird">Github</TopLevelNavItem>
-            <TopLevelNavItem href="https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g">Support</TopLevelNavItem>
+            <TopLevelNavItem href="/slack-url">Support</TopLevelNavItem>
           </ul>
         </nav>
         <div className="hidden md:block md:h-5 md:w-px md:bg-zinc-900/10 md:dark:bg-white/15" />

--- a/src/components/NavigationAPI.jsx
+++ b/src/components/NavigationAPI.jsx
@@ -48,7 +48,7 @@ export function NavigationAPI({tableOfContents, className}) {
           <TopLevelNavItem href="/api">API</TopLevelNavItem>
           <TopLevelNavItem href="https://netbird.io/knowledge-hub/">Learn</TopLevelNavItem>
           <TopLevelNavItem href="https://github.com/netbirdio/netbird">Github</TopLevelNavItem>
-          <TopLevelNavItem href="https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g">Support</TopLevelNavItem>
+          <TopLevelNavItem href="/slack-url">Support</TopLevelNavItem>
           {apiNavigation.map((group, groupIndex) => (
               <NavigationStateProvider key={group.title} index={groupIndex}>
                 <NavigationGroup

--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -286,7 +286,7 @@ export const docsNavigation = [
           <TopLevelNavItem href="/api">API</TopLevelNavItem>
           <TopLevelNavItem href="https://netbird.io/knowledge-hub/">Learn</TopLevelNavItem>
           <TopLevelNavItem href="https://github.com/netbirdio/netbird">Github</TopLevelNavItem>
-          <TopLevelNavItem href="https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g">Support</TopLevelNavItem>
+          <TopLevelNavItem href="/slack-url">Support</TopLevelNavItem>
           {docsNavigation.map((group, groupIndex) => (
               <NavigationStateProvider key={group.title} index={groupIndex}>
                   <NavigationGroup

--- a/src/pages/how-to/add-machines-to-your-network.mdx
+++ b/src/pages/how-to/add-machines-to-your-network.mdx
@@ -48,6 +48,6 @@ Here are a few links that might be handy as you venture further into NetBird:
 </p>
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Follow us [on X](https://x.com/netbird)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/add-users-to-your-network.mdx
+++ b/src/pages/how-to/add-users-to-your-network.mdx
@@ -27,7 +27,7 @@ Public domains are the ones of the public email providers like Gmail.
 <Note>
     It might happen (unlikely) that the domain classification system didn't classify your company's domain as private.
     Our system was unsure about your domain and assigned an unclassified or public category to be on the safe side.
-    Just email us at [hello@netbird.io](mailto:hello@netbird.io) or ping us on [Slack](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g) to fix this.
+    Just email us at [hello@netbird.io](mailto:hello@netbird.io) or ping us on [Slack](/slack-url) to fix this.
 </Note>
 
 ## Direct user invites
@@ -104,6 +104,6 @@ Click the `Save` button to save the changes.
 </p>
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Follow us [on X](https://x.com/netbird)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/approve-peers.mdx
+++ b/src/pages/how-to/approve-peers.mdx
@@ -46,5 +46,5 @@ Check the [EDR integrations](/how-to/endpoint-detection-and-response) guide for 
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
 - Follow us [on X](https://x.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/audit-events-logging.mdx
+++ b/src/pages/how-to/audit-events-logging.mdx
@@ -131,6 +131,6 @@ NetBird can stream audit events to your Security Information and Event Managemen
 </p>
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Follow us [on X](https://x.com/netbird)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/configuring-default-routes-for-internet-traffic.mdx
+++ b/src/pages/how-to/configuring-default-routes-for-internet-traffic.mdx
@@ -101,6 +101,6 @@ section for more information.
 </p>
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Follow us [on X](https://x.com/netbird)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/delete-account.mdx
+++ b/src/pages/how-to/delete-account.mdx
@@ -28,5 +28,5 @@ After you delete your account, your session will end, and you will be redirected
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
 - Follow us [on X](https://x.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/enable-post-quantum-cryptography.mdx
+++ b/src/pages/how-to/enable-post-quantum-cryptography.mdx
@@ -65,6 +65,6 @@ netbird up --enable-rosenpass --rosenpass-permissive
 </p>
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Follow us [on X](https://x.com/netbird)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/enforce-periodic-user-authentication.mdx
+++ b/src/pages/how-to/enforce-periodic-user-authentication.mdx
@@ -45,6 +45,6 @@ Peers with `Expiration disabled` will be marked with a corresponding label in th
 </p>
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Follow us [on X](https://x.com/netbird)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/getting-started.mdx
+++ b/src/pages/how-to/getting-started.mdx
@@ -125,5 +125,5 @@ Try creating a [network access policy](/how-to/manage-network-access) to control
 
 - Star us on [GitHub](https://github.com/netbirdio/netbird)
 - Follow us [on X](https://x.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Join our [Slack Channel](/slack-url)
 - NetBird release page on GitHub: [releases](https://github.com/netbirdio/netbird/releases/latest)

--- a/src/pages/how-to/kubernetes-operator.mdx
+++ b/src/pages/how-to/kubernetes-operator.mdx
@@ -344,6 +344,6 @@ With this setup, other peers in your NetBird network can reach these pods using 
 </p>
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Follow us [on X](https://x.com/netbird)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/lazy-connection.mdx
+++ b/src/pages/how-to/lazy-connection.mdx
@@ -80,6 +80,6 @@ Setting disabled:
 </p>
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Follow us [on X](https://x.com/netbird)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/manage-dns-in-your-network.mdx
+++ b/src/pages/how-to/manage-dns-in-your-network.mdx
@@ -158,6 +158,6 @@ resolvectl query peer-a.netbird.cloud
 </p>
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Follow us [on X](https://x.com/netbird)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/manage-posture-checks.mdx
+++ b/src/pages/how-to/manage-posture-checks.mdx
@@ -133,6 +133,6 @@ Following these steps, you can effectively implement and manage NetBird's Postur
 </p>
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Follow us [on X](https://x.com/netbird)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/multi-factor-authentication.mdx
+++ b/src/pages/how-to/multi-factor-authentication.mdx
@@ -59,6 +59,6 @@ This will reset MFA for the user, and they will need to set it up again during t
 </p>
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Follow us [on X](https://x.com/netbird)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/networks.mdx
+++ b/src/pages/how-to/networks.mdx
@@ -114,6 +114,6 @@ You can enable DNS resolution on the routing peer by accessing your account `Set
 </p>
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Follow us [on X](https://x.com/netbird)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/report-bug-issues.mdx
+++ b/src/pages/how-to/report-bug-issues.mdx
@@ -1,9 +1,9 @@
 # Report bugs and issues
 NetBird offers different ways to report bugs and issues. For prompt and effective assistance, please provide detailed information as outlined in our bug/issue [reporting template](#reporting-template).
 
-For cloud users, you can report bugs and issues via email by sending an email to [support@netbird.io](mailto:support@netbird.io), via [Github issues](https://github.com/netbirdio/netbird/issues/new/choose) or by joining our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g).
+For cloud users, you can report bugs and issues via email by sending an email to [support@netbird.io](mailto:support@netbird.io), via [Github issues](https://github.com/netbirdio/netbird/issues/new/choose) or by joining our [Slack Channel](/slack-url).
 
-For on-premise users, you can report bugs and issues via [Github issues](https://github.com/netbirdio/netbird/issues/new/choose) or by joining our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g).
+For on-premise users, you can report bugs and issues via [Github issues](https://github.com/netbirdio/netbird/issues/new/choose) or by joining our [Slack Channel](/slack-url).
 
 ## Reporting Template
 When reporting bugs and issues, please ensure you provide the following information:

--- a/src/pages/how-to/resolve-overlapping-routes.mdx
+++ b/src/pages/how-to/resolve-overlapping-routes.mdx
@@ -88,6 +88,6 @@ This applies not only to the currently available routes but also to any routes t
 </p>
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Follow us [on X](https://x.com/netbird)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/routing-traffic-to-multiple-resources.mdx
+++ b/src/pages/how-to/routing-traffic-to-multiple-resources.mdx
@@ -106,6 +106,6 @@ With the steps above, we created resources that allow different levels of access
 </p>
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Follow us [on X](https://x.com/netbird)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/routing-traffic-to-private-networks.mdx
+++ b/src/pages/how-to/routing-traffic-to-private-networks.mdx
@@ -216,5 +216,5 @@ This way, devices that don't have the agent installed can communicate with your 
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
 - Follow us [on X](https://x.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/how-to/secure-remote-webserver-access.mdx
+++ b/src/pages/how-to/secure-remote-webserver-access.mdx
@@ -166,6 +166,6 @@ This straightforward test confirms your successful implementation of a secure, f
 </p>
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Follow us [on X](https://x.com/netbird)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/ipa/guides/errors.mdx
+++ b/src/pages/ipa/guides/errors.mdx
@@ -26,7 +26,7 @@ Here is a list of the different categories of status codes returned by the NetBi
     A 4xx status code indicates a client error - those are mostly related to missing permissions or invalid parameters inside the request.
   </Property>
   <Property name="5xx">
-    A 5xx status code indicates a server error - in this case please reach out to us via [Slack](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g) or [GitHub](https://github.com/netbirdio/netbird/issues).
+    A 5xx status code indicates a server error - in this case please reach out to us via [Slack](/slack-url) or [GitHub](https://github.com/netbirdio/netbird/issues).
   </Property>
 </Properties>
 

--- a/src/pages/selfhosted/self-hosted-vs-cloud-netbird.mdx
+++ b/src/pages/selfhosted/self-hosted-vs-cloud-netbird.mdx
@@ -64,5 +64,5 @@ your critical network infrastructure.
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
 - Follow us [on X](https://x.com/netbird)
-- Join our [Slack Channel](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g)
+- Join our [Slack Channel](/slack-url)
 - NetBird [latest release](https://github.com/netbirdio/netbird/releases) on GitHub

--- a/src/pages/selfhosted/selfhosted-guide.mdx
+++ b/src/pages/selfhosted/selfhosted-guide.mdx
@@ -241,8 +241,8 @@ To upgrade NetBird to the latest version, you need to review the [release notes]
 
 ## Get in touch
 
-Feel free to ping us on [Slack](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g) if you have any questions
+Feel free to ping us on [Slack](/slack-url) if you have any questions
 
 - NetBird managed version: [https://app.netbird.io](https://app.netbird.io)
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
+- Follow us [on X](https://x.com/netbird)

--- a/src/pages/selfhosted/selfhosted-quickstart.mdx
+++ b/src/pages/selfhosted/selfhosted-quickstart.mdx
@@ -111,8 +111,8 @@ rm -f docker-compose.yml Caddyfile zitadel.env dashboard.env machinekey/zitadel-
 
 ## Get in touch
 
-Feel free to ping us on [Slack](https://join.slack.com/t/netbirdio/shared_invite/zt-31rofwmxc-27akKd0Le0vyRpBcwXkP0g) if you have any questions
+Feel free to ping us on [Slack](/slack-url) if you have any questions
 
 - NetBird managed version: [https://app.netbird.io](https://app.netbird.io)
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
-- Follow us [on Twitter](https://twitter.com/netbird)
+- Follow us [on X](https://x.com/netbird)


### PR DESCRIPTION
use a dedicated URL for Slack, allowing updates in a single place

rename Twitter references to X

fixes  #325