### PR TITLE
Fixed non-functioning `Step 3` hyperlink on `Update selfhosted-guide.mdx`

### DIFF
--- a/src/pages/selfhosted/selfhosted-guide.mdx
+++ b/src/pages/selfhosted/selfhosted-guide.mdx
@@ -163,7 +163,7 @@ Optional:
     The `coturn`-service still needs to be directly accessible under your set-domain as it uses UDP for communication.
 </Note>
 
-Now you can continue with [Step 3](#step-3-configure-identity-provider).
+Now you can continue with [Step 3](#step-3-configure-identity-provider-idp).
 
 ### Configuration for your reverse-proxy
 


### PR DESCRIPTION
I might be wrong in understanding the issue and doing this from my phone, but https://github.com/netbirdio/docs/issues/295 mentioned the broken link.

I couldn't see braces-related issue mentioned by the user, but I did see that the non-functioning `Step 3` link was pointing at `#step-3-configure-identity-provider` instead of `#step-3-configure-identity-provider-idp`.

Could well be wrong—it wouldn't be the first time. :- )