### PR TITLE
Updated `identity-providers.mdx` to correct information regarding Authentik service account passwords

### DIFF
--- a/src/pages/selfhosted/identity-providers.mdx
+++ b/src/pages/selfhosted/identity-providers.mdx
@@ -515,7 +515,11 @@ In this step, we will create service account.
     <img src="/docs-static/img/integrations/identity-providers/self-hosted/authentik-new-service-account.png" alt="high-level-dia" className="imagewrapper-big"/>
 </p>
 
-- Take note of service account `username` and `password`, we will need it later
+- Take note of the NetBird service account `username`, we will need it later.
+- N.B. The `password` defined when creating the NetBird service account is not required.
+Users should instead create an app password for the NetBird service account within `Directory > Tokens and App passwords` in authentik's `Admin interface.
+Be sure to select the NetBird Service account object as the `User` when creating the app password.
+Take note of the app password as we will need it later.
 
 <p>
     <img src="/docs-static/img/integrations/identity-providers/self-hosted/authentik-service-account-details.png" alt="high-level-dia" className="imagewrapper-big"/>


### PR DESCRIPTION
After 11h of troubleshooting yesterday (https://github.com/netbirdio/netbird/issues/2142#issuecomment-2915471588), I found this out for myself.

There's a non-zero chance my solution was wrong, but perhaps someone with more insight can verify this for me. :- )