### PR TITLE
Fixed broken image on `cli.mdx`

### DIFF
--- a/src/pages/how-to/cli.mdx
+++ b/src/pages/how-to/cli.mdx
@@ -397,7 +397,7 @@ netbird up --allow-server-ssh
 ```
 This will allow the the `SSH Access feature` to work when enabled in the dashboard, under Peers > _your_peer_ > SSH Access.
 <p>
-    <img src="/docs-static/img/how-to/enable-ssh-access.png" alt="high-level-dia" className="imagewrapper-big"/>
+    <img src="/docs-static/img/how-to-guides/enable-ssh-access.png" alt="high-level-dia" className="imagewrapper-big"/>
 </p>
 
 ### version


### PR DESCRIPTION
Saw that https://github.com/netbirdio/docs/pull/275 never updated their PR to be relative and sat feeling confused about this in the docs until I realized the image URL was wrong. :- )