### PR TITLE
Troubleshooting improvements

### DIFF
--- a/src/pages/about-netbird/faq.mdx
+++ b/src/pages/about-netbird/faq.mdx
@@ -5,9 +5,12 @@ export const title = 'FAQ'
 ## What firewall ports should I open to use NetBird?
 
 ### Incoming ports
+
 NetBird's agent doesn't require any incoming port to be open; It negotiates the connection with the support of the signal and relay services.
 That said, it helps to open inbound UDP to wireguard port (51820 by default) on one of the peers if they are only getting relayed.
+
 ### Outgoing ports
+
 NetBird usually won't need open ports, but sometimes you or your IT team needs to secure and verify
 all outgoing traffic, and that may affect how NetBird clients connect to the [control layer](/about-netbird/how-netbird-works)
 and negotiate the peer-to-peer connections. 
@@ -23,6 +26,7 @@ and negotiate the peer-to-peer connections.
 </Note>
 
 Below is the list of NetBird hosted endpoints and ports they listen to:
+
 * Management service:
   * **Endpoint**: api.netbird.io
     * **Port**: TCP/443
@@ -53,11 +57,10 @@ Below is the list of NetBird hosted endpoints and ports they listen to:
   * **IPv4**: The list is dynamic and geo-distributed; When looking at the `netbird status -d` output, you can see which relay you are connecting to.
   * It is advised to wildcard `*.relay.netbird.io` when possible, to avoid interrupts.
 
-
-
 ## Why and what are the anonymous usage metrics?
 
 ### Why did we add metrics collection?
+
 As an open-source project and business, making data-driven decisions is essential. By collecting anonymous metrics, we can understand our adoption rate, feature usage, and the types of client operating systems in use. We kindly ask our community users to keep metrics enabled, as this helps us assess the impact of bugs and measure the quality of our software over time.
 
 <Note>
@@ -67,6 +70,7 @@ The collection is strict to our management system.
 If the metric collection infringes any internal regulation or policy, it can be disabled by setting the flag `--disable-anonymous-metrics=true` to the management service startup command. the default interval is 12 hours, but it can be adjusted with the environment variable `NETBIRD_METRICS_INTERVAL_IN_SECONDS`.
 
 ### What are the metrics being collected?
+
 We are collecting the following metrics:
 * Number of accounts
 * Number of users
@@ -82,9 +86,10 @@ We are collecting the following metrics:
 * Service version
 * Metrics generation time
 
-
 ### Metrics UUID
+
 We are using an installation ID for each management service which is generated once and stored in your management store database. It doesn't have any trace of any other private information, and it helps distinguish each deployment.
 
 ### Metrics pusher IP
+
 We are not storing the pusher IP address; it gets discarded once the request is complete.

--- a/src/pages/about-netbird/faq.mdx
+++ b/src/pages/about-netbird/faq.mdx
@@ -6,6 +6,7 @@ export const title = 'FAQ'
 
 ### Incoming ports
 NetBird's agent doesn't require any incoming port to be open; It negotiates the connection with the support of the signal and relay services.
+That said, it helps to open inbound UDP to wireguard port (51820 by default) on one of the peers if they are only getting relayed.
 ### Outgoing ports
 NetBird usually won't need open ports, but sometimes you or your IT team needs to secure and verify
 all outgoing traffic, and that may affect how NetBird clients connect to the [control layer](/about-netbird/how-netbird-works)

--- a/src/pages/how-to/troubleshooting-client.mdx
+++ b/src/pages/how-to/troubleshooting-client.mdx
@@ -279,7 +279,7 @@ netbird service stop
 In case you need to configure environment variables, you need to add them as system variables so they get picked up by
 the agent on the next psexec run:
 
-```shell
+```powershell
 [Environment]::SetEnvironmentVariable("PIONS_LOG_DEBUG", "all", "Machine")
 ````
 

--- a/src/pages/how-to/troubleshooting-client.mdx
+++ b/src/pages/how-to/troubleshooting-client.mdx
@@ -3,6 +3,12 @@
 This document offers practical tips and insights to help you debug various problems, ensuring a seamless user
 experience.
 
+## P2P / Relayed
+
+Each peer will use signal/stun to try to connect directly (P2P) to other peers, and if that is not possible it'll use the relay server.
+
+To help peers get P2P connections, allowing inbound UDP to wireguard port (51820 by default) to one of the peers can help a lot.
+
 ## NetBird agent status
 
 The netbird agent is a daemon service that runs in the background; it provides information about peers connected and


### PR DESCRIPTION
The documentation lacked basic information about opening UDP 51820 to help with P2P connexions, this attempts to address it.