### PR TITLE
Improve API key documentation for helm chart

### DIFF
--- a/src/pages/how-to/kubernetes-operator.mdx
+++ b/src/pages/how-to/kubernetes-operator.mdx
@@ -28,10 +28,10 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 3. Add NetBird API token. You can create a PAT by following the steps [here](/how-to/access-netbird-public-api#creating-a-service-user).
 ```shell
 kubectl create namespace netbird
-kubectl -n netbird create secret generic netbird-mgmt-api-key --from-literal=NB_API_KEY=$(cat ~/nb-pat.secret)
+kubectl -n netbird create secret generic netbird-mgmt-api-key --from-literal=NB_API_KEY=<API KEY>
 ```
 <Note>
-  Replace `~/nb-pat.secret` with your NetBird API key.
+  Replace `<API KEY>` with your NetBird API key.
 </Note>
 
 4. (Recommended) Create a [`values.yaml`](https://github.com/netbirdio/kubernetes-operator/blob/main/examples/ingress/values.yaml) file, check `helm show values netbirdio/kubernetes-operator` for more info.
@@ -44,7 +44,9 @@ ingress:
     enabled: true
 
 netbirdAPI:
-  keyFromSecret: "netbird-mgmt-api-key"
+  keyFromSecret:
+    name: "netbird-mgmt-api-key"
+    key: NB_API_KEY
 ```
 5. Install using helm install:
 ```shell


### PR DESCRIPTION
- fix `netbirdAPI.keyFromSecret` keys to work with current helm chart
- remove `cat` command which refers to a file that isn't created in previous tutorial steps