### PR TITLE
Universal Blue - Native

### DIFF
--- a/src/pages/how-to/installation/linux.mdx
+++ b/src/pages/how-to/installation/linux.mdx
@@ -91,6 +91,36 @@ sudo gnome-extensions enable appindicatorsupport@rgcjonas.gmail.com
 ```
 Under X11, you may need to restart GNOME Shell (Alt+F2, r, ⏎) after that. Under Wayland you need to logout and login again.
 
+
+### Universal Blue (Native package)
+
+1. Create the repository file:
+```bash
+sudo tee /etc/yum.repos.d/netbird.repo <<EOF
+[netbird]
+name=netbird
+baseurl=https://pkgs.netbird.io/yum/
+enabled=1
+gpgcheck=0
+gpgkey=https://pkgs.netbird.io/yum/repodata/repomd.xml.key
+repo_gpgcheck=1
+EOF
+```
+
+3. Install the package
+```bash
+ # for CLI only
+ rpm-ostree install netbird
+ # for GUI package
+ rpm-ostree install netbird-ui
+ # Don't forget to reboot to apply
+```
+4. Start the service
+```bash
+systemctl enable --now netbird
+```
+
+
 ### Fedora Universal Blue / SteamOS (DistroBox)
 1. Create a distrobox container
 ```bash


### PR DESCRIPTION
Instructions to Add netbird to universal blue via package layering of the RPM package, allows netbird to run natively rather than via the distrobox container.

Tested on Aurora , Although there's no reason why it shouldn't also work on Bazzite and Bluefin at least.