### PR TITLE
Update Backup Section

### DIFF
--- a/src/pages/selfhosted/selfhosted-guide.mdx
+++ b/src/pages/selfhosted/selfhosted-guide.mdx
@@ -210,7 +210,7 @@ The configuration files are located in the folder where you ran the installation
 ```bash
 cd netbird/infrastructure_files/artifacts/
 mkdir backup
-cp docker-compose.yml turnserver.conf management.json backup/
+cp docker-compose.yml turnserver.conf management.json openid-configuration.json backup/
 ```
 
 To save the Management service databases, you need to stop the Management service and copy the files from the store directory using a docker compose command as follows:


### PR DESCRIPTION
Added the backup for openid-configuration.json

Without backing up this file maintainer would have to generate it again manually, which would be time & effort consuming.