### PR TITLE
self-hosted Keycloak: add missing NETBIRD_AUTH_DEVICE_AUTH_AUDIENCE?

### DIFF
--- a/src/pages/selfhosted/identity-providers.mdx
+++ b/src/pages/selfhosted/identity-providers.mdx
@@ -432,6 +432,7 @@ NETBIRD_AUTH_SUPPORTED_SCOPES="openid profile email offline_access api"
 NETBIRD_AUTH_AUDIENCE=`netbird-client`
 
 NETBIRD_AUTH_DEVICE_AUTH_CLIENT_ID=`netbird-client`
+NETBIRD_AUTH_DEVICE_AUTH_AUDIENCE=`netbird-client`
 
 NETBIRD_MGMT_IDP="keycloak"
 NETBIRD_IDP_MGMT_CLIENT_ID="netbird-backend"


### PR DESCRIPTION
not 100% sure this is required, but seems off that only Keycloak is missing it