### PR TITLE
introduces a new openapi-gen parser that replaces the old EJS-based generator

### DIFF
--- a/openapi-gen/index.ts
+++ b/openapi-gen/index.ts
@@ -1,0 +1,57 @@
+import path from 'path';
+import YAML from 'yaml';
+import { OpenAPIV3_1 } from 'openapi-types'
+import { Endpoint, extractSpec } from './tsxParser/openapi-extractor';
+import React from 'react';
+import { ApiTemplate } from './templates/ApiTemplate';
+import { renderToMDX } from './tsxParser/renderToMDX';
+import { mkdir, writeFile } from "fs/promises"
+
+(async function main() {
+  const inputUrl = process.argv[2]
+  if (!inputUrl) {
+    console.error('Usage: ts-node index.ts <openapi-url>');
+    process.exit(1);
+  }
+  const outputDir = process.argv[3] || path.join('..', 'src', 'pages', 'ipa', 'resources');
+  const yml = await readYaml(inputUrl)
+  const mdxFile: Record<string, Endpoint[]> = {}
+
+  const { endpoints } = extractSpec(yml)
+  endpoints.forEach(endpoint => {
+    if (!endpoint.tag) {
+      console.error('No tag for this endpoint:', endpoint.path)
+      return
+    }
+
+    if (!mdxFile[endpoint.tag]) {
+      mdxFile[endpoint.tag] = []
+    }
+
+    mdxFile[endpoint.tag].push(endpoint)
+  })
+
+  for (let tag in mdxFile) {
+    const element = React.createElement(ApiTemplate, { tag: tag, endpoints: mdxFile[tag] });
+    const component = renderToMDX(element)
+    const fileName = path.join(outputDir, tag.toLowerCase().replace(" ", "-") + ".mdx")
+    const dir = path.dirname(fileName)
+    await mkdir(dir, { recursive: true })
+    await writeFile(fileName, component)
+  }
+
+})()
+
+
+async function readYaml(url: string) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.statusText}`);
+  const text = await res.text();
+  const parsed = YAML.parse(text) as OpenAPIV3_1.Document;
+  if (parsed.openapi != "3.1.0") {
+    throw new Error('Unsupported OpenAPI version: ' + parsed.openapi);
+  }
+  return parsed;
+}
+
+

--- a/openapi-gen/index.ts
+++ b/openapi-gen/index.ts
@@ -13,35 +13,46 @@ import { mkdir, writeFile } from "fs/promises"
     console.error('Usage: ts-node index.ts <openapi-url>');
     process.exit(1);
   }
-  const outputDir = process.argv[3] || path.join('..', 'src', 'pages', 'ipa', 'resources');
-  const yml = await readYaml(inputUrl)
-  const mdxFile: Record<string, Endpoint[]> = {}
+  const outputDir = process.argv[3] || path.join('src', 'pages', 'ipa', 'resources');
+  try {
+    const yml = await readYaml(inputUrl)
 
-  const { endpoints } = extractSpec(yml)
-  endpoints.forEach(endpoint => {
-    if (!endpoint.tag) {
-      console.error('No tag for this endpoint:', endpoint.path)
-      return
+    const mdxFile: Record<string, Endpoint[]> = {}
+    const customFlags: string[] = []
+    const endpoints = extractSpec(yml)
+
+    endpoints.forEach(endpoint => {
+      if (!endpoint.tag) {
+        console.error('No tag for this endpoint:', endpoint.path)
+        return
+      }
+
+      if (!mdxFile[endpoint.tag]) {
+        mdxFile[endpoint.tag] = []
+      }
+
+      mdxFile[endpoint.tag].push(endpoint)
+      const ymlTag = yml.tags.find(tag => tag.name == endpoint.tag)
+      if (!ymlTag) return;
+      for (let flag in ymlTag) {
+        if (flag.startsWith('x-') && ymlTag[flag]) {
+          customFlags.push(flag)
+        }
+      }
+    })
+
+    for (let tag in mdxFile) {
+      const element = React.createElement(ApiTemplate, { tag: tag, endpoints: mdxFile[tag], customFlags: customFlags[tag] });
+      const component = renderToMDX(element)
+      const fileName = path.join(outputDir, tag.toLowerCase().replace(" ", "-") + ".mdx")
+      const dir = path.dirname(fileName)
+      await mkdir(dir, { recursive: true })
+      await writeFile(fileName, component)
     }
-
-    if (!mdxFile[endpoint.tag]) {
-      mdxFile[endpoint.tag] = []
-    }
-
-    mdxFile[endpoint.tag].push(endpoint)
-  })
-
-  for (let tag in mdxFile) {
-    const element = React.createElement(ApiTemplate, { tag: tag, endpoints: mdxFile[tag] });
-    const component = renderToMDX(element)
-    const fileName = path.join(outputDir, tag.toLowerCase().replace(" ", "-") + ".mdx")
-    const dir = path.dirname(fileName)
-    await mkdir(dir, { recursive: true })
-    await writeFile(fileName, component)
+  } catch (error) {
+    console.error(error);
   }
-
 })()
-
 
 async function readYaml(url: string) {
   const res = await fetch(url);
@@ -53,5 +64,3 @@ async function readYaml(url: string) {
   }
   return parsed;
 }
-
-

--- a/openapi-gen/index.ts
+++ b/openapi-gen/index.ts
@@ -33,10 +33,14 @@ import { mkdir, writeFile } from "fs/promises"
 
       mdxFile[endpoint.tag].push(endpoint)
       const ymlTag = yml.tags.find(tag => tag.name == endpoint.tag)
+
       if (!ymlTag) return;
+      if (!customFlags[endpoint.tag]) {
+        customFlags[endpoint.tag] = []
+      }
       for (let flag in ymlTag) {
-        if (flag.startsWith('x-') && ymlTag[flag]) {
-          customFlags.push(flag)
+        if (flag.startsWith('x-') && ymlTag[flag] && !customFlags[endpoint.tag].includes(flag)) {
+          customFlags[endpoint.tag].push(flag)
         }
       }
     })

--- a/openapi-gen/templates/ApiTemplate.tsx
+++ b/openapi-gen/templates/ApiTemplate.tsx
@@ -1,53 +1,56 @@
 import { Endpoint, Parameter, Request } from "../tsxParser/openapi-extractor"
-import { CodeGroup, Col, Row, Stringify, Property, Properties, Details, Summary } from "../tsxParser/components"
+import { CodeGroup, Col, Row, Stringify, Property, Properties, Details, Summary, Badge } from "../tsxParser/components"
 
 export type ApiTemplateProps = {
   tag: string,
   endpoints: Endpoint[]
+  customFlags?: string[]
 }
 
-export const ApiTemplate = ({ tag, endpoints}: ApiTemplateProps) => {
+export const ApiTemplate = ({ tag, endpoints, customFlags }: ApiTemplateProps) => {
   return (
     <>
       <Stringify str={`export const title = '${tag}'`} />
 
-      {endpoints.map((ap, index) => {
+      {endpoints.map((end, index) => {
+        const flags = customFlags ? [...customFlags, ...end.flags] : end.flags
         return (
-          <div key={`${ap.method}-${ap.path}-${index}`}>
+          <div key={`${end.method}-${end.path}-${index}`}>
             <h2>
-              {ap.summary}
-              {` {{ tag: '${ap.method.toUpperCase()}', label: '${ap.path}' }}`}
+              {end.summary}
+              {flags.length > 0 && flags.map(flag => <Badge key={flag} customFlag={flag} />)}
+              {` {{ tag: '${end.method.toUpperCase()}', label: '${end.path}' }}`}
             </h2>
 
             <Row>
               <Col>
-                {ap.description}
+                {end.description}
 
                 {/* Handle Path Parameters for all methods that might have them */}
-                {ap.parameters && ap.parameters.length > 0 && (
-                  <ParametersApi parameters={ap.parameters} />
+                {end.parameters && end.parameters.length > 0 && (
+                  <ParametersApi parameters={end.parameters} />
                 )}
 
                 {/* Handle Request Body for POST/PUT methods */}
-                {(ap.method === "POST" || ap.method === "PUT") && ap.request && (
-                  <PostBodyApi bodyRequest={ap.request} />
+                {(end.method === "POST" || end.method === "PUT") && end.request && (
+                  <PostBodyApi bodyRequest={end.request} path={end.path} />
                 )}
               </Col>
 
               <Col sticky>
                 <CodeGroup
                   title="Request"
-                  endPoint={ap}
+                  endPoint={end}
                 />
-                {ap.responses["200"]?.schema &&
+                {end.responses["200"]?.schema &&
                   <CodeGroup
                     title="Response"
-                    endPoint={ap}
+                    endPoint={end}
                   />}
-                {ap.responses["201"]?.schema &&
+                {end.responses["201"]?.schema &&
                   <CodeGroup
                     title="Response"
-                    endPoint={ap}
+                    endPoint={end}
                   />}
               </Col>
             </Row>
@@ -60,86 +63,109 @@ export const ApiTemplate = ({ tag, endpoints}: ApiTemplateProps) => {
 }
 
 const ParametersApi = ({ parameters }: { parameters: Parameter[] }) => {
+  const params: Parameter[] = [];
+  const query: Parameter[] = [];
+  for (let p of parameters) {
+    if (p.in === "query") {
+      query.push(p)
+    } else {
+      params.push(p)
+    }
+  }
+
   return (
     <>
-      <h3>Path Parameters</h3>
-      <Properties>
-        {parameters.map((p, index) => {
-          return (
-            <Property
-              key={`param-${p.name}-${index}`}
-              name={p.name}
-              type={p.type}
-              required={p.required}
-            >
-              {p.description}
-            </Property>
-          )
-        })}
-      </Properties>
+      {params.length > 0 && <>
+        <h3>Path Parameters</h3>
+        <Properties>
+          {params.map((p, index) => {
+            return (
+              <Property
+                key={`param-${p.name}-${index}`}
+                name={p.name}
+                type={p.type}
+                required={p.required}
+              >
+                {p.description}
+              </Property>
+            )
+          })}
+        </Properties>
+      </>}
+      {query.length > 0 && <>
+        <h3>Query Parameters</h3>
+        <Properties>
+          {query.map((p, index) => {
+            return (
+              <Property
+                key={`query-${p.name}-${index}`}
+                name={p.name}
+                type={p.type}
+                required={p.required}
+              >
+                {p.description}
+              </Property>
+            )
+          })}
+        </Properties>
+      </>}
     </>
   )
 }
 
-const PostBodyApi = ({ bodyRequest }: { bodyRequest: Request[] }) => {
+const PostBodyApi = ({ bodyRequest, path }: { bodyRequest: Request[], path: string }) => {
   return (
     <>
       <h3>Request-Body Parameters</h3>
-      <Properties>
-        {bodyRequest.map((req, index) => {
-          if (req.type === "object[]" || req.type === "object") {
-            return (
-              <Property
-                key={`body-${req.name}-${index}`}
-                name={req.name}
-                type={req.type}
-                required={req.required}
-                minLen={req.minLen}
-                maxLen={req.maxLen}
-                enumList={req.enumList}
-              >
-                <Details className="custom-details" open>
-                  <Summary>{req.description || "Object list"}</Summary>
-                  <Properties>
-                    <Properties>
-                      {req?.bodyObj?.map((ob, objIndex) => {
-                        return (
-                          <Property
-                            key={`nested-${ob.name}-${objIndex}`}
-                            name={ob.name}
-                            type={ob.type}
-                            required={ob.required}
-                            minLen={ob.minLen}
-                            maxLen={ob.maxLen}
-                            enumList={ob.enumList}
-                          >
-                            {ob.description}
-                          </Property>
-                        )
-                      })}
-                    </Properties>
-                  </Properties>
-                </Details>
-              </Property>
-            )
-          } else {
-            // Handle regular properties (not object arrays)
-            return (
-              <Property
-                key={`body-${req.name}-${index}`}
-                name={req.name}
-                type={req.type}
-                required={req.required}
-                minLen={req.minLen}
-                maxLen={req.maxLen}
-                enumList={req.enumList}
-              >
-                {req.description}
-              </Property>
-            )
-          }
-        })}
-      </Properties>
+      <Properties>{renderProperties(bodyRequest, path)}</Properties>
     </>
   )
 }
+
+
+const renderProperties = (bodyRequest: Request[], path: string, prefix = "body",) => {
+  return bodyRequest.map((req, index) => {
+    const key = `${prefix}-${req.name}-${index}`
+
+    if (req.bodyObj && req.bodyObj.length > 0 && req.type === "object" || req.type === "object[]") {
+      return (
+        <Property
+          key={key}
+          name={req.name}
+          type={req.type}
+          required={req.required}
+          minLen={req.minLength}
+          maxLen={req.maxLength}
+          min={req.minimum}
+          max={req.maximum}
+          enumList={req.enumList}
+        >
+          <Details className="custom-details" open>
+            <Summary>{req.description || "More Information"}</Summary>
+            <Properties>
+              {req.bodyObj && renderProperties(req.bodyObj, path, `nested-${req.name}`)}
+            </Properties>
+          </Details>
+        </Property>
+      )
+    }
+
+    // Primitive type
+    return (
+      <Property
+        key={key}
+        name={req.name}
+        type={req.type}
+        required={req.required}
+        min={req.minimum}
+        max={req.maximum}
+        maxLen={req.maxLength}
+        minLen={req.minLength}
+        enumList={req.enumList}
+      >
+        {req.description}
+      </Property>
+    )
+  })
+}
+

--- a/openapi-gen/templates/ApiTemplate.tsx
+++ b/openapi-gen/templates/ApiTemplate.tsx
@@ -13,7 +13,9 @@ export const ApiTemplate = ({ tag, endpoints, customFlags }: ApiTemplateProps) =
       <Stringify str={`export const title = '${tag}'`} />
 
       {endpoints.map((end, index) => {
-        const flags = customFlags ? [...customFlags, ...end.flags] : end.flags
+        const flags = customFlags
+          ? [...new Set([...customFlags, ...end.flags])]
+          : [...new Set(end.flags)];
         return (
           <div key={`${end.method}-${end.path}-${index}`}>
             <h2>

--- a/openapi-gen/templates/ApiTemplate.tsx
+++ b/openapi-gen/templates/ApiTemplate.tsx
@@ -1,0 +1,145 @@
+import { Endpoint, Parameter, Request } from "../tsxParser/openapi-extractor"
+import { CodeGroup, Col, Row, Stringify, Property, Properties, Details, Summary } from "../tsxParser/components"
+
+export type ApiTemplateProps = {
+  tag: string,
+  endpoints: Endpoint[]
+}
+
+export const ApiTemplate = ({ tag, endpoints}: ApiTemplateProps) => {
+  return (
+    <>
+      <Stringify str={`export const title = '${tag}'`} />
+
+      {endpoints.map((ap, index) => {
+        return (
+          <div key={`${ap.method}-${ap.path}-${index}`}>
+            <h2>
+              {ap.summary}
+              {` {{ tag: '${ap.method.toUpperCase()}', label: '${ap.path}' }}`}
+            </h2>
+
+            <Row>
+              <Col>
+                {ap.description}
+
+                {/* Handle Path Parameters for all methods that might have them */}
+                {ap.parameters && ap.parameters.length > 0 && (
+                  <ParametersApi parameters={ap.parameters} />
+                )}
+
+                {/* Handle Request Body for POST/PUT methods */}
+                {(ap.method === "POST" || ap.method === "PUT") && ap.request && (
+                  <PostBodyApi bodyRequest={ap.request} />
+                )}
+              </Col>
+
+              <Col sticky>
+                <CodeGroup
+                  title="Request"
+                  endPoint={ap}
+                />
+                {ap.responses["200"]?.schema &&
+                  <CodeGroup
+                    title="Response"
+                    endPoint={ap}
+                  />}
+                {ap.responses["201"]?.schema &&
+                  <CodeGroup
+                    title="Response"
+                    endPoint={ap}
+                  />}
+              </Col>
+            </Row>
+            {"\n---"}
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+const ParametersApi = ({ parameters }: { parameters: Parameter[] }) => {
+  return (
+    <>
+      <h3>Path Parameters</h3>
+      <Properties>
+        {parameters.map((p, index) => {
+          return (
+            <Property
+              key={`param-${p.name}-${index}`}
+              name={p.name}
+              type={p.type}
+              required={p.required}
+            >
+              {p.description}
+            </Property>
+          )
+        })}
+      </Properties>
+    </>
+  )
+}
+
+const PostBodyApi = ({ bodyRequest }: { bodyRequest: Request[] }) => {
+  return (
+    <>
+      <h3>Request-Body Parameters</h3>
+      <Properties>
+        {bodyRequest.map((req, index) => {
+          if (req.type === "object[]" || req.type === "object") {
+            return (
+              <Property
+                key={`body-${req.name}-${index}`}
+                name={req.name}
+                type={req.type}
+                required={req.required}
+                minLen={req.minLen}
+                maxLen={req.maxLen}
+                enumList={req.enumList}
+              >
+                <Details className="custom-details" open>
+                  <Summary>{req.description || "Object list"}</Summary>
+                  <Properties>
+                    <Properties>
+                      {req?.bodyObj?.map((ob, objIndex) => {
+                        return (
+                          <Property
+                            key={`nested-${ob.name}-${objIndex}`}
+                            name={ob.name}
+                            type={ob.type}
+                            required={ob.required}
+                            minLen={ob.minLen}
+                            maxLen={ob.maxLen}
+                            enumList={ob.enumList}
+                          >
+                            {ob.description}
+                          </Property>
+                        )
+                      })}
+                    </Properties>
+                  </Properties>
+                </Details>
+              </Property>
+            )
+          } else {
+            // Handle regular properties (not object arrays)
+            return (
+              <Property
+                key={`body-${req.name}-${index}`}
+                name={req.name}
+                type={req.type}
+                required={req.required}
+                minLen={req.minLen}
+                maxLen={req.maxLen}
+                enumList={req.enumList}
+              >
+                {req.description}
+              </Property>
+            )
+          }
+        })}
+      </Properties>
+    </>
+  )
+}

--- a/openapi-gen/tsconfig.json
+++ b/openapi-gen/tsconfig.json
@@ -1,0 +1,27 @@
+// generator files need their own tsconfig.json because they don't like "module": "esnext" setting that nextjs requires in the main tsconfig
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noImplicitAny": false,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/openapi-gen/tsconfig.json
+++ b/openapi-gen/tsconfig.json
@@ -1,4 +1,3 @@
-// generator files need their own tsconfig.json because they don't like "module": "esnext" setting that nextjs requires in the main tsconfig
 {
   "compilerOptions": {
     "target": "ES2020",

--- a/openapi-gen/tsxParser/api/requests.ts
+++ b/openapi-gen/tsxParser/api/requests.ts
@@ -421,7 +421,7 @@ func main() {
   url := "https://api.netbird.io${url}"
   method := "POST"
   
-  payload := strings.NewReader(\`${body}\`)
+  payload := strings.NewReader('${body}')
   client := &http.Client{}
   req, err := http.NewRequest(method, url, payload)
 
@@ -476,7 +476,7 @@ puts response.read_body
 OkHttpClient client = new OkHttpClient().newBuilder()
   .build();
 MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, "${body.replace(/"/g, '\\"')}");
+RequestBody body = RequestBody.create(mediaType, '${body}';
 Request request = new Request.Builder()
   .url("https://api.netbird.io${url}")
   .method("POST", body)  

--- a/openapi-gen/tsxParser/api/requests.ts
+++ b/openapi-gen/tsxParser/api/requests.ts
@@ -36,64 +36,639 @@ export const getRequestBody = (endPoint: Endpoint) => {
   return JSON.stringify(body, null, 2);
 };
 
-const deleteRequestCode = (url: string) => {
-  const langCode = []
-  langCode.push(`\`\`\`bash {{ title: 'cURL' }}
+
+export const deleteRequestCode = (url: string) => {
+  const snippets: string[] = []
+
+ // ---------------- cURL ----------------
+  snippets.push(`\`\`\`bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io${url} \\
--H 'Authorization: Token <TOKEN>' \\
+-H 'Authorization: Token <TOKEN>'
+\`\`\``)
+
+  // ---------------- JavaScript (Axios) ----------------
+  snippets.push(`\`\`\`js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io${url}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+\`\`\``)
+
+  // ---------------- Python ----------------
+  snippets.push(`\`\`\`python
+import requests
+
+url = "https://api.netbird.io${url}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+\`\`\``)
+
+  // ---------------- Go ----------------
+  snippets.push(`\`\`\`go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io${url}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+\`\`\``)
+
+ // ---------------- Ruby ----------------
+  snippets.push(`\`\`\`ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io${url}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+\`\`\``)
+
+ // ---------------- Java ----------------
+  snippets.push(`\`\`\`java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io${url}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+\`\`\``)
+
+ // ---------------- PHP ----------------
+  snippets.push(`\`\`\`php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io${url}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
+\`\`\``)
+
+  return snippets
+}
+
+export const putRequestCode = (url: string, body: string) => {
+  const langCode: string[] = []
+
+  // ---------------- cURL ----------------
+  const curlLines: string[] = [
+    `curl -X PUT https://api.netbird.io${url} \\`,
+    `-H 'Accept: application/json' \\`,
+    `-H 'Content-Type: application/json' \\`,
+    `-H 'Authorization: Token <TOKEN>' \\`,
+    `--data-raw '${body}'`
+  ]
+  langCode.push(`\`\`\`bash {{ title: 'cURL' }}\n${curlLines.join("\n")}\n\`\`\``)
+
+  // ---------------- JavaScript (Axios) ----------------
+  langCode.push(`\`\`\`js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify(${body});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io${url}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+\`\`\``)
+
+  // ---------------- Python ----------------
+  langCode.push(`\`\`\`python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io${url}"
+payload = json.dumps(${body})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+\`\`\``)
+
+  // ---------------- Go ----------------
+  langCode.push(`\`\`\`go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io${url}"
+  method := "PUT"
+  
+  payload := strings.NewReader(${body})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+\`\`\``)
+
+  // ---------------- Ruby ----------------
+  langCode.push(`\`\`\`ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io${url}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump(${body})
+response = https.request(request)
+puts response.read_body
+\`\`\``)
+
+  // ---------------- Java ----------------
+  langCode.push(`\`\`\`java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '${body}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io${url}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+\`\`\``)
+
+  // ---------------- PHP ----------------
+  langCode.push(`\`\`\`php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io${url}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '${body}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 \`\`\``)
 
   return langCode
 }
 
-const putRequestCode = (url: string, body: string | null) => {
-  const langCode = []
-  const lines: string[] = [
-    `curl -X PUT https://api.netbird.io${url} \\`,
-    `-H 'Authorization: Token <TOKEN>' \\`,
-  ]
+const postRequestCode = (url: string, body: string) => {
+  const langCode: string[] = []
 
-  if (body && body !== "{}") {
-    lines.push(`-H 'Accept: application/json' \\`)
-    lines.push(`-H 'Content-Type: application/json' \\`)
-    lines.push(`--data-raw '${body}'`)
-  }
-
-  langCode.push(`\`\`\`bash {{ title: 'cURL' }}\n${lines.join("\n")}\n\`\`\``)
-  return langCode
-}
-
-
-
-const postRequestCode = (url: string, body: string | null) => {
-  const langCode = []
-  const lines: string[] = [
+  // ---------------- cURL ----------------
+  const curlLines: string[] = [
     `curl -X POST https://api.netbird.io${url} \\`,
+    `-H 'Accept: application/json' \\`,
+    `-H 'Content-Type: application/json' \\`,
     `-H 'Authorization: Token <TOKEN>' \\`,
+    `--data-raw '${body}'`
   ]
+  langCode.push(`\`\`\`bash {{ title: 'cURL' }}\n${curlLines.join("\n")}\n\`\`\``)
 
-  if (body && body !== "{}") {
-    lines.push(`-H 'Accept: application/json' \\`)
-    lines.push(`-H 'Content-Type: application/json' \\`)
-    lines.push(`--data-raw '${body}'`)
+  // ---------------- JavaScript (Axios) ----------------
+  langCode.push(`\`\`\`js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify(${body});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io${url}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+\`\`\``)
+
+  // ---------------- Python ----------------
+  langCode.push(`\`\`\`python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io${url}"
+payload = json.dumps(${body})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+\`\`\``)
+
+  // ---------------- Go ----------------
+  langCode.push(`\`\`\`go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io${url}"
+  method := "POST"
+  
+  payload := strings.NewReader(\`${body}\`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
   }
+  defer res.Body.Close()
 
-  langCode.push(`\`\`\`bash {{ title: 'cURL' }}\n${lines.join("\n")}\n\`\`\``)
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+\`\`\``)
+
+  // ---------------- Ruby ----------------
+  langCode.push(`\`\`\`ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io${url}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump(${body})
+response = https.request(request)
+puts response.read_body
+\`\`\``)
+
+  // ---------------- Java ----------------
+  langCode.push(`\`\`\`java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "${body.replace(/"/g, '\\"')}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io${url}")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+\`\`\``)
+
+  // ---------------- PHP ----------------
+  langCode.push(`\`\`\`php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io${url}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '${body}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+\`\`\``)
 
   return langCode
 }
-
-
-
 
 const getRequestCode = (label: string) => {
-  const langCode = []
+  const langCode: string[] = []
+
+  // ---------------- cURL ----------------
   langCode.push(`\`\`\`bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io${label} \\
 -H 'Accept: application/json' \\
 -H 'Authorization: Token <TOKEN>' 
 \`\`\``)
 
-  return langCode
+  // ---------------- JavaScript (Axios) ----------------
+  langCode.push(`\`\`\`js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io${label}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+\`\`\``)
+
+  // ---------------- Python ----------------
+  langCode.push(`\`\`\`python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io${label}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
 }
 
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+\`\`\``)
+
+  // ---------------- Go ----------------
+  langCode.push(`\`\`\`go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io${label}"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+\`\`\``)
+
+  // ---------------- Ruby ----------------
+  langCode.push(`\`\`\`ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io${label}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+\`\`\``)
+
+  // ---------------- Java ----------------
+  langCode.push(`\`\`\`java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io${label}")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+\`\`\``)
+
+  // ---------------- PHP ----------------
+  langCode.push(`\`\`\`php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io${label}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+\`\`\``)
+
+  return langCode
+}

--- a/openapi-gen/tsxParser/api/requests.ts
+++ b/openapi-gen/tsxParser/api/requests.ts
@@ -2,26 +2,39 @@ import { Endpoint } from "../../tsxParser/openapi-extractor"
 
 
 export const requestCode = (endPoint: Endpoint) => {
-  const body = {};
-  endPoint?.request?.map(req => {
-    if (req.example !== undefined) {
-      body[req.name] = req.example
-    }
-  })
-
-  const bodyJson = JSON.stringify(body, null, 2)
-
+  const body = getRequestBody(endPoint)
   switch (endPoint.method) {
     case 'GET':
       return getRequestCode(endPoint.path)
     case "POST":
-      return postRequestCode(endPoint.path, bodyJson)
+      return postRequestCode(endPoint.path, body)
     case "PUT":
-      return putRequestCode(endPoint.path, bodyJson)
+      return putRequestCode(endPoint.path, body)
     case "DELETE":
       return deleteRequestCode(endPoint.path)
   }
 }
+
+export const getRequestBody = (endPoint: Endpoint) => {
+  const body: Record<string, any> = {};
+
+  if (!endPoint?.request) return "{}";
+
+  for (const req of endPoint.request) {
+    if (req.isOneOf && req.bodyObj?.[0]?.bodyObj) {
+      body[req.name] = Object.fromEntries(
+        req.bodyObj[0].bodyObj.map(({ name, example }) => [name, example])
+      );
+      continue;
+    }
+
+    if (req.example !== undefined) {
+      body[req.name] = req.example;
+    }
+  }
+
+  return JSON.stringify(body, null, 2);
+};
 
 const deleteRequestCode = (url: string) => {
   const langCode = []

--- a/openapi-gen/tsxParser/api/requests.ts
+++ b/openapi-gen/tsxParser/api/requests.ts
@@ -1,0 +1,65 @@
+export const requestCode = (method: string, url: string, body: string) => {
+  switch (method) {
+    case 'GET':
+      return getRequestCode(url)
+    case "POST":
+      return postRequestCode(url, body)
+    case "PUT":
+    return putRequestCode(url, body)
+    case "DELETE":
+    return deleteRequestCode(url)
+  }
+}
+
+const deleteRequestCode = (url:string) => {
+  const langCode = []
+  langCode.push(`\`\`\`bash {{ title: 'cURL' }}
+curl -X DELETE https://api.netbird.io${url} \\
+-H 'Authorization: Token <TOKEN>' \\
+\`\`\``)
+
+  return langCode
+}
+
+const putRequestCode = (url:string, body:string) => {
+  const langCode = []
+  langCode.push(`\`\`\`bash {{ title: 'cURL' }}
+curl -X PUT https://api.netbird.io${url} \\
+-H 'Accept: application/json' \\
+-H 'Content-Type: application/json' \\
+-H 'Authorization: Token <TOKEN>' \\
+--data-raw '${body}'
+\`\`\``)
+
+  return langCode
+}
+
+
+
+const postRequestCode = (url: string, body: string) => {
+  const langCode = []
+  langCode.push(`\`\`\`bash {{ title: 'cURL' }}
+curl -X POST https://api.netbird.io${url} \\
+-H 'Accept: application/json' \\
+-H 'Content-Type: application/json' \\
+-H 'Authorization: Token <TOKEN>' \\
+--data-raw '${body}'
+\`\`\``)
+
+  return langCode
+}
+
+
+
+
+const getRequestCode = (label: string) => {
+  const langCode = []
+  langCode.push(`\`\`\`bash {{ title: 'cURL' }}
+curl -X GET https://api.netbird.io${label} \\
+-H 'Accept: application/json' \\
+-H 'Authorization: Token <TOKEN>' 
+\`\`\``)
+
+  return langCode
+}
+

--- a/openapi-gen/tsxParser/api/requests.ts
+++ b/openapi-gen/tsxParser/api/requests.ts
@@ -1,17 +1,29 @@
-export const requestCode = (method: string, url: string, body: string) => {
-  switch (method) {
+import { Endpoint } from "../../tsxParser/openapi-extractor"
+
+
+export const requestCode = (endPoint: Endpoint) => {
+  const body = {};
+  endPoint?.request?.map(req => {
+    if (req.example !== undefined) {
+      body[req.name] = req.example
+    }
+  })
+
+  const bodyJson = JSON.stringify(body, null, 2)
+
+  switch (endPoint.method) {
     case 'GET':
-      return getRequestCode(url)
+      return getRequestCode(endPoint.path)
     case "POST":
-      return postRequestCode(url, body)
+      return postRequestCode(endPoint.path, bodyJson)
     case "PUT":
-    return putRequestCode(url, body)
+      return putRequestCode(endPoint.path, bodyJson)
     case "DELETE":
-    return deleteRequestCode(url)
+      return deleteRequestCode(endPoint.path)
   }
 }
 
-const deleteRequestCode = (url:string) => {
+const deleteRequestCode = (url: string) => {
   const langCode = []
   langCode.push(`\`\`\`bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io${url} \\
@@ -21,30 +33,39 @@ curl -X DELETE https://api.netbird.io${url} \\
   return langCode
 }
 
-const putRequestCode = (url:string, body:string) => {
+const putRequestCode = (url: string, body: string | null) => {
   const langCode = []
-  langCode.push(`\`\`\`bash {{ title: 'cURL' }}
-curl -X PUT https://api.netbird.io${url} \\
--H 'Accept: application/json' \\
--H 'Content-Type: application/json' \\
--H 'Authorization: Token <TOKEN>' \\
---data-raw '${body}'
-\`\`\``)
+  const lines: string[] = [
+    `curl -X PUT https://api.netbird.io${url} \\`,
+    `-H 'Authorization: Token <TOKEN>' \\`,
+  ]
 
+  if (body && body !== "{}") {
+    lines.push(`-H 'Accept: application/json' \\`)
+    lines.push(`-H 'Content-Type: application/json' \\`)
+    lines.push(`--data-raw '${body}'`)
+  }
+
+  langCode.push(`\`\`\`bash {{ title: 'cURL' }}\n${lines.join("\n")}\n\`\`\``)
   return langCode
 }
 
 
 
-const postRequestCode = (url: string, body: string) => {
+const postRequestCode = (url: string, body: string | null) => {
   const langCode = []
-  langCode.push(`\`\`\`bash {{ title: 'cURL' }}
-curl -X POST https://api.netbird.io${url} \\
--H 'Accept: application/json' \\
--H 'Content-Type: application/json' \\
--H 'Authorization: Token <TOKEN>' \\
---data-raw '${body}'
-\`\`\``)
+  const lines: string[] = [
+    `curl -X POST https://api.netbird.io${url} \\`,
+    `-H 'Authorization: Token <TOKEN>' \\`,
+  ]
+
+  if (body && body !== "{}") {
+    lines.push(`-H 'Accept: application/json' \\`)
+    lines.push(`-H 'Content-Type: application/json' \\`)
+    lines.push(`--data-raw '${body}'`)
+  }
+
+  langCode.push(`\`\`\`bash {{ title: 'cURL' }}\n${lines.join("\n")}\n\`\`\``)
 
   return langCode
 }

--- a/openapi-gen/tsxParser/api/responses.ts
+++ b/openapi-gen/tsxParser/api/responses.ts
@@ -1,0 +1,13 @@
+
+export const responseCode = (schema: string, example: string) => {
+  const langCode = []
+  langCode.push(`\`\`\`json {{ title: 'Example' }}
+${example}
+\`\`\``)
+
+  langCode.push(`\`\`\`json {{ title: 'Schema' }}
+${schema}
+\`\`\``)
+
+  return langCode
+} 

--- a/openapi-gen/tsxParser/components/index.tsx
+++ b/openapi-gen/tsxParser/components/index.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { requestCode } from "../api/requests";
+import { responseCode } from "../api/responses";
+import { Endpoint } from "../openapi-extractor";
+
+export const Stringify = ({ str }: { str: string }) => <>{str}</>
+
+export const Row = ({ children }) => <>
+  {"\n<"}Row{">\n"}
+  {children}
+  {"\n</"}Row{">"}
+</>
+
+export const Details = ({ children, className, open }: { children: React.ReactNode, className: string, open?: boolean }) => <>
+  {"\n<"}details{className ? ` class="${className}" ` : ""}{open ? "open " : ""}{">\n"}
+  {children}
+  {"\n</"}details{">"}
+</>
+
+export const Summary = ({ children }: { children: React.ReactNode }) => <>
+  {"\n<"}summary{">"}
+  {children}
+  {"</"}summary{">"}
+
+</>
+
+
+
+export const Col = ({ children, sticky }: { children: React.ReactNode, sticky?: boolean }) => <>
+  {"\n<"}Col{sticky ? ' sticky' : ""}{">\n"}
+  {children}
+  {"\n</"}Col{">\n"}
+</>
+
+export const Properties = ({ children }) => <>
+  {"\n<"}Properties{">\n"}
+  {children}
+  {"\n</"}Properties{">\n"}
+</>
+
+type PropertyProps = {
+  name?: string,
+  type?: string,
+  required?: boolean,
+  minLen?: number,
+  maxLen?: number,
+  enumList?: string[]
+  children: React.ReactNode,
+}
+
+export const Property = ({ name, type, required, minLen, maxLen, enumList, children }: PropertyProps) => {
+  const childNodes = React.Children.toArray(children).map((child) =>
+    typeof child === "string" ? child.trim() : ""
+  );
+  let header = "<Property "
+  if (name) header += `name="${name}"`
+  if (type) header += ` type="${type}"`
+  if (required) header += ` required={${required}}`
+  if (minLen) header += ` minLen={${minLen}}`
+  if (maxLen) header += ` maxLen={${maxLen}}`
+  if (enumList && enumList.length === 0) header += `enumList={[${enumList.join(",")}]}`
+
+  header += " >\n"
+  const footer = `\n</Property>\n`;
+
+  // join each child code fence with newlines
+  const content = childNodes.length === 0 ? childNodes.join("\n\n") : children
+
+  return (
+    <>
+      {header}
+      {content}
+      {footer}
+    </>
+  );
+}
+
+type CodeGroupProps = {
+  title: string;
+  endPoint: Endpoint
+};
+
+export const CodeGroup = ({ title, endPoint }: CodeGroupProps) => {
+  const tag = endPoint.method.toUpperCase()
+  const label = endPoint.path
+  const obj = endPoint.responses["200"] ?? endPoint.responses["201"]
+  const exampleJson = obj?.example ? JSON.stringify(obj.example, null, 2) : ""
+  const schemaJson = obj?.schema ? JSON.stringify(obj.schema, null, 2) : ""
+
+  let langCode = []
+  if (title === "Request") langCode = requestCode(tag, label, exampleJson)
+  if (title === "Response") langCode = responseCode(schemaJson, schemaJson)
+  let header = "<CodeGroup "
+  if (title) header += `title="${title}"`
+  if (tag) header += ` tag="${tag}"`
+  if (label) header += ` label="${label}"`
+
+  header += " >\n"
+  const footer = `\n</CodeGroup>\n`;
+
+  // join each child code fence with newlines
+  const content = langCode.join("\n\n");
+
+  return (
+    <>
+      {header}
+      {content}
+      {footer}
+    </>
+  );
+}
+

--- a/openapi-gen/tsxParser/components/index.tsx
+++ b/openapi-gen/tsxParser/components/index.tsx
@@ -6,34 +6,47 @@ import { Endpoint } from "../openapi-extractor";
 export const Stringify = ({ str }: { str: string }) => <>{str}</>
 
 export const Row = ({ children }) => <>
-  {"\n<"}Row{">\n"}
+  {"\n<Row>\n"}
   {children}
-  {"\n</"}Row{">"}
+  {"\n</Row>\n"}
 </>
 
-export const Details = ({ children, className, open }: { children: React.ReactNode, className: string, open?: boolean }) => <>
-  {"\n<"}details{className ? ` class="${className}" ` : ""}{open ? "open " : ""}{">\n"}
-  {children}
-  {"\n</"}details{">"}
-</>
+export const Details = ({ children, className, open }: { children: React.ReactNode, className: string, open?: boolean }) => {
+  let header = ` <details`
+  if (className) header += ` class="${className}"`
+  if (open != undefined) header += ` open`
+  header += `>\n`
+  const footer = "\n</details>\n"
+
+  return <>
+    {header}
+    {children}
+    {footer}
+  </>
+}
 
 export const Summary = ({ children }: { children: React.ReactNode }) => <>
-  {"\n<"}summary{">"}
+  {"\n<summary>"}
   {children}
-  {"</"}summary{">"}
-
+  {"</summary>"}
 </>
 
-export const Col = ({ children, sticky }: { children: React.ReactNode, sticky?: boolean }) => <>
-  {"\n<"}Col{sticky ? ' sticky' : ""}{">\n"}
-  {children}
-  {"\n</"}Col{">\n"}
-</>
+export const Col = ({ children, sticky }: { children: React.ReactNode, sticky?: boolean }) => {
+  let header = " <Col"
+  if (sticky != undefined) header += ` sticky`
+  header += `>\n`
+  const footer = "\n</Col>\n"
+  return <>
+    {header}
+    {children}
+    {footer}
+  </>
+}
 
 export const Properties = ({ children }) => <>
-  {"\n<"}Properties{">\n"}
+  {"\n<Properties>\n"}
   {children}
-  {"\n</"}Properties{">\n"}
+  {"\n</Properties>\n"}
 </>
 
 export const Badge = ({ customFlag }: { customFlag: string }) => {
@@ -50,7 +63,6 @@ export const Badge = ({ customFlag }: { customFlag: string }) => {
     component += ` hoverText="This feature is experimental. The endpoint will likely change and we do not guarantee backwards compatibility."`
   }
 
-
   component += " />"
 
   return <>
@@ -66,7 +78,6 @@ type PropertyProps = {
   minLen?: number,
   maxLen?: number
   enumList?: string[]
-
   children: React.ReactNode,
 }
 

--- a/openapi-gen/tsxParser/components/index.tsx
+++ b/openapi-gen/tsxParser/components/index.tsx
@@ -24,8 +24,6 @@ export const Summary = ({ children }: { children: React.ReactNode }) => <>
 
 </>
 
-
-
 export const Col = ({ children, sticky }: { children: React.ReactNode, sticky?: boolean }) => <>
   {"\n<"}Col{sticky ? ' sticky' : ""}{">\n"}
   {children}
@@ -38,17 +36,41 @@ export const Properties = ({ children }) => <>
   {"\n</"}Properties{">\n"}
 </>
 
+export const Badge = ({ customFlag }: { customFlag: string }) => {
+  let component = "  <Badge "
+  if (customFlag === "x-cloud-only") {
+    component += ` status="cloud-only"`
+    component += ` text="cloud-only"`
+    component += ` hoverText="This feature is only available in the cloud version of NetBird."`
+  }
+
+  if (customFlag === "x-experimental") {
+    component += ` status="experimental"`
+    component += ` text="experimental"`
+    component += ` hoverText="This feature is experimental. The endpoint will likely change and we do not guarantee backwards compatibility."`
+  }
+
+
+  component += " />"
+
+  return <>
+    {component}
+  </>
+}
 type PropertyProps = {
   name?: string,
   type?: string,
   required?: boolean,
+  min?: number,
+  max?: number,
   minLen?: number,
-  maxLen?: number,
+  maxLen?: number
   enumList?: string[]
+
   children: React.ReactNode,
 }
 
-export const Property = ({ name, type, required, minLen, maxLen, enumList, children }: PropertyProps) => {
+export const Property = ({ name, type, required, min, max, minLen, maxLen, enumList, children }: PropertyProps) => {
   const childNodes = React.Children.toArray(children).map((child) =>
     typeof child === "string" ? child.trim() : ""
   );
@@ -56,8 +78,10 @@ export const Property = ({ name, type, required, minLen, maxLen, enumList, child
   if (name) header += `name="${name}"`
   if (type) header += ` type="${type}"`
   if (required) header += ` required={${required}}`
-  if (minLen) header += ` minLen={${minLen}}`
-  if (maxLen) header += ` maxLen={${maxLen}}`
+  if (min != undefined) header += ` min={${min}}`
+  if (max != undefined) header += ` max={${max}}`
+  if (minLen != undefined) header += ` minLen={${minLen}}`
+  if (maxLen != undefined) header += ` maxLen={${maxLen}}`
   if (enumList && enumList.length === 0) header += `enumList={[${enumList.join(",")}]}`
 
   header += " >\n"
@@ -88,12 +112,12 @@ export const CodeGroup = ({ title, endPoint }: CodeGroupProps) => {
   const schemaJson = obj?.schema ? JSON.stringify(obj.schema, null, 2) : ""
 
   let langCode = []
-  if (title === "Request") langCode = requestCode(tag, label, exampleJson)
-  if (title === "Response") langCode = responseCode(schemaJson, schemaJson)
+  if (title === "Request") langCode = requestCode(endPoint)
+  if (title === "Response") langCode = responseCode(schemaJson, exampleJson)
   let header = "<CodeGroup "
   if (title) header += `title="${title}"`
-  if (tag) header += ` tag="${tag}"`
-  if (label) header += ` label="${label}"`
+  if (tag && title === "Request") header += ` tag="${tag}"`
+  if (label && title === "Request") header += ` label="${label}"`
 
   header += " >\n"
   const footer = `\n</CodeGroup>\n`;

--- a/openapi-gen/tsxParser/openapi-extractor.ts
+++ b/openapi-gen/tsxParser/openapi-extractor.ts
@@ -1,0 +1,740 @@
+import { OpenAPIV3_1 } from 'openapi-types'
+
+export type Extracted = {
+  schema: any | null
+  example: any | null
+}
+
+export type Parameter = {
+  name: string
+  required?: boolean
+  type?: string
+  description?: string
+  in?: string
+}
+
+export type Request = {
+  name: string
+  type: string
+  required: boolean
+  description?: string
+  minLen?: number
+  maxLen?: number
+  minimum?: number
+  maximum?: number
+  enumList?: any[]
+  bodyObj?: Request[]
+}
+
+export type Endpoint = {
+  path: string
+  method: string
+  summary?: string
+  description?: string
+  parameters?: Parameter[]
+  responses: Record<string, Extracted | null>
+  request?: Request[] | null
+  tag: string
+}
+
+
+/**
+ * Resolve a local JSON Pointer reference (e.g. "#/components/schemas/Foo")
+ */
+function resolveRef(ref: string | undefined | null, doc: OpenAPIV3_1.Document): any | null {
+  if (!ref || typeof ref !== 'string') return null
+  if (!ref.startsWith('#/')) return null
+  const parts = ref.slice(2).split('/')
+  let node: any = doc
+  for (const p of parts) {
+    if (node == null) return null
+    const key = p.replace(/~1/g, '/').replace(/~0/g, '~')
+    node = node[key]
+  }
+  return node
+}
+
+/**
+ * Merge helper for allOf: merges properties, required, other top-level keys.
+ * Later entries override earlier ones for overlapping property names.
+ */
+function mergeAllOfParts(parts: any[], doc: OpenAPIV3_1.Document, seenRefs: Set<string>) {
+  const out: any = {}
+  out.properties = {}
+  out.required = []
+  for (const part of parts) {
+    const resolved = dereferenceNode(part, doc, new Set(seenRefs))
+    // merge properties
+    if (resolved.properties && typeof resolved.properties === 'object') {
+      for (const [k, v] of Object.entries(resolved.properties)) {
+        out.properties[k] = v
+      }
+    }
+    // merge required
+    if (Array.isArray(resolved.required)) {
+      for (const r of resolved.required) {
+        if (!out.required.includes(r)) out.required.push(r)
+      }
+    }
+    // keep example if present and not set yet
+    if (resolved.example !== undefined && out.example === undefined) {
+      out.example = resolved.example
+    }
+    // copy other keys when sensical (type, description, additionalProperties)
+    if (resolved.type && !out.type) out.type = resolved.type
+    if (resolved.description && !out.description) out.description = resolved.description
+    if (resolved.additionalProperties && !out.additionalProperties) out.additionalProperties = resolved.additionalProperties
+  }
+
+  // if no required entries => delete empty array
+  if (!out.required.length) delete out.required
+  if (Object.keys(out.properties).length === 0) delete out.properties
+
+  return out
+}
+
+/**
+ * Dereference & normalize a schema node:
+ * - resolves $ref (recursively)
+ * - merges allOf into a single object (resolving contained refs)
+ * - resolves arrays/items
+ * - returns a node that no longer contains $ref strings (except unknown external refs we can't resolve)
+ *
+ * Uses seenRefs to avoid infinite recursion.
+ */
+function dereferenceNode(node: any, doc: OpenAPIV3_1.Document, seenRefs = new Set<string>()): any {
+  if (!node) return node
+
+  // If the node is a string ref "#/..."
+  if (typeof node === 'string' && node.startsWith('#/')) {
+    const resolved = resolveRef(node, doc)
+    return dereferenceNode(resolved, doc, seenRefs)
+  }
+
+  // If $ref object
+  if (node.$ref) {
+    const ref = node.$ref as string
+    if (seenRefs.has(ref)) {
+      // circular -> stop and return an empty placeholder
+      return {}
+    }
+    seenRefs.add(ref)
+    const resolved = resolveRef(ref, doc)
+    if (!resolved) {
+      // unresolved external ref -> return empty placeholder
+      return {}
+    }
+    return dereferenceNode(resolved, doc, seenRefs)
+  }
+
+  // allOf: merge parts
+  if (Array.isArray(node.allOf)) {
+    return mergeAllOfParts(node.allOf, doc, seenRefs)
+  }
+
+  // anyOf/oneOf: return array of resolved options (keep as oneOf/anyOf structure)
+  if (Array.isArray(node.oneOf)) {
+    return { oneOf: node.oneOf.map((opt: any) => dereferenceNode(opt, doc, new Set(seenRefs))) }
+  }
+  if (Array.isArray(node.anyOf)) {
+    return { anyOf: node.anyOf.map((opt: any) => dereferenceNode(opt, doc, new Set(seenRefs))) }
+  }
+
+  // arrays: dereference items
+  if (node.type === 'array' || node.items) {
+    const items = node.items ?? {}
+    const derefItems = dereferenceNode(items, doc, new Set(seenRefs))
+    // return normalized array node
+    const arr: any = { type: 'array', items: derefItems }
+    if (node.minItems !== undefined) arr.minItems = node.minItems
+    if (node.maxItems !== undefined) arr.maxItems = node.maxItems
+    if (node.description) arr.description = node.description
+    if (node.example !== undefined) arr.example = node.example
+    return arr
+  }
+
+  // object with properties/additionalProperties -> dereference children
+  if (node.type === 'object' || node.properties || node.additionalProperties) {
+    const out: any = {}
+    if (node.type) out.type = node.type
+    if (node.description) out.description = node.description
+    if (node.example !== undefined) out.example = node.example
+
+    if (node.properties && typeof node.properties === 'object') {
+      out.properties = {}
+      for (const [k, v] of Object.entries(node.properties)) {
+        out.properties[k] = dereferenceNode(v, doc, new Set(seenRefs))
+      }
+    }
+    if (node.required) out.required = Array.isArray(node.required) ? [...node.required] : []
+    if (node.additionalProperties) {
+      out.additionalProperties = node.additionalProperties === true ? true : dereferenceNode(node.additionalProperties, doc, new Set(seenRefs))
+    }
+    return out
+  }
+
+  // primitives (string/boolean/number...), keep example/enum if present
+  if (node.type && ['string', 'integer', 'number', 'boolean'].includes(node.type)) {
+    const p: any = { type: node.type }
+    if (node.example !== undefined) p.example = node.example
+    if (node.enum) p.enum = node.enum
+    if (node.format) p.format = node.format
+    if (node.description) p.description = node.description
+    if (node.minimum !== undefined) p.minimum = node.minimum
+    if (node.maximum !== undefined) p.maximum = node.maximum
+    if (node.minLength !== undefined) p.minLength = node.minLength
+    if (node.maxLength !== undefined) p.maxLength = node.maxLength
+    return p
+  }
+
+  // fallback: return shallow copy but dereference any child objects
+  if (typeof node === 'object') {
+    const out: any = {}
+    for (const [k, v] of Object.entries(node)) {
+      if (k === 'examples') {
+        out[k] = v
+      } else {
+        out[k] = dereferenceNode(v, doc, new Set(seenRefs))
+      }
+    }
+    return out
+  }
+
+  return node
+}
+
+/**
+ * Build a simplified schema representation from a (dereferenced) node.
+ * The node is expected to have no $ref strings (dereferenceNode must be used first).
+ */
+function buildSchemaRepresentation(node: any, doc: OpenAPIV3_1.Document, seenRefs: Set<string> = new Set()): any {
+  if (!node) return null
+
+  // If the node still contains a $ref (shouldn't after dereference), attempt to resolve
+  if (node.$ref) {
+    const resolved = resolveRef(node.$ref, doc)
+    return buildSchemaRepresentation(dereferenceNode(resolved, doc, seenRefs), doc, seenRefs)
+  }
+
+  // oneOf/anyOf (already dereferenced to actual nodes)
+  if (node.oneOf) {
+    return { oneOf: node.oneOf.map((o: any) => buildSchemaRepresentation(o, doc, new Set(seenRefs))) }
+  }
+  if (node.anyOf) {
+    return { anyOf: node.anyOf.map((o: any) => buildSchemaRepresentation(o, doc, new Set(seenRefs))) }
+  }
+
+  // array
+  if (node.type === 'array' || node.items) {
+    const items = node.items ?? {}
+    return [buildSchemaRepresentation(items, doc, new Set(seenRefs))]
+  }
+
+  // primitive type
+  if (node.type && ['string', 'integer', 'number', 'boolean'].includes(node.type)) {
+    return node.type
+  }
+
+  // object with properties
+  if (node.type === 'object' || node.properties || node.additionalProperties) {
+    if (node.properties && typeof node.properties === 'object') {
+      const out: any = {}
+      for (const [k, v] of Object.entries(node.properties)) {
+        out[k] = buildSchemaRepresentation(v as any, doc, new Set(seenRefs))
+      }
+      return out
+    }
+
+    if (node.additionalProperties) {
+      const add = node.additionalProperties === true ? true : buildSchemaRepresentation(node.additionalProperties, doc, new Set(seenRefs))
+      const rep: any = { type: 'object', additionalProperties: add }
+      if (node.propertyNames) rep.propertyNames = node.propertyNames
+      if (node.example !== undefined) rep.example = node.example
+      return rep
+    }
+
+    return { type: 'object' }
+  }
+
+  if (node.enum) return { enum: node.enum }
+
+  // fallback
+  return node
+}
+
+/**
+ * Extract schema representation and example from node AFTER dereferencing.
+ * This ensures schema doesn't include $ref strings or allOf wrappers.
+ */
+function extractFromSchema(node: any, doc: OpenAPIV3_1.Document, seenRefs = new Set<string>()): Extracted {
+  if (!node) return { schema: null, example: null }
+
+  // Always dereference first so we operate on normalized node.
+  const deref = dereferenceNode(node, doc, seenRefs)
+
+  // If it's a oneOf structure
+  if (deref.oneOf) {
+    const options = deref.oneOf.map((opt: any) => extractFromSchema(opt, doc, new Set(seenRefs)))
+    const firstExample = options.find(o => o.example !== undefined && o.example !== null)?.example ?? null
+    return { schema: { oneOf: options.map(o => o.schema) }, example: firstExample }
+  }
+  if (deref.anyOf) {
+    const options = deref.anyOf.map((opt: any) => extractFromSchema(opt, doc, new Set(seenRefs)))
+    const firstExample = options.find(o => o.example !== undefined && o.example !== null)?.example ?? null
+    return { schema: { anyOf: options.map(o => o.schema) }, example: firstExample }
+  }
+
+  // Arrays
+  if (deref.type === 'array' || deref.items) {
+    const items = deref.items ?? {}
+    const itemExtract = extractFromSchema(items, doc, new Set(seenRefs))
+    const schema = [itemExtract.schema]
+    const example = deref.example !== undefined ? deref.example : (itemExtract.example !== null ? [itemExtract.example] : null)
+    return { schema, example }
+  }
+
+  // Objects
+  if (deref.type === 'object' || deref.properties || deref.additionalProperties) {
+    const schemaRep = buildSchemaRepresentation(deref, doc, seenRefs)
+
+    // If explicit example provided at this level, use it
+    if (deref.example !== undefined && deref.example !== null) {
+      return { schema: schemaRep, example: deref.example }
+    }
+
+    // Build example by iterating properties
+    const ex: any = {}
+    if (deref.properties) {
+      for (const [propName, propSchema] of Object.entries(deref.properties)) {
+        const sub = extractFromSchema(propSchema as any, doc, new Set(seenRefs))
+        if (sub.example !== undefined && sub.example !== null) ex[propName] = sub.example
+        else ex[propName] = defaultForSchema(sub.schema)
+      }
+    }
+
+    // additionalProperties: add a sample value using its example if present
+    if (deref.additionalProperties && typeof deref.additionalProperties === 'object') {
+      const add = extractFromSchema(deref.additionalProperties as any, doc, new Set(seenRefs))
+      if (add.example !== undefined && add.example !== null) {
+        const sampleKey = Object.keys(ex)[0] ?? 'key'
+        ex[sampleKey] = add.example
+      }
+    }
+
+    return { schema: schemaRep, example: Object.keys(ex).length ? ex : null }
+  }
+
+  // Primitive
+  if (deref.type && ['string', 'integer', 'number', 'boolean'].includes(deref.type)) {
+    const t = deref.type
+    const example = deref.example !== undefined ? deref.example : defaultForPrimitive(t)
+    return { schema: t, example }
+  }
+
+  // enum
+  if (deref.enum) {
+    return { schema: { enum: deref.enum }, example: Array.isArray(deref.enum) ? deref.enum[0] : null }
+  }
+
+  // Fallback: if there is an example field return it, else return nulls
+  if (deref.example !== undefined) {
+    const schemaRep = buildSchemaRepresentation(deref, doc, seenRefs)
+    return { schema: schemaRep, example: deref.example }
+  }
+
+  return { schema: null, example: null }
+}
+
+
+
+/* ----------------- helpers ----------------- */
+
+function defaultForPrimitive(t: string) {
+  switch (t) {
+    case 'string': return 'string'
+    case 'integer': return 0
+    case 'number': return 0
+    case 'boolean': return false
+    default: return null
+  }
+}
+
+function defaultForSchema(schemaRep: any) {
+  if (schemaRep == null) return null
+  if (Array.isArray(schemaRep)) {
+    return [defaultForSchema(schemaRep[0])]
+  }
+  if (typeof schemaRep === 'string') {
+    return defaultForPrimitive(schemaRep)
+  }
+  if (typeof schemaRep === 'object') {
+    const out: any = {}
+    for (const k of Object.keys(schemaRep)) {
+      out[k] = defaultForSchema(schemaRep[k])
+    }
+    return out
+  }
+  return null
+}
+
+function buildSchemaRepresentationFromExample(example: any): any {
+  if (example === null || example === undefined) return null
+  if (Array.isArray(example)) {
+    return [buildSchemaRepresentationFromExample(example[0])]
+  }
+  if (typeof example === 'object') {
+    const out: any = {}
+    for (const [k, v] of Object.entries(example)) {
+      out[k] = buildSchemaRepresentationFromExample(v)
+    }
+    return out
+  }
+  const t = typeof example
+  if (t === 'string') return 'string'
+  if (t === 'number') return Number.isInteger(example as number) ? 'integer' : 'number'
+  if (t === 'boolean') return 'boolean'
+  return null
+}
+
+function schemaNodeToRequests(
+  node: any,
+  doc: OpenAPIV3_1.Document,
+  nameForRoot = 'body',
+  requiredNames: string[] = [],
+  seenRefs = new Set<string>()
+): Request[] {
+  if (!node) return []
+
+  // If node is a string ref like '#/components/...' -> resolve and recurse
+  if (typeof node === 'string' && node.startsWith('#/')) {
+    const resolved = resolveRef(node, doc)
+    return schemaNodeToRequests(resolved, doc, nameForRoot, requiredNames, seenRefs)
+  }
+
+  // If it's a $ref object, resolve (avoid infinite loop)
+  if (node.$ref) {
+    const ref = node.$ref as string
+    if (seenRefs.has(ref)) {
+      // circular: return a placeholder
+      return [{ name: nameForRoot, type: ref, required: requiredNames.includes(nameForRoot) }]
+    }
+    seenRefs.add(ref)
+    const resolved = resolveRef(ref, doc)
+    if (!resolved) return [{ name: nameForRoot, type: ref, required: requiredNames.includes(nameForRoot) }]
+    return schemaNodeToRequests(resolved, doc, nameForRoot, requiredNames, seenRefs)
+  }
+
+  // If oneOf -> produce one Request entry with type 'oneOf' and bodyObj containing options
+  if (Array.isArray(node.oneOf)) {
+    const options: Request[] = node.oneOf.map((opt: any, idx: number) => {
+      const optReqs = schemaNodeToRequests(opt, doc, `option_${idx+1}`, [], new Set(seenRefs))
+      if (optReqs.length === 1 && optReqs[0].type === 'object' && optReqs[0].bodyObj) {
+        return {
+          name: `Option ${idx+1}`,
+          type: 'object',
+          required: true,
+          description: opt.description || undefined,
+          bodyObj: optReqs[0].bodyObj
+        }
+      }
+      return {
+        name: `Option ${idx+1}`,
+        type: 'object',
+        required: true,
+        bodyObj: optReqs
+      }
+    })
+    return [{
+      name: nameForRoot,
+      type: 'oneOf',
+      required: true,
+      description: node.description || undefined,
+      bodyObj: options
+    }]
+  }
+
+  // If array -> create a single Request describing the array
+  if (node.type === 'array' || node.items) {
+    const items = node.items ?? {}
+    // object[] case
+    if ((items.type === 'object') || items.properties || items.$ref || items.oneOf) {
+      const nested = schemaNodeToRequests(items, doc, 'item', items.required || [], new Set(seenRefs))
+      return [{
+        name: nameForRoot,
+        type: 'object[]',
+        required: requiredNames.includes(nameForRoot),
+        description: node.description || undefined,
+        bodyObj: nested
+      }]
+    } else {
+      const itemType = items.type || 'any'
+      return [{
+        name: nameForRoot,
+        type: `${itemType}[]`,
+        required: requiredNames.includes(nameForRoot),
+        description: node.description || undefined,
+        minLen: node.minItems,
+        maxLen: node.maxItems,
+      }]
+    }
+  }
+
+  // If object with properties -> map each property to Request
+  if (node.type === 'object' || node.properties || node.additionalProperties) {
+    if (node.properties && typeof node.properties === 'object') {
+      const out: Request[] = []
+      const reqArr: string[] = Array.isArray(node.required) ? node.required : requiredNames || []
+      for (const [propName, propSchema] of Object.entries(node.properties)) {
+        const prop = propSchema as any
+
+        // $ref property
+        if (prop.$ref) {
+          const resolved = resolveRef(prop.$ref, doc)
+          const nestedReqs = schemaNodeToRequests(resolved, doc, propName, resolved?.required || [], new Set(seenRefs))
+          if (nestedReqs.length === 1 && nestedReqs[0].type === 'object' && nestedReqs[0].bodyObj) {
+            out.push({
+              name: propName,
+              type: 'object',
+              required: reqArr.includes(propName),
+              description: prop.description || undefined,
+              bodyObj: nestedReqs[0].bodyObj
+            })
+            continue
+          } else {
+            out.push({
+              name: propName,
+              type: 'object',
+              required: reqArr.includes(propName),
+              description: prop.description || undefined,
+              bodyObj: nestedReqs
+            })
+            continue
+          }
+        }
+
+        // array property
+        if (prop.type === 'array' || prop.items) {
+          const items = prop.items ?? {}
+          if ((items.type === 'object') || items.properties || items.$ref || items.oneOf) {
+            const nested = schemaNodeToRequests(items, doc, propName, items.required || [], new Set(seenRefs))
+            out.push({
+              name: propName,
+              type: 'object[]',
+              required: reqArr.includes(propName),
+              description: prop.description || undefined,
+              minLen: prop.minItems,
+              maxLen: prop.maxItems,
+              bodyObj: nested
+            })
+          } else {
+            out.push({
+              name: propName,
+              type: `${items.type || 'any'}[]`,
+              required: reqArr.includes(propName),
+              description: prop.description || undefined,
+              minLen: prop.minItems,
+              maxLen: prop.maxItems,
+              enumList: items.enum
+            })
+          }
+          continue
+        }
+
+        // nested object property
+        if (prop.type === 'object' || prop.properties || prop.additionalProperties) {
+          const nested = schemaNodeToRequests(prop, doc, propName, prop.required || [], new Set(seenRefs))
+          out.push({
+            name: propName,
+            type: 'object',
+            required: reqArr.includes(propName),
+            description: prop.description || undefined,
+            bodyObj: nested
+          })
+          continue
+        }
+
+        // primitive property
+        const r: Request = {
+          name: propName,
+          type: prop.type || (prop.enum ? 'string' : 'any'),
+          required: reqArr.includes(propName),
+          description: prop.description || undefined
+        }
+        if (prop.minLength !== undefined) r.minLen = prop.minLength
+        if (prop.maxLength !== undefined) r.maxLen = prop.maxLength
+        if (prop.minimum !== undefined) r.minimum = prop.minimum
+        if (prop.maximum !== undefined) r.maximum = prop.maximum
+        if (prop.enum) r.enumList = Array.isArray(prop.enum) ? prop.enum : undefined
+        out.push(r)
+      }
+      return out
+    }
+
+    // additionalProperties (map)
+    if (node.additionalProperties) {
+      const add = node.additionalProperties === true ? { type: 'any' } : node.additionalProperties
+      const nested = schemaNodeToRequests(add, doc, 'value', add?.required || [], new Set(seenRefs))
+      return [{
+        name: nameForRoot,
+        type: 'object',
+        required: requiredNames.includes(nameForRoot),
+        description: node.description || undefined,
+        bodyObj: nested.length ? nested : undefined
+      }]
+    }
+
+    // empty object
+    return [{
+      name: nameForRoot,
+      type: 'object',
+      required: requiredNames.includes(nameForRoot),
+      description: node.description || undefined
+    }]
+  }
+
+  // primitive at root
+  if (typeof node.type === 'string') {
+    const r: Request = {
+      name: nameForRoot,
+      type: node.type,
+      required: requiredNames.includes(nameForRoot),
+      description: node.description || undefined
+    }
+    if (node.minLength !== undefined) r.minLen = node.minLength
+    if (node.maxLength !== undefined) r.maxLen = node.maxLength
+    if (node.minimum !== undefined) r.minimum = node.minimum
+    if (node.maximum !== undefined) r.maximum = node.maximum
+    if (node.enum) r.enumList = node.enum
+    return [r]
+  }
+
+  // enum fallback
+  if (node.enum) {
+    return [{
+      name: nameForRoot,
+      type: 'string',
+      required: requiredNames.includes(nameForRoot),
+      enumList: Array.isArray(node.enum) ? node.enum : undefined,
+      description: node.description || undefined
+    }]
+  }
+
+  // fallback
+  return [{
+    name: nameForRoot,
+    type: typeof node === 'object' ? 'object' : 'any',
+    required: requiredNames.includes(nameForRoot),
+    description: node?.description || undefined
+  }]
+}
+
+/* ----------------- main extraction: extractSpec ----------------- */
+
+/**
+ * Walks all paths & methods and extracts:
+ * - parameters (path/query)
+ * - request body (application/json) -> Request[]
+ * - responses -> Extracted { schema, example } (application/json)
+ */
+export function extractSpec(doc: OpenAPIV3_1.Document): { endpoints: Endpoint[] } {
+  const endpoints: Endpoint[] = []
+  const methods = ['get', 'post', 'put', 'delete', 'patch', 'options', 'head']
+
+  for (const [p, pathItem] of Object.entries(doc.paths || {})) {
+    for (const method of methods) {
+      const op: any = (pathItem as any)[method]
+      if (!op) continue
+
+      const parameters: Parameter[] = (op.parameters || []).map((param: any) => ({
+        name: param.name,
+        required: !!param.required,
+        type: param.schema?.type,
+        description: param.description,
+        in: param.in,
+      }))
+
+      const endpoint: Endpoint = {
+        path: p,
+        method: method.toUpperCase(),
+        summary: op.summary,
+        description: op.description,
+        parameters,
+        responses: {},
+        request: null,
+        tag: Array.isArray(op.tags) ? op.tags[0] ?? '' : (op.tags ?? '') as any,
+      }
+
+      // ---------- Request body ----------
+      if (op.requestBody) {
+        let rb: any = op.requestBody
+        if (rb.$ref) {
+          const resolved = resolveRef(rb.$ref, doc)
+          if (resolved) rb = resolved
+        }
+        const reqSchema = rb?.content?.['application/json']?.schema
+        if (reqSchema) {
+          const topReqs = schemaNodeToRequests(reqSchema, doc, 'body', reqSchema.required || [], new Set<string>())
+          endpoint.request = topReqs.length ? topReqs : null
+        } else if (rb?.content?.['application/json']?.example !== undefined) {
+          endpoint.request = [{
+            name: 'body',
+            type: Array.isArray(rb.content['application/json'].example) ? 'array' : typeof rb.content['application/json'].example,
+            required: true,
+            description: rb.description || undefined
+          }]
+        } else {
+          endpoint.request = null
+        }
+      }
+
+      // ---------- Responses ----------
+      for (const [statusCode, resp] of Object.entries(op.responses || {})) {
+        let respObj: any = resp
+
+        // If response is a $ref to components.responses, resolve it
+        if (respObj && respObj.$ref) {
+          const resolvedResp = resolveRef(respObj.$ref, doc)
+          if (resolvedResp) respObj = resolvedResp
+        }
+
+        // content['application/json'].schema is the expected place
+        const contentSchema = respObj?.content?.['application/json']?.schema
+        if (contentSchema) {
+          endpoint.responses[statusCode] = extractFromSchema(contentSchema, doc)
+          continue
+        }
+
+        // content example fallback (no schema)
+        const contentExample = respObj?.content?.['application/json']?.example
+        if (contentExample !== undefined) {
+          const example = contentExample
+          const schemaRep = buildSchemaRepresentationFromExample(example)
+          endpoint.responses[statusCode] = { schema: schemaRep, example }
+          continue
+        }
+
+        // Maybe the response object directly references a schema ($ref inside response 'schema' rare)
+        if (respObj && respObj.schema && respObj.schema.$ref) {
+          endpoint.responses[statusCode] = extractFromSchema(respObj.schema, doc)
+          continue
+        }
+
+        // Another fallback: if respObj has a top-level example
+        if (respObj && respObj.example !== undefined) {
+          const example = respObj.example
+          const schemaRep = buildSchemaRepresentationFromExample(example)
+          endpoint.responses[statusCode] = { schema: schemaRep, example }
+          continue
+        }
+
+        // No useful info
+        endpoint.responses[statusCode] = null
+      }
+
+      endpoints.push(endpoint)
+    }
+  }
+
+  return { endpoints }
+}
+

--- a/openapi-gen/tsxParser/renderToMDX.ts
+++ b/openapi-gen/tsxParser/renderToMDX.ts
@@ -19,16 +19,6 @@ type ElementShape = {
   $$typeof?: symbol;
 };
 
-/** Detect a React element object (the $$typeof check) */
-function isReactElementObject(obj: unknown): obj is React.ReactElement {
-  return (
-    typeof obj === "object" &&
-    obj !== null &&
-    // Symbol.for('react.element') is the canonical marker
-    (obj as any).$$typeof === Symbol.for("react.element")
-  );
-}
-
 /** Main renderer: accepts any React node (element, string, number, array, fragment) */
 export function renderToMDX(node: React.ReactNode): string {
   function renderNode(n: React.ReactNode): string {
@@ -102,3 +92,12 @@ export function renderToMDX(node: React.ReactNode): string {
   return renderNode(node);
 }
 
+/** Detect a React element object (the $$typeof check) */
+function isReactElementObject(obj: unknown): obj is React.ReactElement {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    // Symbol.for('react.element') is the canonical marker
+    (obj as any).$$typeof === Symbol.for("react.element")
+  );
+}

--- a/openapi-gen/tsxParser/renderToMDX.ts
+++ b/openapi-gen/tsxParser/renderToMDX.ts
@@ -1,0 +1,104 @@
+import React from "react";
+
+/** heading map */
+const headingMap: Record<string, string> = {
+  h1: "#",
+  h2: "##",
+  h3: "###",
+  h4: "####",
+  h5: "#####",
+  h6: "######",
+};
+
+type ElementShape = {
+  type: string | Function | symbol;
+  props?: {
+    children?: React.ReactNode;
+    [key: string]: any;
+  };
+  $$typeof?: symbol;
+};
+
+/** Detect a React element object (the $$typeof check) */
+function isReactElementObject(obj: unknown): obj is React.ReactElement {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    // Symbol.for('react.element') is the canonical marker
+    (obj as any).$$typeof === Symbol.for("react.element")
+  );
+}
+
+/** Main renderer: accepts any React node (element, string, number, array, fragment) */
+export function renderToMDX(node: React.ReactNode): string {
+  function renderNode(n: React.ReactNode): string {
+    if (n === null || n === undefined) return "";
+
+    // primitives
+    if (typeof n === "string" || typeof n === "number") {
+      return String(n);
+    }
+
+    // arrays
+    if (Array.isArray(n)) {
+      return n.map(renderNode).join("");
+    }
+
+    // React element object
+    if (isReactElementObject(n)) {
+      const el = n as ElementShape;
+
+      // Fragment handling: render children directly
+      if (el.type === React.Fragment) {
+        return renderNode((el.props && el.props.children) ?? "");
+      }
+
+      // Functional component: call it and continue rendering result
+      if (typeof el.type === "function") {
+        // call component with props (some components expect no args, but usually props)
+        // TypeScript: we don't know the exact return type, but renderNode handles it
+        const res = (el.type as Function)(el.props ?? {});
+        return renderNode(res);
+      }
+
+      // Native HTML tag: render children and map headings
+      if (typeof el.type === "string") {
+        const children = renderNode((el.props && el.props.children) ?? "");
+        if (el.type in headingMap) {
+          // ensure blank lines around headings
+          return `\n\n${headingMap[el.type]} ${children}\n\n`;
+        }
+        // block elements add spacing (a conservative approach)
+        // you can refine which tags are blocks vs inline if needed
+        const blockTags = new Set([
+          "p",
+          "div",
+          "section",
+          "article",
+          "header",
+          "footer",
+          "main",
+          "nav",
+          "ul",
+          "ol",
+          "li",
+        ]);
+        if (blockTags.has(el.type)) {
+          return `\n${children}\n`;
+        }
+
+        // inline/small tags: just return children
+        return children;
+      }
+
+      // If el.type is symbol or unknown, fallback to children
+      return renderNode((el.props && el.props.children) ?? "");
+    }
+
+    // Unknown object (possible Polymorphic returns) -> attempt to stringify
+    return "";
+  }
+
+  return renderNode(node);
+}
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "gen": "swagger-codegen generate -i https://raw.githubusercontent.com/netbirdio/netbird/main/management/server/http/api/openapi.yml -l openapi -o generator/openapi && npx ts-node generator/index.ts gen --input generator/openapi/openapi.json --output src/pages/ipa/resources",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "api-gen": "npx ts-node openapi-gen/index.ts https://raw.githubusercontent.com/netbirdio/netbird/main/shared/management/http/api/openapi.yml"
   },
   "browserslist": {
     "production": [

--- a/src/components/NavigationAPI.jsx
+++ b/src/components/NavigationAPI.jsx
@@ -35,6 +35,7 @@ export const apiNavigation = [
       { title: 'Networks', href: '/api/resources/networks' },
       { title: 'DNS', href: '/api/resources/dns' },
       { title: 'Events', href: '/api/resources/events' },
+      { title: 'Jobs', href: '/api/resources/jobs' },
     ],
   },
 ]

--- a/src/components/NavigationAPI.jsx
+++ b/src/components/NavigationAPI.jsx
@@ -35,7 +35,6 @@ export const apiNavigation = [
       { title: 'Networks', href: '/api/resources/networks' },
       { title: 'DNS', href: '/api/resources/dns' },
       { title: 'Events', href: '/api/resources/events' },
-      { title: 'Jobs', href: '/api/resources/jobs' },
     ],
   },
 ]

--- a/src/components/Resources.jsx
+++ b/src/components/Resources.jsx
@@ -142,6 +142,17 @@ const resources = [
       squares: [[0, 1]],
     },
   },
+    {
+    href: '/api/resources/jobs',
+    name: 'Jobs',
+    description:
+      'Learn about how to list jobs.',
+    icon: UsersIcon,
+    pattern: {
+      y: 22,
+      squares: [[0, 1]],
+    },
+  },
 ]
 
 function ResourceIcon({ icon: Icon }) {

--- a/src/components/Resources.jsx
+++ b/src/components/Resources.jsx
@@ -142,17 +142,6 @@ const resources = [
       squares: [[0, 1]],
     },
   },
-    {
-    href: '/api/resources/jobs',
-    name: 'Jobs',
-    description:
-      'Learn about how to list jobs.',
-    icon: UsersIcon,
-    pattern: {
-      y: 22,
-      squares: [[0, 1]],
-    },
-  },
 ]
 
 function ResourceIcon({ icon: Icon }) {

--- a/src/pages/ipa/resources/accounts.mdx
+++ b/src/pages/ipa/resources/accounts.mdx
@@ -18,43 +18,44 @@ curl -X GET https://api.netbird.io/api/accounts \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/accounts" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
+    "id": "ch8i4ug6lnn4g9hqv7l0",
     "settings": {
-      "peer_login_expiration_enabled": "boolean",
-      "peer_login_expiration": "integer",
-      "peer_inactivity_expiration_enabled": "boolean",
-      "peer_inactivity_expiration": "integer",
-      "regular_users_view_blocked": "boolean",
-      "groups_propagation_enabled": "boolean",
-      "jwt_groups_enabled": "boolean",
-      "jwt_groups_claim_name": "string",
+      "peer_login_expiration_enabled": true,
+      "peer_login_expiration": 43200,
+      "peer_inactivity_expiration_enabled": true,
+      "peer_inactivity_expiration": 43200,
+      "regular_users_view_blocked": true,
+      "groups_propagation_enabled": true,
+      "jwt_groups_enabled": true,
+      "jwt_groups_claim_name": "roles",
       "jwt_allow_groups": [
-        "string"
+        "Administrators"
       ],
-      "routing_peer_dns_resolution_enabled": "boolean",
-      "dns_domain": "string",
-      "network_range": "string",
+      "routing_peer_dns_resolution_enabled": true,
+      "dns_domain": "my-organization.org",
+      "network_range": "100.64.0.0/16",
       "extra": {
-        "peer_approval_enabled": "boolean",
-        "network_traffic_logs_enabled": "boolean",
+        "peer_approval_enabled": true,
+        "user_approval_required": false,
+        "network_traffic_logs_enabled": true,
         "network_traffic_logs_groups": [
-          "string"
+          "ch8i4ug6lnn4g9hqv7m0"
         ],
-        "network_traffic_packet_counter_enabled": "boolean"
+        "network_traffic_packet_counter_enabled": true
       },
-      "lazy_connection_enabled": "boolean"
+      "lazy_connection_enabled": true
     },
-    "domain": "string",
-    "domain_category": "string",
-    "created_at": "string",
-    "created_by": "string",
+    "domain": "netbird.io",
+    "domain_category": "private",
+    "created_at": "2023-05-05T09:00:35.477782Z",
+    "created_by": "google-oauth2|277474792786460067937",
     "onboarding": {
-      "signup_form_pending": "boolean",
-      "onboarding_flow_pending": "boolean"
+      "signup_form_pending": true,
+      "onboarding_flow_pending": false
     }
   }
 ]
@@ -81,6 +82,7 @@ curl -X GET https://api.netbird.io/api/accounts \
       "network_range": "string",
       "extra": {
         "peer_approval_enabled": "boolean",
+        "user_approval_required": "boolean",
         "network_traffic_logs_enabled": "boolean",
         "network_traffic_logs_groups": [
           "string"
@@ -136,9 +138,7 @@ The unique identifier of an account
 
 <details class="custom-details" open >
 
-<summary>Object list</summary>
-<Properties>
-
+<summary>More Information</summary>
 <Properties>
 <Property name="peer_login_expiration_enabled" type="boolean" required={true} >
 Enables or disables peer login expiration globally. After peer's login has expired the user has to log in (authenticate). Applies only to peers that were added by a user (interactive SSO login).
@@ -178,12 +178,33 @@ Allows to define a custom network range for the account in CIDR format
 </Property>
 <Property name="extra" type="object" >
 
+<details class="custom-details" open >
+
+<summary>More Information</summary>
+<Properties>
+<Property name="peer_approval_enabled" type="boolean" required={true} >
+(Cloud only) Enables or disables peer approval globally. If enabled, all peers added will be in pending state until approved by an admin.
+</Property>
+<Property name="user_approval_required" type="boolean" required={true} >
+Enables manual approval for new users joining via domain matching. When enabled, users are blocked with pending approval status until explicitly approved by an admin.
+</Property>
+<Property name="network_traffic_logs_enabled" type="boolean" required={true} >
+Enables or disables network traffic logging. If enabled, all network traffic events from peers will be stored.
+</Property>
+<Property name="network_traffic_logs_groups" type="string[]" required={true} >
+Limits traffic logging to these groups. If unset all peers are enabled.
+</Property>
+<Property name="network_traffic_packet_counter_enabled" type="boolean" required={true} >
+Enables or disables network traffic packet counter. If enabled, network packets and their size will be counted and reported. (This can have an slight impact on performance)
+</Property>
+
+</Properties>
+
+</details>
 </Property>
 <Property name="lazy_connection_enabled" type="boolean" >
 Enables or disables experimental lazy connection
 </Property>
-
-</Properties>
 
 </Properties>
 
@@ -193,9 +214,7 @@ Enables or disables experimental lazy connection
 
 <details class="custom-details" open >
 
-<summary>Object list</summary>
-<Properties>
-
+<summary>More Information</summary>
 <Properties>
 <Property name="signup_form_pending" type="boolean" required={true} >
 Indicates whether the account signup form is pending
@@ -203,8 +222,6 @@ Indicates whether the account signup form is pending
 <Property name="onboarding_flow_pending" type="boolean" required={true} >
 Indicates whether the account onboarding flow is pending
 </Property>
-
-</Properties>
 
 </Properties>
 
@@ -219,10 +236,46 @@ Indicates whether the account onboarding flow is pending
 <CodeGroup title="Request" tag="PUT" label="/api/accounts/{accountId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/accounts/{accountId} \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "settings": {
+    "peer_login_expiration_enabled": true,
+    "peer_login_expiration": 43200,
+    "peer_inactivity_expiration_enabled": true,
+    "peer_inactivity_expiration": 43200,
+    "regular_users_view_blocked": true,
+    "groups_propagation_enabled": true,
+    "jwt_groups_enabled": true,
+    "jwt_groups_claim_name": "roles",
+    "jwt_allow_groups": [
+      "Administrators"
+    ],
+    "routing_peer_dns_resolution_enabled": true,
+    "dns_domain": "my-organization.org",
+    "network_range": "100.64.0.0/16",
+    "extra": {
+      "peer_approval_enabled": true,
+      "user_approval_required": false,
+      "network_traffic_logs_enabled": true,
+      "network_traffic_logs_groups": [
+        "ch8i4ug6lnn4g9hqv7m0"
+      ],
+      "network_traffic_packet_counter_enabled": true
+    },
+    "lazy_connection_enabled": true
+  },
+  "onboarding": {
+    "signup_form_pending": true,
+    "onboarding_flow_pending": false
+  }
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "ch8i4ug6lnn4g9hqv7l0",
   "settings": {
     "peer_login_expiration_enabled": true,
@@ -241,6 +294,7 @@ curl -X PUT https://api.netbird.io/api/accounts/{accountId} \
     "network_range": "100.64.0.0/16",
     "extra": {
       "peer_approval_enabled": true,
+      "user_approval_required": false,
       "network_traffic_logs_enabled": true,
       "network_traffic_logs_groups": [
         "ch8i4ug6lnn4g9hqv7m0"
@@ -256,46 +310,6 @@ curl -X PUT https://api.netbird.io/api/accounts/{accountId} \
   "onboarding": {
     "signup_form_pending": true,
     "onboarding_flow_pending": false
-  }
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="PUT" label="/api/accounts/{accountId}" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "settings": {
-    "peer_login_expiration_enabled": "boolean",
-    "peer_login_expiration": "integer",
-    "peer_inactivity_expiration_enabled": "boolean",
-    "peer_inactivity_expiration": "integer",
-    "regular_users_view_blocked": "boolean",
-    "groups_propagation_enabled": "boolean",
-    "jwt_groups_enabled": "boolean",
-    "jwt_groups_claim_name": "string",
-    "jwt_allow_groups": [
-      "string"
-    ],
-    "routing_peer_dns_resolution_enabled": "boolean",
-    "dns_domain": "string",
-    "network_range": "string",
-    "extra": {
-      "peer_approval_enabled": "boolean",
-      "network_traffic_logs_enabled": "boolean",
-      "network_traffic_logs_groups": [
-        "string"
-      ],
-      "network_traffic_packet_counter_enabled": "boolean"
-    },
-    "lazy_connection_enabled": "boolean"
-  },
-  "domain": "string",
-  "domain_category": "string",
-  "created_at": "string",
-  "created_by": "string",
-  "onboarding": {
-    "signup_form_pending": "boolean",
-    "onboarding_flow_pending": "boolean"
   }
 }
 ```
@@ -320,6 +334,7 @@ curl -X PUT https://api.netbird.io/api/accounts/{accountId} \
     "network_range": "string",
     "extra": {
       "peer_approval_enabled": "boolean",
+      "user_approval_required": "boolean",
       "network_traffic_logs_enabled": "boolean",
       "network_traffic_logs_groups": [
         "string"

--- a/src/pages/ipa/resources/accounts.mdx
+++ b/src/pages/ipa/resources/accounts.mdx
@@ -15,6 +15,141 @@ curl -X GET https://api.netbird.io/api/accounts \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/accounts',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/accounts"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/accounts"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/accounts")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/accounts")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/accounts',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
 </CodeGroup>
 <CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
@@ -233,9 +368,9 @@ Indicates whether the account onboarding flow is pending
 <CodeGroup title="Request" tag="PUT" label="/api/accounts/{accountId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/accounts/{accountId} \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "settings": {
     "peer_login_expiration_enabled": true,
@@ -268,6 +403,340 @@ curl -X PUT https://api.netbird.io/api/accounts/{accountId} \
     "onboarding_flow_pending": false
   }
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "settings": {
+    "peer_login_expiration_enabled": true,
+    "peer_login_expiration": 43200,
+    "peer_inactivity_expiration_enabled": true,
+    "peer_inactivity_expiration": 43200,
+    "regular_users_view_blocked": true,
+    "groups_propagation_enabled": true,
+    "jwt_groups_enabled": true,
+    "jwt_groups_claim_name": "roles",
+    "jwt_allow_groups": [
+      "Administrators"
+    ],
+    "routing_peer_dns_resolution_enabled": true,
+    "dns_domain": "my-organization.org",
+    "network_range": "100.64.0.0/16",
+    "extra": {
+      "peer_approval_enabled": true,
+      "user_approval_required": false,
+      "network_traffic_logs_enabled": true,
+      "network_traffic_logs_groups": [
+        "ch8i4ug6lnn4g9hqv7m0"
+      ],
+      "network_traffic_packet_counter_enabled": true
+    },
+    "lazy_connection_enabled": true
+  },
+  "onboarding": {
+    "signup_form_pending": true,
+    "onboarding_flow_pending": false
+  }
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/accounts/{accountId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/accounts/{accountId}"
+payload = json.dumps({
+  "settings": {
+    "peer_login_expiration_enabled": true,
+    "peer_login_expiration": 43200,
+    "peer_inactivity_expiration_enabled": true,
+    "peer_inactivity_expiration": 43200,
+    "regular_users_view_blocked": true,
+    "groups_propagation_enabled": true,
+    "jwt_groups_enabled": true,
+    "jwt_groups_claim_name": "roles",
+    "jwt_allow_groups": [
+      "Administrators"
+    ],
+    "routing_peer_dns_resolution_enabled": true,
+    "dns_domain": "my-organization.org",
+    "network_range": "100.64.0.0/16",
+    "extra": {
+      "peer_approval_enabled": true,
+      "user_approval_required": false,
+      "network_traffic_logs_enabled": true,
+      "network_traffic_logs_groups": [
+        "ch8i4ug6lnn4g9hqv7m0"
+      ],
+      "network_traffic_packet_counter_enabled": true
+    },
+    "lazy_connection_enabled": true
+  },
+  "onboarding": {
+    "signup_form_pending": true,
+    "onboarding_flow_pending": false
+  }
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/accounts/{accountId}"
+  method := "PUT"
+  
+  payload := strings.NewReader({
+  "settings": {
+    "peer_login_expiration_enabled": true,
+    "peer_login_expiration": 43200,
+    "peer_inactivity_expiration_enabled": true,
+    "peer_inactivity_expiration": 43200,
+    "regular_users_view_blocked": true,
+    "groups_propagation_enabled": true,
+    "jwt_groups_enabled": true,
+    "jwt_groups_claim_name": "roles",
+    "jwt_allow_groups": [
+      "Administrators"
+    ],
+    "routing_peer_dns_resolution_enabled": true,
+    "dns_domain": "my-organization.org",
+    "network_range": "100.64.0.0/16",
+    "extra": {
+      "peer_approval_enabled": true,
+      "user_approval_required": false,
+      "network_traffic_logs_enabled": true,
+      "network_traffic_logs_groups": [
+        "ch8i4ug6lnn4g9hqv7m0"
+      ],
+      "network_traffic_packet_counter_enabled": true
+    },
+    "lazy_connection_enabled": true
+  },
+  "onboarding": {
+    "signup_form_pending": true,
+    "onboarding_flow_pending": false
+  }
+})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/accounts/{accountId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "settings": {
+    "peer_login_expiration_enabled": true,
+    "peer_login_expiration": 43200,
+    "peer_inactivity_expiration_enabled": true,
+    "peer_inactivity_expiration": 43200,
+    "regular_users_view_blocked": true,
+    "groups_propagation_enabled": true,
+    "jwt_groups_enabled": true,
+    "jwt_groups_claim_name": "roles",
+    "jwt_allow_groups": [
+      "Administrators"
+    ],
+    "routing_peer_dns_resolution_enabled": true,
+    "dns_domain": "my-organization.org",
+    "network_range": "100.64.0.0/16",
+    "extra": {
+      "peer_approval_enabled": true,
+      "user_approval_required": false,
+      "network_traffic_logs_enabled": true,
+      "network_traffic_logs_groups": [
+        "ch8i4ug6lnn4g9hqv7m0"
+      ],
+      "network_traffic_packet_counter_enabled": true
+    },
+    "lazy_connection_enabled": true
+  },
+  "onboarding": {
+    "signup_form_pending": true,
+    "onboarding_flow_pending": false
+  }
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "settings": {
+    "peer_login_expiration_enabled": true,
+    "peer_login_expiration": 43200,
+    "peer_inactivity_expiration_enabled": true,
+    "peer_inactivity_expiration": 43200,
+    "regular_users_view_blocked": true,
+    "groups_propagation_enabled": true,
+    "jwt_groups_enabled": true,
+    "jwt_groups_claim_name": "roles",
+    "jwt_allow_groups": [
+      "Administrators"
+    ],
+    "routing_peer_dns_resolution_enabled": true,
+    "dns_domain": "my-organization.org",
+    "network_range": "100.64.0.0/16",
+    "extra": {
+      "peer_approval_enabled": true,
+      "user_approval_required": false,
+      "network_traffic_logs_enabled": true,
+      "network_traffic_logs_groups": [
+        "ch8i4ug6lnn4g9hqv7m0"
+      ],
+      "network_traffic_packet_counter_enabled": true
+    },
+    "lazy_connection_enabled": true
+  },
+  "onboarding": {
+    "signup_form_pending": true,
+    "onboarding_flow_pending": false
+  }
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/accounts/{accountId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/accounts/{accountId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "settings": {
+    "peer_login_expiration_enabled": true,
+    "peer_login_expiration": 43200,
+    "peer_inactivity_expiration_enabled": true,
+    "peer_inactivity_expiration": 43200,
+    "regular_users_view_blocked": true,
+    "groups_propagation_enabled": true,
+    "jwt_groups_enabled": true,
+    "jwt_groups_claim_name": "roles",
+    "jwt_allow_groups": [
+      "Administrators"
+    ],
+    "routing_peer_dns_resolution_enabled": true,
+    "dns_domain": "my-organization.org",
+    "network_range": "100.64.0.0/16",
+    "extra": {
+      "peer_approval_enabled": true,
+      "user_approval_required": false,
+      "network_traffic_logs_enabled": true,
+      "network_traffic_logs_groups": [
+        "ch8i4ug6lnn4g9hqv7m0"
+      ],
+      "network_traffic_packet_counter_enabled": true
+    },
+    "lazy_connection_enabled": true
+  },
+  "onboarding": {
+    "signup_form_pending": true,
+    "onboarding_flow_pending": false
+  }
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -382,7 +851,131 @@ The unique identifier of an account
 <CodeGroup title="Request" tag="DELETE" label="/api/accounts/{accountId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/accounts/{accountId} \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/accounts/{accountId}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/accounts/{accountId}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/accounts/{accountId}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/accounts/{accountId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/accounts/{accountId}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/accounts/{accountId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 

--- a/src/pages/ipa/resources/accounts.mdx
+++ b/src/pages/ipa/resources/accounts.mdx
@@ -1,204 +1,65 @@
 export const title = 'Accounts'
 
 
+## List all Accounts {{ tag: 'GET', label: '/api/accounts' }}
 
-## List all Accounts  {{ tag: 'GET' , label: '/api/accounts' }}
 
 <Row>
-  <Col>
-    Returns a list of accounts of a user. Always returns a list of one account.
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/accounts">
+<Col>
+Returns a list of accounts of a user. Always returns a list of one account.
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/accounts" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/accounts \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/accounts',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/accounts"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/accounts"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/accounts")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/accounts")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/accounts',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/accounts" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "ch8i4ug6lnn4g9hqv7l0",
+    "id": "string",
     "settings": {
-      "peer_login_expiration_enabled": true,
-      "peer_login_expiration": 43200,
-      "peer_inactivity_expiration_enabled": true,
-      "peer_inactivity_expiration": 43200,
-      "regular_users_view_blocked": true,
-      "groups_propagation_enabled": true,
-      "jwt_groups_enabled": true,
-      "jwt_groups_claim_name": "roles",
+      "peer_login_expiration_enabled": "boolean",
+      "peer_login_expiration": "integer",
+      "peer_inactivity_expiration_enabled": "boolean",
+      "peer_inactivity_expiration": "integer",
+      "regular_users_view_blocked": "boolean",
+      "groups_propagation_enabled": "boolean",
+      "jwt_groups_enabled": "boolean",
+      "jwt_groups_claim_name": "string",
       "jwt_allow_groups": [
-        "Administrators"
+        "string"
       ],
-      "routing_peer_dns_resolution_enabled": true,
-      "dns_domain": "my-organization.org",
-      "network_range": "100.64.0.0/16",
+      "routing_peer_dns_resolution_enabled": "boolean",
+      "dns_domain": "string",
+      "network_range": "string",
       "extra": {
-        "peer_approval_enabled": true,
-        "network_traffic_logs_enabled": true,
+        "peer_approval_enabled": "boolean",
+        "network_traffic_logs_enabled": "boolean",
         "network_traffic_logs_groups": [
-          "ch8i4ug6lnn4g9hqv7m0"
+          "string"
         ],
-        "network_traffic_packet_counter_enabled": true
+        "network_traffic_packet_counter_enabled": "boolean"
       },
-      "lazy_connection_enabled": true
+      "lazy_connection_enabled": "boolean"
     },
-    "domain": "netbird.io",
-    "domain_category": "private",
-    "created_at": "2023-05-05T09:00:35.477782Z",
-    "created_by": "google-oauth2|277474792786460067937",
+    "domain": "string",
+    "domain_category": "string",
+    "created_at": "string",
+    "created_by": "string",
     "onboarding": {
-      "signup_form_pending": true,
-      "onboarding_flow_pending": false
+      "signup_form_pending": "boolean",
+      "onboarding_flow_pending": "boolean"
     }
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -239,706 +100,129 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Delete an Account  {{ tag: 'DELETE' , label: '/api/accounts/{accountId}' }}
+
+## Update an Account {{ tag: 'PUT', label: '/api/accounts/{accountId}' }}
+
 
 <Row>
-  <Col>
-    Deletes an account and all its resources. Only account owners can delete accounts.
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="accountId" type="string" required={true}> 
-            The unique identifier of an account
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="DELETE" label="/api/accounts/{accountId}">
-```bash {{ title: 'cURL' }}
-curl -X DELETE https://api.netbird.io/api/accounts/{accountId} \
--H 'Authorization: Token <TOKEN>' 
-```
+<Col>
+Update information about an account
 
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'delete',
-  maxBodyLength: Infinity,
-  url: '/api/accounts/{accountId}',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/accounts/{accountId}"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("DELETE", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/accounts/{accountId}"
-  method := "DELETE"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/accounts/{accountId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Delete.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/accounts/{accountId}")
-  .method("DELETE")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/accounts/{accountId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'DELETE',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
-</Row>
-
----
+### Path Parameters
 
 
-## Update an Account  {{ tag: 'PUT' , label: '/api/accounts/{accountId}' }}
+<Properties>
+<Property name="accountId" type="string" required={true} >
+The unique identifier of an account
+</Property>
 
-<Row>
-  <Col>
-    Update information about an account
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="accountId" type="string" required={true}> 
-            The unique identifier of an account
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="settings" type="object" required={true}>
-        
-            <details class="custom-details" open>
-                <summary>More Information</summary>
-                <Properties>
-                
-                    <Properties><Property name="peer_login_expiration_enabled" type="boolean" required={true}>
-        
-            Enables or disables peer login expiration globally. After peer's login has expired the user has to log in (authenticate). Applies only to peers that were added by a user (interactive SSO login).
-        
-        </Property>
-    <Property name="peer_login_expiration" type="integer" required={true}>
-        
-            Period of time after which peer login expires (seconds).
-        
-        </Property>
-    <Property name="peer_inactivity_expiration_enabled" type="boolean" required={true}>
-        
-            Enables or disables peer inactivity expiration globally. After peer's session has expired the user has to log in (authenticate). Applies only to peers that were added by a user (interactive SSO login).
-        
-        </Property>
-    <Property name="peer_inactivity_expiration" type="integer" required={true}>
-        
-            Period of time of inactivity after which peer session expires (seconds).
-        
-        </Property>
-    <Property name="regular_users_view_blocked" type="boolean" required={true}>
-        
-            Allows blocking regular users from viewing parts of the system.
-        
-        </Property>
-    <Property name="groups_propagation_enabled" type="boolean" required={false}>
-        
-            Allows propagate the new user auto groups to peers that belongs to the user
-        
-        </Property>
-    <Property name="jwt_groups_enabled" type="boolean" required={false}>
-        
-            Allows extract groups from JWT claim and add it to account groups.
-        
-        </Property>
-    <Property name="jwt_groups_claim_name" type="string" required={false}>
-        
-            Name of the claim from which we extract groups names to add it to account groups.
-        
-        </Property>
-    <Property name="jwt_allow_groups" type="string[]" required={false}>
-        
-            List of groups to which users are allowed access
-        
-        </Property>
-    <Property name="routing_peer_dns_resolution_enabled" type="boolean" required={false}>
-        
-            Enables or disables DNS resolution on the routing peers
-        
-        </Property>
-    <Property name="dns_domain" type="string" required={false}>
-        
-            Allows to define a custom dns domain for the account
-        
-        </Property>
-    <Property name="network_range" type="string" required={false}>
-        
-            Allows to define a custom network range for the account in CIDR format
-        
-        </Property>
-    <Property name="extra" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>More Information</summary>
-                <Properties>
-                
-                    <Properties><Property name="peer_approval_enabled" type="boolean" required={true}>
-        
-            (Cloud only) Enables or disables peer approval globally. If enabled, all peers added will be in pending state until approved by an admin.
-        
-        </Property>
-    <Property name="network_traffic_logs_enabled" type="boolean" required={true}>
-        
-            Enables or disables network traffic logging. If enabled, all network traffic events from peers will be stored.
-        
-        </Property>
-    <Property name="network_traffic_logs_groups" type="string[]" required={true}>
-        
-            Limits traffic logging to these groups. If unset all peers are enabled.
-        
-        </Property>
-    <Property name="network_traffic_packet_counter_enabled" type="boolean" required={true}>
-        
-            Enables or disables network traffic packet counter. If enabled, network packets and their size will be counted and reported. (This can have an slight impact on performance)
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="lazy_connection_enabled" type="boolean" required={false}>
-        
-            Enables or disables experimental lazy connection
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="onboarding" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>More Information</summary>
-                <Properties>
-                
-                    <Properties><Property name="signup_form_pending" type="boolean" required={true}>
-        
-            Indicates whether the account signup form is pending
-        
-        </Property>
-    <Property name="onboarding_flow_pending" type="boolean" required={true}>
-        
-            Indicates whether the account onboarding flow is pending
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
+</Properties>
 
-    
-       </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="PUT" label="/api/accounts/{accountId}">
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="settings" type="object" required={true} >
+
+<details class="custom-details" open >
+
+<summary>Object list</summary>
+<Properties>
+
+<Properties>
+<Property name="peer_login_expiration_enabled" type="boolean" required={true} >
+Enables or disables peer login expiration globally. After peer's login has expired the user has to log in (authenticate). Applies only to peers that were added by a user (interactive SSO login).
+</Property>
+<Property name="peer_login_expiration" type="integer" required={true} >
+Period of time after which peer login expires (seconds).
+</Property>
+<Property name="peer_inactivity_expiration_enabled" type="boolean" required={true} >
+Enables or disables peer inactivity expiration globally. After peer's session has expired the user has to log in (authenticate). Applies only to peers that were added by a user (interactive SSO login).
+</Property>
+<Property name="peer_inactivity_expiration" type="integer" required={true} >
+Period of time of inactivity after which peer session expires (seconds).
+</Property>
+<Property name="regular_users_view_blocked" type="boolean" required={true} >
+Allows blocking regular users from viewing parts of the system.
+</Property>
+<Property name="groups_propagation_enabled" type="boolean" >
+Allows propagate the new user auto groups to peers that belongs to the user
+</Property>
+<Property name="jwt_groups_enabled" type="boolean" >
+Allows extract groups from JWT claim and add it to account groups.
+</Property>
+<Property name="jwt_groups_claim_name" type="string" >
+Name of the claim from which we extract groups names to add it to account groups.
+</Property>
+<Property name="jwt_allow_groups" type="string[]" >
+List of groups to which users are allowed access
+</Property>
+<Property name="routing_peer_dns_resolution_enabled" type="boolean" >
+Enables or disables DNS resolution on the routing peers
+</Property>
+<Property name="dns_domain" type="string" >
+Allows to define a custom dns domain for the account
+</Property>
+<Property name="network_range" type="string" >
+Allows to define a custom network range for the account in CIDR format
+</Property>
+<Property name="extra" type="object" >
+
+</Property>
+<Property name="lazy_connection_enabled" type="boolean" >
+Enables or disables experimental lazy connection
+</Property>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="onboarding" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Object list</summary>
+<Properties>
+
+<Properties>
+<Property name="signup_form_pending" type="boolean" required={true} >
+Indicates whether the account signup form is pending
+</Property>
+<Property name="onboarding_flow_pending" type="boolean" required={true} >
+Indicates whether the account onboarding flow is pending
+</Property>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="PUT" label="/api/accounts/{accountId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/accounts/{accountId} \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "settings": {
-    "peer_login_expiration_enabled": true,
-    "peer_login_expiration": 43200,
-    "peer_inactivity_expiration_enabled": true,
-    "peer_inactivity_expiration": 43200,
-    "regular_users_view_blocked": true,
-    "groups_propagation_enabled": true,
-    "jwt_groups_enabled": true,
-    "jwt_groups_claim_name": "roles",
-    "jwt_allow_groups": [
-      "Administrators"
-    ],
-    "routing_peer_dns_resolution_enabled": true,
-    "dns_domain": "my-organization.org",
-    "network_range": "100.64.0.0/16",
-    "extra": {
-      "peer_approval_enabled": true,
-      "network_traffic_logs_enabled": true,
-      "network_traffic_logs_groups": [
-        "ch8i4ug6lnn4g9hqv7m0"
-      ],
-      "network_traffic_packet_counter_enabled": true
-    },
-    "lazy_connection_enabled": true
-  },
-  "onboarding": {
-    "signup_form_pending": true,
-    "onboarding_flow_pending": false
-  }
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "settings": {
-    "peer_login_expiration_enabled": true,
-    "peer_login_expiration": 43200,
-    "peer_inactivity_expiration_enabled": true,
-    "peer_inactivity_expiration": 43200,
-    "regular_users_view_blocked": true,
-    "groups_propagation_enabled": true,
-    "jwt_groups_enabled": true,
-    "jwt_groups_claim_name": "roles",
-    "jwt_allow_groups": [
-      "Administrators"
-    ],
-    "routing_peer_dns_resolution_enabled": true,
-    "dns_domain": "my-organization.org",
-    "network_range": "100.64.0.0/16",
-    "extra": {
-      "peer_approval_enabled": true,
-      "network_traffic_logs_enabled": true,
-      "network_traffic_logs_groups": [
-        "ch8i4ug6lnn4g9hqv7m0"
-      ],
-      "network_traffic_packet_counter_enabled": true
-    },
-    "lazy_connection_enabled": true
-  },
-  "onboarding": {
-    "signup_form_pending": true,
-    "onboarding_flow_pending": false
-  }
-});
-let config = {
-  method: 'put',
-  maxBodyLength: Infinity,
-  url: '/api/accounts/{accountId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/accounts/{accountId}"
-payload = json.dumps({
-  "settings": {
-    "peer_login_expiration_enabled": true,
-    "peer_login_expiration": 43200,
-    "peer_inactivity_expiration_enabled": true,
-    "peer_inactivity_expiration": 43200,
-    "regular_users_view_blocked": true,
-    "groups_propagation_enabled": true,
-    "jwt_groups_enabled": true,
-    "jwt_groups_claim_name": "roles",
-    "jwt_allow_groups": [
-      "Administrators"
-    ],
-    "routing_peer_dns_resolution_enabled": true,
-    "dns_domain": "my-organization.org",
-    "network_range": "100.64.0.0/16",
-    "extra": {
-      "peer_approval_enabled": true,
-      "network_traffic_logs_enabled": true,
-      "network_traffic_logs_groups": [
-        "ch8i4ug6lnn4g9hqv7m0"
-      ],
-      "network_traffic_packet_counter_enabled": true
-    },
-    "lazy_connection_enabled": true
-  },
-  "onboarding": {
-    "signup_form_pending": true,
-    "onboarding_flow_pending": false
-  }
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("PUT", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/accounts/{accountId}"
-  method := "PUT"
-  
-  payload := strings.NewReader(`{
-  "settings": {
-    "peer_login_expiration_enabled": true,
-    "peer_login_expiration": 43200,
-    "peer_inactivity_expiration_enabled": true,
-    "peer_inactivity_expiration": 43200,
-    "regular_users_view_blocked": true,
-    "groups_propagation_enabled": true,
-    "jwt_groups_enabled": true,
-    "jwt_groups_claim_name": "roles",
-    "jwt_allow_groups": [
-      "Administrators"
-    ],
-    "routing_peer_dns_resolution_enabled": true,
-    "dns_domain": "my-organization.org",
-    "network_range": "100.64.0.0/16",
-    "extra": {
-      "peer_approval_enabled": true,
-      "network_traffic_logs_enabled": true,
-      "network_traffic_logs_groups": [
-        "ch8i4ug6lnn4g9hqv7m0"
-      ],
-      "network_traffic_packet_counter_enabled": true
-    },
-    "lazy_connection_enabled": true
-  },
-  "onboarding": {
-    "signup_form_pending": true,
-    "onboarding_flow_pending": false
-  }
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/accounts/{accountId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Put.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "settings": {
-    "peer_login_expiration_enabled": true,
-    "peer_login_expiration": 43200,
-    "peer_inactivity_expiration_enabled": true,
-    "peer_inactivity_expiration": 43200,
-    "regular_users_view_blocked": true,
-    "groups_propagation_enabled": true,
-    "jwt_groups_enabled": true,
-    "jwt_groups_claim_name": "roles",
-    "jwt_allow_groups": [
-      "Administrators"
-    ],
-    "routing_peer_dns_resolution_enabled": true,
-    "dns_domain": "my-organization.org",
-    "network_range": "100.64.0.0/16",
-    "extra": {
-      "peer_approval_enabled": true,
-      "network_traffic_logs_enabled": true,
-      "network_traffic_logs_groups": [
-        "ch8i4ug6lnn4g9hqv7m0"
-      ],
-      "network_traffic_packet_counter_enabled": true
-    },
-    "lazy_connection_enabled": true
-  },
-  "onboarding": {
-    "signup_form_pending": true,
-    "onboarding_flow_pending": false
-  }
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "settings": {
-    "peer_login_expiration_enabled": true,
-    "peer_login_expiration": 43200,
-    "peer_inactivity_expiration_enabled": true,
-    "peer_inactivity_expiration": 43200,
-    "regular_users_view_blocked": true,
-    "groups_propagation_enabled": true,
-    "jwt_groups_enabled": true,
-    "jwt_groups_claim_name": "roles",
-    "jwt_allow_groups": [
-      "Administrators"
-    ],
-    "routing_peer_dns_resolution_enabled": true,
-    "dns_domain": "my-organization.org",
-    "network_range": "100.64.0.0/16",
-    "extra": {
-      "peer_approval_enabled": true,
-      "network_traffic_logs_enabled": true,
-      "network_traffic_logs_groups": [
-        "ch8i4ug6lnn4g9hqv7m0"
-      ],
-      "network_traffic_packet_counter_enabled": true
-    },
-    "lazy_connection_enabled": true
-  },
-  "onboarding": {
-    "signup_form_pending": true,
-    "onboarding_flow_pending": false
-  }
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/accounts/{accountId}")
-  .method("PUT", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/accounts/{accountId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'PUT',  
-  CURLOPT_POSTFIELDS => '{
-  "settings": {
-    "peer_login_expiration_enabled": true,
-    "peer_login_expiration": 43200,
-    "peer_inactivity_expiration_enabled": true,
-    "peer_inactivity_expiration": 43200,
-    "regular_users_view_blocked": true,
-    "groups_propagation_enabled": true,
-    "jwt_groups_enabled": true,
-    "jwt_groups_claim_name": "roles",
-    "jwt_allow_groups": [
-      "Administrators"
-    ],
-    "routing_peer_dns_resolution_enabled": true,
-    "dns_domain": "my-organization.org",
-    "network_range": "100.64.0.0/16",
-    "extra": {
-      "peer_approval_enabled": true,
-      "network_traffic_logs_enabled": true,
-      "network_traffic_logs_groups": [
-        "ch8i4ug6lnn4g9hqv7m0"
-      ],
-      "network_traffic_packet_counter_enabled": true
-    },
-    "lazy_connection_enabled": true
-  },
-  "onboarding": {
-    "signup_form_pending": true,
-    "onboarding_flow_pending": false
-  }
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": "ch8i4ug6lnn4g9hqv7l0",
   "settings": {
     "peer_login_expiration_enabled": true,
@@ -973,8 +257,49 @@ echo $response;
     "signup_form_pending": true,
     "onboarding_flow_pending": false
   }
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="PUT" label="/api/accounts/{accountId}" >
+```json {{ title: 'Example' }}
+{
+  "id": "string",
+  "settings": {
+    "peer_login_expiration_enabled": "boolean",
+    "peer_login_expiration": "integer",
+    "peer_inactivity_expiration_enabled": "boolean",
+    "peer_inactivity_expiration": "integer",
+    "regular_users_view_blocked": "boolean",
+    "groups_propagation_enabled": "boolean",
+    "jwt_groups_enabled": "boolean",
+    "jwt_groups_claim_name": "string",
+    "jwt_allow_groups": [
+      "string"
+    ],
+    "routing_peer_dns_resolution_enabled": "boolean",
+    "dns_domain": "string",
+    "network_range": "string",
+    "extra": {
+      "peer_approval_enabled": "boolean",
+      "network_traffic_logs_enabled": "boolean",
+      "network_traffic_logs_groups": [
+        "string"
+      ],
+      "network_traffic_packet_counter_enabled": "boolean"
+    },
+    "lazy_connection_enabled": "boolean"
+  },
+  "domain": "string",
+  "domain_category": "string",
+  "created_at": "string",
+  "created_by": "string",
+  "onboarding": {
+    "signup_form_pending": "boolean",
+    "onboarding_flow_pending": "boolean"
+  }
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -1013,10 +338,44 @@ echo $response;
   }
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
+---
+
+
+
+## Delete an Account {{ tag: 'DELETE', label: '/api/accounts/{accountId}' }}
+
+
+<Row>
+
+<Col>
+Deletes an account and all its resources. Only account owners can delete accounts.
+
+### Path Parameters
+
+
+<Properties>
+<Property name="accountId" type="string" required={true} >
+The unique identifier of an account
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/accounts/{accountId}" >
+```bash {{ title: 'cURL' }}
+curl -X DELETE https://api.netbird.io/api/accounts/{accountId} \
+-H 'Authorization: Token <TOKEN>' \
+```
+</CodeGroup>
+
+</Col>
+
+</Row>
 ---

--- a/src/pages/ipa/resources/accounts.mdx
+++ b/src/pages/ipa/resources/accounts.mdx
@@ -5,12 +5,10 @@ export const title = 'Accounts'
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of accounts of a user. Always returns a list of one account.
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/accounts" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/accounts \
@@ -107,6 +105,7 @@ curl -X GET https://api.netbird.io/api/accounts \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -115,8 +114,7 @@ curl -X GET https://api.netbird.io/api/accounts \
 
 
 <Row>
-
-<Col>
+ <Col>
 Update information about an account
 
 ### Path Parameters
@@ -135,8 +133,7 @@ The unique identifier of an account
 
 <Properties>
 <Property name="settings" type="object" required={true} >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>More Information</summary>
 <Properties>
@@ -177,8 +174,7 @@ Allows to define a custom dns domain for the account
 Allows to define a custom network range for the account in CIDR format
 </Property>
 <Property name="extra" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>More Information</summary>
 <Properties>
@@ -201,6 +197,7 @@ Enables or disables network traffic packet counter. If enabled, network packets 
 </Properties>
 
 </details>
+
 </Property>
 <Property name="lazy_connection_enabled" type="boolean" >
 Enables or disables experimental lazy connection
@@ -209,10 +206,10 @@ Enables or disables experimental lazy connection
 </Properties>
 
 </details>
+
 </Property>
 <Property name="onboarding" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>More Information</summary>
 <Properties>
@@ -226,13 +223,13 @@ Indicates whether the account onboarding flow is pending
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="PUT" label="/api/accounts/{accountId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/accounts/{accountId} \
@@ -358,6 +355,7 @@ curl -X PUT https://api.netbird.io/api/accounts/{accountId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -366,8 +364,7 @@ curl -X PUT https://api.netbird.io/api/accounts/{accountId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Deletes an account and all its resources. Only account owners can delete accounts.
 
 ### Path Parameters
@@ -381,8 +378,7 @@ The unique identifier of an account
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/accounts/{accountId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/accounts/{accountId} \
@@ -393,4 +389,5 @@ curl -X DELETE https://api.netbird.io/api/accounts/{accountId} \
 </Col>
 
 </Row>
+
 ---

--- a/src/pages/ipa/resources/dns.mdx
+++ b/src/pages/ipa/resources/dns.mdx
@@ -18,29 +18,29 @@ curl -X GET https://api.netbird.io/api/dns/nameservers \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/dns/nameservers" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
-    "name": "string",
-    "description": "string",
+    "id": "ch8i4ug6lnn4g9hqv7m0",
+    "name": "Google DNS",
+    "description": "Google DNS servers",
     "nameservers": [
       {
-        "ip": "string",
-        "ns_type": "string",
-        "port": "integer"
+        "ip": "8.8.8.8",
+        "ns_type": "udp",
+        "port": 53
       }
     ],
-    "enabled": "boolean",
+    "enabled": true,
     "groups": [
-      "string"
+      "ch8i4ug6lnn4g9hqv7m0"
     ],
-    "primary": "boolean",
+    "primary": true,
     "domains": [
-      "string"
+      "example.com"
     ],
-    "search_domains_enabled": "boolean"
+    "search_domains_enabled": true
   }
 ]
 ```
@@ -97,13 +97,11 @@ Name of nameserver group name
 <Property name="description" type="string" required={true} >
 Description of the nameserver group
 </Property>
-<Property name="nameservers" type="object[]" required={true} >
+<Property name="nameservers" type="object[]" required={true} minLen={1} maxLen={3} >
 
 <details class="custom-details" open >
 
 <summary>Nameserver list</summary>
-<Properties>
-
 <Properties>
 <Property name="ip" type="string" required={true} >
 Nameserver IP
@@ -114,8 +112,6 @@ Nameserver Type
 <Property name="port" type="integer" required={true} >
 Nameserver Port
 </Property>
-
-</Properties>
 
 </Properties>
 
@@ -145,11 +141,10 @@ Search domain status for match domains. It should be true only if domains list i
 <CodeGroup title="Request" tag="POST" label="/api/dns/nameservers" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/dns/nameservers \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "id": "ch8i4ug6lnn4g9hqv7m0",
   "name": "Google DNS",
   "description": "Google DNS servers",
   "nameservers": [
@@ -171,28 +166,28 @@ curl -X POST https://api.netbird.io/api/dns/nameservers \
 }'
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="POST" label="/api/dns/nameservers" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "name": "string",
-  "description": "string",
+  "id": "ch8i4ug6lnn4g9hqv7m0",
+  "name": "Google DNS",
+  "description": "Google DNS servers",
   "nameservers": [
     {
-      "ip": "string",
-      "ns_type": "string",
-      "port": "integer"
+      "ip": "8.8.8.8",
+      "ns_type": "udp",
+      "port": 53
     }
   ],
-  "enabled": "boolean",
+  "enabled": true,
   "groups": [
-    "string"
+    "ch8i4ug6lnn4g9hqv7m0"
   ],
-  "primary": "boolean",
+  "primary": true,
   "domains": [
-    "string"
+    "example.com"
   ],
-  "search_domains_enabled": "boolean"
+  "search_domains_enabled": true
 }
 ```
 
@@ -256,28 +251,28 @@ curl -X GET https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/dns/nameservers/{nsgroupId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "name": "string",
-  "description": "string",
+  "id": "ch8i4ug6lnn4g9hqv7m0",
+  "name": "Google DNS",
+  "description": "Google DNS servers",
   "nameservers": [
     {
-      "ip": "string",
-      "ns_type": "string",
-      "port": "integer"
+      "ip": "8.8.8.8",
+      "ns_type": "udp",
+      "port": 53
     }
   ],
-  "enabled": "boolean",
+  "enabled": true,
   "groups": [
-    "string"
+    "ch8i4ug6lnn4g9hqv7m0"
   ],
-  "primary": "boolean",
+  "primary": true,
   "domains": [
-    "string"
+    "example.com"
   ],
-  "search_domains_enabled": "boolean"
+  "search_domains_enabled": true
 }
 ```
 
@@ -342,13 +337,11 @@ Name of nameserver group name
 <Property name="description" type="string" required={true} >
 Description of the nameserver group
 </Property>
-<Property name="nameservers" type="object[]" required={true} >
+<Property name="nameservers" type="object[]" required={true} minLen={1} maxLen={3} >
 
 <details class="custom-details" open >
 
 <summary>Nameserver list</summary>
-<Properties>
-
 <Properties>
 <Property name="ip" type="string" required={true} >
 Nameserver IP
@@ -359,8 +352,6 @@ Nameserver Type
 <Property name="port" type="integer" required={true} >
 Nameserver Port
 </Property>
-
-</Properties>
 
 </Properties>
 
@@ -390,11 +381,10 @@ Search domain status for match domains. It should be true only if domains list i
 <CodeGroup title="Request" tag="PUT" label="/api/dns/nameservers/{nsgroupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "id": "ch8i4ug6lnn4g9hqv7m0",
   "name": "Google DNS",
   "description": "Google DNS servers",
   "nameservers": [
@@ -416,28 +406,28 @@ curl -X PUT https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
 }'
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="PUT" label="/api/dns/nameservers/{nsgroupId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "name": "string",
-  "description": "string",
+  "id": "ch8i4ug6lnn4g9hqv7m0",
+  "name": "Google DNS",
+  "description": "Google DNS servers",
   "nameservers": [
     {
-      "ip": "string",
-      "ns_type": "string",
-      "port": "integer"
+      "ip": "8.8.8.8",
+      "ns_type": "udp",
+      "port": 53
     }
   ],
-  "enabled": "boolean",
+  "enabled": true,
   "groups": [
-    "string"
+    "ch8i4ug6lnn4g9hqv7m0"
   ],
-  "primary": "boolean",
+  "primary": true,
   "domains": [
-    "string"
+    "example.com"
   ],
-  "search_domains_enabled": "boolean"
+  "search_domains_enabled": true
 }
 ```
 
@@ -525,12 +515,12 @@ curl -X GET https://api.netbird.io/api/dns/settings \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/dns/settings" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
     "disabled_management_groups": [
-      "string"
+      "ch8i4ug6lnn4g9hqv7m0"
     ]
   }
 ]
@@ -578,9 +568,9 @@ Groups whose DNS management is disabled
 <CodeGroup title="Request" tag="PUT" label="/api/dns/settings" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/dns/settings \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "disabled_management_groups": [
     "ch8i4ug6lnn4g9hqv7m0"
@@ -588,11 +578,11 @@ curl -X PUT https://api.netbird.io/api/dns/settings \
 }'
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="PUT" label="/api/dns/settings" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
   "disabled_management_groups": [
-    "string"
+    "ch8i4ug6lnn4g9hqv7m0"
   ]
 }
 ```

--- a/src/pages/ipa/resources/dns.mdx
+++ b/src/pages/ipa/resources/dns.mdx
@@ -5,12 +5,10 @@ export const title = 'DNS'
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all Nameserver Groups
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/dns/nameservers" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/dns/nameservers \
@@ -75,6 +73,7 @@ curl -X GET https://api.netbird.io/api/dns/nameservers \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -83,8 +82,7 @@ curl -X GET https://api.netbird.io/api/dns/nameservers \
 
 
 <Row>
-
-<Col>
+ <Col>
 Creates a Nameserver Group
 
 ### Request-Body Parameters
@@ -98,8 +96,7 @@ Name of nameserver group name
 Description of the nameserver group
 </Property>
 <Property name="nameservers" type="object[]" required={true} minLen={1} maxLen={3} >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Nameserver list</summary>
 <Properties>
@@ -116,6 +113,7 @@ Nameserver Port
 </Properties>
 
 </details>
+
 </Property>
 <Property name="enabled" type="boolean" required={true} >
 Nameserver group status
@@ -136,8 +134,7 @@ Search domain status for match domains. It should be true only if domains list i
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="POST" label="/api/dns/nameservers" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/dns/nameservers \
@@ -219,6 +216,7 @@ curl -X POST https://api.netbird.io/api/dns/nameservers \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -227,8 +225,7 @@ curl -X POST https://api.netbird.io/api/dns/nameservers \
 
 
 <Row>
-
-<Col>
+ <Col>
 Get information about a Nameserver Groups
 
 ### Path Parameters
@@ -242,8 +239,7 @@ The unique identifier of a Nameserver Group
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/dns/nameservers/{nsgroupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
@@ -304,6 +300,7 @@ curl -X GET https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -312,8 +309,7 @@ curl -X GET https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Update/Replace a Nameserver Group
 
 ### Path Parameters
@@ -338,8 +334,7 @@ Name of nameserver group name
 Description of the nameserver group
 </Property>
 <Property name="nameservers" type="object[]" required={true} minLen={1} maxLen={3} >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Nameserver list</summary>
 <Properties>
@@ -356,6 +351,7 @@ Nameserver Port
 </Properties>
 
 </details>
+
 </Property>
 <Property name="enabled" type="boolean" required={true} >
 Nameserver group status
@@ -376,8 +372,7 @@ Search domain status for match domains. It should be true only if domains list i
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="PUT" label="/api/dns/nameservers/{nsgroupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
@@ -459,6 +454,7 @@ curl -X PUT https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -467,8 +463,7 @@ curl -X PUT https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Delete a Nameserver Group
 
 ### Path Parameters
@@ -482,8 +477,7 @@ The unique identifier of a Nameserver Group
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/dns/nameservers/{nsgroupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
@@ -494,6 +488,7 @@ curl -X DELETE https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -502,12 +497,10 @@ curl -X DELETE https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a DNS settings object
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/dns/settings" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/dns/settings \
@@ -540,6 +533,7 @@ curl -X GET https://api.netbird.io/api/dns/settings \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -548,8 +542,7 @@ curl -X GET https://api.netbird.io/api/dns/settings \
 
 
 <Row>
-
-<Col>
+ <Col>
 Updates a DNS settings object
 
 ### Request-Body Parameters
@@ -563,8 +556,7 @@ Groups whose DNS management is disabled
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="PUT" label="/api/dns/settings" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/dns/settings \
@@ -599,4 +591,5 @@ curl -X PUT https://api.netbird.io/api/dns/settings \
 </Col>
 
 </Row>
+
 ---

--- a/src/pages/ipa/resources/dns.mdx
+++ b/src/pages/ipa/resources/dns.mdx
@@ -15,6 +15,141 @@ curl -X GET https://api.netbird.io/api/dns/nameservers \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/dns/nameservers',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/dns/nameservers"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/dns/nameservers"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/dns/nameservers")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/dns/nameservers")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/dns/nameservers',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
 </CodeGroup>
 <CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
@@ -138,9 +273,9 @@ Search domain status for match domains. It should be true only if domains list i
 <CodeGroup title="Request" tag="POST" label="/api/dns/nameservers" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/dns/nameservers \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "Google DNS",
   "description": "Google DNS servers",
@@ -161,6 +296,268 @@ curl -X POST https://api.netbird.io/api/dns/nameservers \
   ],
   "search_domains_enabled": true
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "Google DNS",
+  "description": "Google DNS servers",
+  "nameservers": [
+    {
+      "ip": "8.8.8.8",
+      "ns_type": "udp",
+      "port": 53
+    }
+  ],
+  "enabled": true,
+  "groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "primary": true,
+  "domains": [
+    "example.com"
+  ],
+  "search_domains_enabled": true
+});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/dns/nameservers',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/dns/nameservers"
+payload = json.dumps({
+  "name": "Google DNS",
+  "description": "Google DNS servers",
+  "nameservers": [
+    {
+      "ip": "8.8.8.8",
+      "ns_type": "udp",
+      "port": 53
+    }
+  ],
+  "enabled": true,
+  "groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "primary": true,
+  "domains": [
+    "example.com"
+  ],
+  "search_domains_enabled": true
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/dns/nameservers"
+  method := "POST"
+  
+  payload := strings.NewReader(`{
+  "name": "Google DNS",
+  "description": "Google DNS servers",
+  "nameservers": [
+    {
+      "ip": "8.8.8.8",
+      "ns_type": "udp",
+      "port": 53
+    }
+  ],
+  "enabled": true,
+  "groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "primary": true,
+  "domains": [
+    "example.com"
+  ],
+  "search_domains_enabled": true
+}`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/dns/nameservers")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "Google DNS",
+  "description": "Google DNS servers",
+  "nameservers": [
+    {
+      "ip": "8.8.8.8",
+      "ns_type": "udp",
+      "port": 53
+    }
+  ],
+  "enabled": true,
+  "groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "primary": true,
+  "domains": [
+    "example.com"
+  ],
+  "search_domains_enabled": true
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{
+  \"name\": \"Google DNS\",
+  \"description\": \"Google DNS servers\",
+  \"nameservers\": [
+    {
+      \"ip\": \"8.8.8.8\",
+      \"ns_type\": \"udp\",
+      \"port\": 53
+    }
+  ],
+  \"enabled\": true,
+  \"groups\": [
+    \"ch8i4ug6lnn4g9hqv7m0\"
+  ],
+  \"primary\": true,
+  \"domains\": [
+    \"example.com\"
+  ],
+  \"search_domains_enabled\": true
+}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/dns/nameservers")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/dns/nameservers',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "Google DNS",
+  "description": "Google DNS servers",
+  "nameservers": [
+    {
+      "ip": "8.8.8.8",
+      "ns_type": "udp",
+      "port": 53
+    }
+  ],
+  "enabled": true,
+  "groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "primary": true,
+  "domains": [
+    "example.com"
+  ],
+  "search_domains_enabled": true
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -245,6 +642,141 @@ The unique identifier of a Nameserver Group
 curl -X GET https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/dns/nameservers/{nsgroupId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/dns/nameservers/{nsgroupId}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/dns/nameservers/{nsgroupId}"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/dns/nameservers/{nsgroupId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/dns/nameservers/{nsgroupId}")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/dns/nameservers/{nsgroupId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -376,9 +908,9 @@ Search domain status for match domains. It should be true only if domains list i
 <CodeGroup title="Request" tag="PUT" label="/api/dns/nameservers/{nsgroupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "Google DNS",
   "description": "Google DNS servers",
@@ -399,6 +931,268 @@ curl -X PUT https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
   ],
   "search_domains_enabled": true
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "Google DNS",
+  "description": "Google DNS servers",
+  "nameservers": [
+    {
+      "ip": "8.8.8.8",
+      "ns_type": "udp",
+      "port": 53
+    }
+  ],
+  "enabled": true,
+  "groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "primary": true,
+  "domains": [
+    "example.com"
+  ],
+  "search_domains_enabled": true
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/dns/nameservers/{nsgroupId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/dns/nameservers/{nsgroupId}"
+payload = json.dumps({
+  "name": "Google DNS",
+  "description": "Google DNS servers",
+  "nameservers": [
+    {
+      "ip": "8.8.8.8",
+      "ns_type": "udp",
+      "port": 53
+    }
+  ],
+  "enabled": true,
+  "groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "primary": true,
+  "domains": [
+    "example.com"
+  ],
+  "search_domains_enabled": true
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/dns/nameservers/{nsgroupId}"
+  method := "PUT"
+  
+  payload := strings.NewReader({
+  "name": "Google DNS",
+  "description": "Google DNS servers",
+  "nameservers": [
+    {
+      "ip": "8.8.8.8",
+      "ns_type": "udp",
+      "port": 53
+    }
+  ],
+  "enabled": true,
+  "groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "primary": true,
+  "domains": [
+    "example.com"
+  ],
+  "search_domains_enabled": true
+})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/dns/nameservers/{nsgroupId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "Google DNS",
+  "description": "Google DNS servers",
+  "nameservers": [
+    {
+      "ip": "8.8.8.8",
+      "ns_type": "udp",
+      "port": 53
+    }
+  ],
+  "enabled": true,
+  "groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "primary": true,
+  "domains": [
+    "example.com"
+  ],
+  "search_domains_enabled": true
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "name": "Google DNS",
+  "description": "Google DNS servers",
+  "nameservers": [
+    {
+      "ip": "8.8.8.8",
+      "ns_type": "udp",
+      "port": 53
+    }
+  ],
+  "enabled": true,
+  "groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "primary": true,
+  "domains": [
+    "example.com"
+  ],
+  "search_domains_enabled": true
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/dns/nameservers/{nsgroupId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/dns/nameservers/{nsgroupId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "Google DNS",
+  "description": "Google DNS servers",
+  "nameservers": [
+    {
+      "ip": "8.8.8.8",
+      "ns_type": "udp",
+      "port": 53
+    }
+  ],
+  "enabled": true,
+  "groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "primary": true,
+  "domains": [
+    "example.com"
+  ],
+  "search_domains_enabled": true
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -481,7 +1275,131 @@ The unique identifier of a Nameserver Group
 <CodeGroup title="Request" tag="DELETE" label="/api/dns/nameservers/{nsgroupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/dns/nameservers/{nsgroupId}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/dns/nameservers/{nsgroupId}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/dns/nameservers/{nsgroupId}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/dns/nameservers/{nsgroupId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/dns/nameservers/{nsgroupId}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/dns/nameservers/{nsgroupId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 
@@ -506,6 +1424,141 @@ Returns a DNS settings object
 curl -X GET https://api.netbird.io/api/dns/settings \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/dns/settings',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/dns/settings"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/dns/settings"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/dns/settings")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/dns/settings")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/dns/settings',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -560,14 +1613,186 @@ Groups whose DNS management is disabled
 <CodeGroup title="Request" tag="PUT" label="/api/dns/settings" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/dns/settings \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "disabled_management_groups": [
     "ch8i4ug6lnn4g9hqv7m0"
   ]
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "disabled_management_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ]
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/dns/settings',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/dns/settings"
+payload = json.dumps({
+  "disabled_management_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ]
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/dns/settings"
+  method := "PUT"
+  
+  payload := strings.NewReader({
+  "disabled_management_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ]
+})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/dns/settings")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "disabled_management_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ]
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "disabled_management_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ]
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/dns/settings")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/dns/settings',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "disabled_management_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ]
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >

--- a/src/pages/ipa/resources/dns.mdx
+++ b/src/pages/ipa/resources/dns.mdx
@@ -1,189 +1,50 @@
 export const title = 'DNS'
 
 
+## List all Nameserver Groups {{ tag: 'GET', label: '/api/dns/nameservers' }}
 
-## List all Nameserver Groups  {{ tag: 'GET' , label: '/api/dns/nameservers' }}
 
 <Row>
-  <Col>
-    Returns a list of all Nameserver Groups
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/dns/nameservers">
+<Col>
+Returns a list of all Nameserver Groups
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/dns/nameservers" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/dns/nameservers \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/dns/nameservers',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/dns/nameservers"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/dns/nameservers"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/dns/nameservers")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/dns/nameservers")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/dns/nameservers',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/dns/nameservers" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "ch8i4ug6lnn4g9hqv7m0",
-    "name": "Google DNS",
-    "description": "Google DNS servers",
+    "id": "string",
+    "name": "string",
+    "description": "string",
     "nameservers": [
       {
-        "ip": "8.8.8.8",
-        "ns_type": "udp",
-        "port": 53
+        "ip": "string",
+        "ns_type": "string",
+        "port": "integer"
       }
     ],
-    "enabled": true,
+    "enabled": "boolean",
     "groups": [
-      "ch8i4ug6lnn4g9hqv7m0"
+      "string"
     ],
-    "primary": true,
+    "primary": "boolean",
     "domains": [
-      "example.com"
+      "string"
     ],
-    "search_domains_enabled": true
+    "search_domains_enabled": "boolean"
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -209,98 +70,86 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Create a Nameserver Group  {{ tag: 'POST' , label: '/api/dns/nameservers' }}
+
+## Create a Nameserver Group {{ tag: 'POST', label: '/api/dns/nameservers' }}
+
 
 <Row>
-  <Col>
-    Creates a Nameserver Group
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true} minLen={1} maxLen={40}>
-        
-            Name of nameserver group name
-        
-        </Property>
-    <Property name="description" type="string" required={true}>
-        
-            Description of the nameserver group
-        
-        </Property>
-    <Property name="nameservers" type="object[]" required={true} minLen={1} maxLen={3}>
-        
-            <details class="custom-details" open>
-                <summary>Nameserver list</summary>
-                <Properties>
-                
-                    <Properties><Property name="ip" type="string" required={true}>
-        
-            Nameserver IP
-        
-        </Property>
-    <Property name="ns_type" type="string" required={true} enumList={["udp"]}>
-        
-            Nameserver Type
-        
-        </Property>
-    <Property name="port" type="integer" required={true}>
-        
-            Nameserver Port
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="enabled" type="boolean" required={true}>
-        
-            Nameserver group status
-        
-        </Property>
-    <Property name="groups" type="string[]" required={true}>
-        
-            Distribution group IDs that defines group of peers that will use this nameserver group
-        
-        </Property>
-    <Property name="primary" type="boolean" required={true}>
-        
-            Defines if a nameserver group is primary that resolves all domains. It should be true only if domains list is empty.
-        
-        </Property>
-    <Property name="domains" type="string[]" required={true}>
-        
-            Match domain list. It should be empty only if primary is true.
-        
-        </Property>
-    <Property name="search_domains_enabled" type="boolean" required={true}>
-        
-            Search domain status for match domains. It should be true only if domains list is not empty.
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Creates a Nameserver Group
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/api/dns/nameservers">
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="name" type="string" required={true} minLen={1} maxLen={40} >
+Name of nameserver group name
+</Property>
+<Property name="description" type="string" required={true} >
+Description of the nameserver group
+</Property>
+<Property name="nameservers" type="object[]" required={true} >
+
+<details class="custom-details" open >
+
+<summary>Nameserver list</summary>
+<Properties>
+
+<Properties>
+<Property name="ip" type="string" required={true} >
+Nameserver IP
+</Property>
+<Property name="ns_type" type="string" required={true} >
+Nameserver Type
+</Property>
+<Property name="port" type="integer" required={true} >
+Nameserver Port
+</Property>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="enabled" type="boolean" required={true} >
+Nameserver group status
+</Property>
+<Property name="groups" type="string[]" required={true} >
+Distribution group IDs that defines group of peers that will use this nameserver group
+</Property>
+<Property name="primary" type="boolean" required={true} >
+Defines if a nameserver group is primary that resolves all domains. It should be true only if domains list is empty.
+</Property>
+<Property name="domains" type="string[]" required={true} >
+Match domain list. It should be empty only if primary is true.
+</Property>
+<Property name="search_domains_enabled" type="boolean" required={true} >
+Search domain status for match domains. It should be true only if domains list is not empty.
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="POST" label="/api/dns/nameservers" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/dns/nameservers \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "id": "ch8i4ug6lnn4g9hqv7m0",
   "name": "Google DNS",
   "description": "Google DNS servers",
   "nameservers": [
@@ -321,297 +170,32 @@ curl -X POST https://api.netbird.io/api/dns/nameservers \
   "search_domains_enabled": true
 }'
 ```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "Google DNS",
-  "description": "Google DNS servers",
-  "nameservers": [
-    {
-      "ip": "8.8.8.8",
-      "ns_type": "udp",
-      "port": 53
-    }
-  ],
-  "enabled": true,
-  "groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "primary": true,
-  "domains": [
-    "example.com"
-  ],
-  "search_domains_enabled": true
-});
-let config = {
-  method: 'post',
-  maxBodyLength: Infinity,
-  url: '/api/dns/nameservers',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/dns/nameservers"
-payload = json.dumps({
-  "name": "Google DNS",
-  "description": "Google DNS servers",
-  "nameservers": [
-    {
-      "ip": "8.8.8.8",
-      "ns_type": "udp",
-      "port": 53
-    }
-  ],
-  "enabled": true,
-  "groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "primary": true,
-  "domains": [
-    "example.com"
-  ],
-  "search_domains_enabled": true
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("POST", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/dns/nameservers"
-  method := "POST"
-  
-  payload := strings.NewReader(`{
-  "name": "Google DNS",
-  "description": "Google DNS servers",
-  "nameservers": [
-    {
-      "ip": "8.8.8.8",
-      "ns_type": "udp",
-      "port": 53
-    }
-  ],
-  "enabled": true,
-  "groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "primary": true,
-  "domains": [
-    "example.com"
-  ],
-  "search_domains_enabled": true
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/dns/nameservers")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Post.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "Google DNS",
-  "description": "Google DNS servers",
-  "nameservers": [
-    {
-      "ip": "8.8.8.8",
-      "ns_type": "udp",
-      "port": 53
-    }
-  ],
-  "enabled": true,
-  "groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "primary": true,
-  "domains": [
-    "example.com"
-  ],
-  "search_domains_enabled": true
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "Google DNS",
-  "description": "Google DNS servers",
-  "nameservers": [
-    {
-      "ip": "8.8.8.8",
-      "ns_type": "udp",
-      "port": 53
-    }
-  ],
-  "enabled": true,
-  "groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "primary": true,
-  "domains": [
-    "example.com"
-  ],
-  "search_domains_enabled": true
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/dns/nameservers")
-  .method("POST", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/dns/nameservers',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'POST',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "Google DNS",
-  "description": "Google DNS servers",
-  "nameservers": [
-    {
-      "ip": "8.8.8.8",
-      "ns_type": "udp",
-      "port": 53
-    }
-  ],
-  "enabled": true,
-  "groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "primary": true,
-  "domains": [
-    "example.com"
-  ],
-  "search_domains_enabled": true
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="POST" label="/api/dns/nameservers" >
 ```json {{ title: 'Example' }}
 {
-  "id": "ch8i4ug6lnn4g9hqv7m0",
-  "name": "Google DNS",
-  "description": "Google DNS servers",
+  "id": "string",
+  "name": "string",
+  "description": "string",
   "nameservers": [
     {
-      "ip": "8.8.8.8",
-      "ns_type": "udp",
-      "port": 53
+      "ip": "string",
+      "ns_type": "string",
+      "port": "integer"
     }
   ],
-  "enabled": true,
+  "enabled": "boolean",
   "groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
+    "string"
   ],
-  "primary": true,
+  "primary": "boolean",
   "domains": [
-    "example.com"
+    "string"
   ],
-  "search_domains_enabled": true
+  "search_domains_enabled": "boolean"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -635,203 +219,68 @@ echo $response;
   "search_domains_enabled": "boolean"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Retrieve a Nameserver Group  {{ tag: 'GET' , label: '/api/dns/nameservers/{nsgroupId}' }}
+
+## Retrieve a Nameserver Group {{ tag: 'GET', label: '/api/dns/nameservers/{nsgroupId}' }}
+
 
 <Row>
-  <Col>
-    Get information about a Nameserver Groups
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="nsgroupId" type="string" required={true}> 
-            The unique identifier of a Nameserver Group
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/dns/nameservers/{nsgroupId}">
+<Col>
+Get information about a Nameserver Groups
+
+### Path Parameters
+
+
+<Properties>
+<Property name="nsgroupId" type="string" required={true} >
+The unique identifier of a Nameserver Group
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/dns/nameservers/{nsgroupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/dns/nameservers/{nsgroupId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/dns/nameservers/{nsgroupId}"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/dns/nameservers/{nsgroupId}"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/dns/nameservers/{nsgroupId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/dns/nameservers/{nsgroupId}")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/dns/nameservers/{nsgroupId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/dns/nameservers/{nsgroupId}" >
 ```json {{ title: 'Example' }}
 {
-  "id": "ch8i4ug6lnn4g9hqv7m0",
-  "name": "Google DNS",
-  "description": "Google DNS servers",
+  "id": "string",
+  "name": "string",
+  "description": "string",
   "nameservers": [
     {
-      "ip": "8.8.8.8",
-      "ns_type": "udp",
-      "port": 53
+      "ip": "string",
+      "ns_type": "string",
+      "port": "integer"
     }
   ],
-  "enabled": true,
+  "enabled": "boolean",
   "groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
+    "string"
   ],
-  "primary": true,
+  "primary": "boolean",
   "domains": [
-    "example.com"
+    "string"
   ],
-  "search_domains_enabled": true
+  "search_domains_enabled": "boolean"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -855,106 +304,97 @@ echo $response;
   "search_domains_enabled": "boolean"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Update a Nameserver Group  {{ tag: 'PUT' , label: '/api/dns/nameservers/{nsgroupId}' }}
+
+## Update a Nameserver Group {{ tag: 'PUT', label: '/api/dns/nameservers/{nsgroupId}' }}
+
 
 <Row>
-  <Col>
-    Update/Replace a Nameserver Group
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="nsgroupId" type="string" required={true}> 
-            The unique identifier of a Nameserver Group
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true} minLen={1} maxLen={40}>
-        
-            Name of nameserver group name
-        
-        </Property>
-    <Property name="description" type="string" required={true}>
-        
-            Description of the nameserver group
-        
-        </Property>
-    <Property name="nameservers" type="object[]" required={true} minLen={1} maxLen={3}>
-        
-            <details class="custom-details" open>
-                <summary>Nameserver list</summary>
-                <Properties>
-                
-                    <Properties><Property name="ip" type="string" required={true}>
-        
-            Nameserver IP
-        
-        </Property>
-    <Property name="ns_type" type="string" required={true} enumList={["udp"]}>
-        
-            Nameserver Type
-        
-        </Property>
-    <Property name="port" type="integer" required={true}>
-        
-            Nameserver Port
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="enabled" type="boolean" required={true}>
-        
-            Nameserver group status
-        
-        </Property>
-    <Property name="groups" type="string[]" required={true}>
-        
-            Distribution group IDs that defines group of peers that will use this nameserver group
-        
-        </Property>
-    <Property name="primary" type="boolean" required={true}>
-        
-            Defines if a nameserver group is primary that resolves all domains. It should be true only if domains list is empty.
-        
-        </Property>
-    <Property name="domains" type="string[]" required={true}>
-        
-            Match domain list. It should be empty only if primary is true.
-        
-        </Property>
-    <Property name="search_domains_enabled" type="boolean" required={true}>
-        
-            Search domain status for match domains. It should be true only if domains list is not empty.
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Update/Replace a Nameserver Group
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="PUT" label="/api/dns/nameservers/{nsgroupId}">
+### Path Parameters
+
+
+<Properties>
+<Property name="nsgroupId" type="string" required={true} >
+The unique identifier of a Nameserver Group
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="name" type="string" required={true} minLen={1} maxLen={40} >
+Name of nameserver group name
+</Property>
+<Property name="description" type="string" required={true} >
+Description of the nameserver group
+</Property>
+<Property name="nameservers" type="object[]" required={true} >
+
+<details class="custom-details" open >
+
+<summary>Nameserver list</summary>
+<Properties>
+
+<Properties>
+<Property name="ip" type="string" required={true} >
+Nameserver IP
+</Property>
+<Property name="ns_type" type="string" required={true} >
+Nameserver Type
+</Property>
+<Property name="port" type="integer" required={true} >
+Nameserver Port
+</Property>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="enabled" type="boolean" required={true} >
+Nameserver group status
+</Property>
+<Property name="groups" type="string[]" required={true} >
+Distribution group IDs that defines group of peers that will use this nameserver group
+</Property>
+<Property name="primary" type="boolean" required={true} >
+Defines if a nameserver group is primary that resolves all domains. It should be true only if domains list is empty.
+</Property>
+<Property name="domains" type="string[]" required={true} >
+Match domain list. It should be empty only if primary is true.
+</Property>
+<Property name="search_domains_enabled" type="boolean" required={true} >
+Search domain status for match domains. It should be true only if domains list is not empty.
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="PUT" label="/api/dns/nameservers/{nsgroupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "id": "ch8i4ug6lnn4g9hqv7m0",
   "name": "Google DNS",
   "description": "Google DNS servers",
   "nameservers": [
@@ -975,297 +415,32 @@ curl -X PUT https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
   "search_domains_enabled": true
 }'
 ```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "Google DNS",
-  "description": "Google DNS servers",
-  "nameservers": [
-    {
-      "ip": "8.8.8.8",
-      "ns_type": "udp",
-      "port": 53
-    }
-  ],
-  "enabled": true,
-  "groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "primary": true,
-  "domains": [
-    "example.com"
-  ],
-  "search_domains_enabled": true
-});
-let config = {
-  method: 'put',
-  maxBodyLength: Infinity,
-  url: '/api/dns/nameservers/{nsgroupId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/dns/nameservers/{nsgroupId}"
-payload = json.dumps({
-  "name": "Google DNS",
-  "description": "Google DNS servers",
-  "nameservers": [
-    {
-      "ip": "8.8.8.8",
-      "ns_type": "udp",
-      "port": 53
-    }
-  ],
-  "enabled": true,
-  "groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "primary": true,
-  "domains": [
-    "example.com"
-  ],
-  "search_domains_enabled": true
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("PUT", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/dns/nameservers/{nsgroupId}"
-  method := "PUT"
-  
-  payload := strings.NewReader(`{
-  "name": "Google DNS",
-  "description": "Google DNS servers",
-  "nameservers": [
-    {
-      "ip": "8.8.8.8",
-      "ns_type": "udp",
-      "port": 53
-    }
-  ],
-  "enabled": true,
-  "groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "primary": true,
-  "domains": [
-    "example.com"
-  ],
-  "search_domains_enabled": true
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/dns/nameservers/{nsgroupId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Put.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "Google DNS",
-  "description": "Google DNS servers",
-  "nameservers": [
-    {
-      "ip": "8.8.8.8",
-      "ns_type": "udp",
-      "port": 53
-    }
-  ],
-  "enabled": true,
-  "groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "primary": true,
-  "domains": [
-    "example.com"
-  ],
-  "search_domains_enabled": true
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "Google DNS",
-  "description": "Google DNS servers",
-  "nameservers": [
-    {
-      "ip": "8.8.8.8",
-      "ns_type": "udp",
-      "port": 53
-    }
-  ],
-  "enabled": true,
-  "groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "primary": true,
-  "domains": [
-    "example.com"
-  ],
-  "search_domains_enabled": true
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/dns/nameservers/{nsgroupId}")
-  .method("PUT", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/dns/nameservers/{nsgroupId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'PUT',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "Google DNS",
-  "description": "Google DNS servers",
-  "nameservers": [
-    {
-      "ip": "8.8.8.8",
-      "ns_type": "udp",
-      "port": 53
-    }
-  ],
-  "enabled": true,
-  "groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "primary": true,
-  "domains": [
-    "example.com"
-  ],
-  "search_domains_enabled": true
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="PUT" label="/api/dns/nameservers/{nsgroupId}" >
 ```json {{ title: 'Example' }}
 {
-  "id": "ch8i4ug6lnn4g9hqv7m0",
-  "name": "Google DNS",
-  "description": "Google DNS servers",
+  "id": "string",
+  "name": "string",
+  "description": "string",
   "nameservers": [
     {
-      "ip": "8.8.8.8",
-      "ns_type": "udp",
-      "port": 53
+      "ip": "string",
+      "ns_type": "string",
+      "port": "integer"
     }
   ],
-  "enabled": true,
+  "enabled": "boolean",
   "groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
+    "string"
   ],
-  "primary": true,
+  "primary": "boolean",
   "domains": [
-    "example.com"
+    "string"
   ],
-  "search_domains_enabled": true
+  "search_domains_enabled": "boolean"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -1289,383 +464,118 @@ echo $response;
   "search_domains_enabled": "boolean"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Delete a Nameserver Group  {{ tag: 'DELETE' , label: '/api/dns/nameservers/{nsgroupId}' }}
+
+## Delete a Nameserver Group {{ tag: 'DELETE', label: '/api/dns/nameservers/{nsgroupId}' }}
+
 
 <Row>
-  <Col>
-    Delete a Nameserver Group
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="nsgroupId" type="string" required={true}> 
-            The unique identifier of a Nameserver Group
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="DELETE" label="/api/dns/nameservers/{nsgroupId}">
+<Col>
+Delete a Nameserver Group
+
+### Path Parameters
+
+
+<Properties>
+<Property name="nsgroupId" type="string" required={true} >
+The unique identifier of a Nameserver Group
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/dns/nameservers/{nsgroupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/dns/nameservers/{nsgroupId} \
--H 'Authorization: Token <TOKEN>' 
+-H 'Authorization: Token <TOKEN>' \
 ```
+</CodeGroup>
 
-```js
-const axios = require('axios');
+</Col>
 
-let config = {
-  method: 'delete',
-  maxBodyLength: Infinity,
-  url: '/api/dns/nameservers/{nsgroupId}',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/dns/nameservers/{nsgroupId}"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("DELETE", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/dns/nameservers/{nsgroupId}"
-  method := "DELETE"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/dns/nameservers/{nsgroupId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Delete.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/dns/nameservers/{nsgroupId}")
-  .method("DELETE")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/dns/nameservers/{nsgroupId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'DELETE',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
 </Row>
-
 ---
 
 
-## Retrieve DNS settings  {{ tag: 'GET' , label: '/api/dns/settings' }}
+
+## Retrieve DNS settings {{ tag: 'GET', label: '/api/dns/settings' }}
+
 
 <Row>
-  <Col>
-    Returns a DNS settings object
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/dns/settings">
+<Col>
+Returns a DNS settings object
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/dns/settings" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/dns/settings \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/dns/settings',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/dns/settings"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/dns/settings"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/dns/settings")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/dns/settings")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/dns/settings',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/dns/settings" >
 ```json {{ title: 'Example' }}
-{
-  "items": {
-    "disabled_management_groups": [
-      "ch8i4ug6lnn4g9hqv7m0"
-    ]
-  }
-}
-```
-```json {{ title: 'Schema' }}
-{
-  "items": {
+[
+  {
     "disabled_management_groups": [
       "string"
     ]
   }
-}
+]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
 
+```json {{ title: 'Schema' }}
+[
+  {
+    "disabled_management_groups": [
+      "string"
+    ]
+  }
+]
+```
+</CodeGroup>
+
+</Col>
+
+</Row>
 ---
 
 
-## Update DNS Settings  {{ tag: 'PUT' , label: '/api/dns/settings' }}
+
+## Update DNS Settings {{ tag: 'PUT', label: '/api/dns/settings' }}
+
 
 <Row>
-  <Col>
-    Updates a DNS settings object
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="disabled_management_groups" type="string[]" required={true}>
-        
-            Groups whose DNS management is disabled
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Updates a DNS settings object
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="PUT" label="/api/dns/settings">
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="disabled_management_groups" type="string[]" required={true} >
+Groups whose DNS management is disabled
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="PUT" label="/api/dns/settings" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/dns/settings \
 -H 'Accept: application/json' \
@@ -1677,191 +587,16 @@ curl -X PUT https://api.netbird.io/api/dns/settings \
   ]
 }'
 ```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "disabled_management_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ]
-});
-let config = {
-  method: 'put',
-  maxBodyLength: Infinity,
-  url: '/api/dns/settings',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/dns/settings"
-payload = json.dumps({
-  "disabled_management_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ]
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("PUT", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/dns/settings"
-  method := "PUT"
-  
-  payload := strings.NewReader(`{
-  "disabled_management_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ]
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/dns/settings")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Put.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "disabled_management_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ]
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "disabled_management_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ]
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/dns/settings")
-  .method("PUT", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/dns/settings',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'PUT',  
-  CURLOPT_POSTFIELDS => '{
-  "disabled_management_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ]
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="PUT" label="/api/dns/settings" >
 ```json {{ title: 'Example' }}
 {
   "disabled_management_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
+    "string"
   ]
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "disabled_management_groups": [
@@ -1869,10 +604,9 @@ echo $response;
   ]
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---

--- a/src/pages/ipa/resources/events.mdx
+++ b/src/pages/ipa/resources/events.mdx
@@ -5,12 +5,10 @@ export const title = 'Events'
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all audit events
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/events/audit" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/events/audit \
@@ -67,6 +65,7 @@ curl -X GET https://api.netbird.io/api/events/audit \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -75,8 +74,7 @@ curl -X GET https://api.netbird.io/api/events/audit \
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all network traffic events
 
 ### Query Parameters
@@ -120,8 +118,7 @@ End date for filtering events (ISO 8601 format, e.g., 2024-01-31T23:59:59Z).
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/events/network-traffic" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/events/network-traffic \
@@ -262,4 +259,5 @@ curl -X GET https://api.netbird.io/api/events/network-traffic \
 </Col>
 
 </Row>
+
 ---

--- a/src/pages/ipa/resources/events.mdx
+++ b/src/pages/ipa/resources/events.mdx
@@ -15,6 +15,141 @@ curl -X GET https://api.netbird.io/api/events/audit \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/events/audit',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/events/audit"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/events/audit"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/events/audit")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/events/audit")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/events/audit',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
 </CodeGroup>
 <CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
@@ -124,6 +259,141 @@ End date for filtering events (ISO 8601 format, e.g., 2024-01-31T23:59:59Z).
 curl -X GET https://api.netbird.io/api/events/network-traffic \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/events/network-traffic',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/events/network-traffic"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/events/network-traffic"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/events/network-traffic")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/events/network-traffic")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/events/network-traffic',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >

--- a/src/pages/ipa/resources/events.mdx
+++ b/src/pages/ipa/resources/events.mdx
@@ -18,26 +18,22 @@ curl -X GET https://api.netbird.io/api/events/audit \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/events/audit" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
-    "timestamp": "string",
-    "activity": "string",
-    "activity_code": "string",
-    "initiator_id": "string",
-    "initiator_name": "string",
-    "initiator_email": "string",
-    "target_id": "string",
+    "id": 10,
+    "timestamp": "2023-05-05T10:04:37.473542Z",
+    "activity": "Route created",
+    "activity_code": "route.add",
+    "initiator_id": "google-oauth2|123456789012345678901",
+    "initiator_name": "John Doe",
+    "initiator_email": "demo@netbird.io",
+    "target_id": "chad9d86lnnc59g18ou0",
     "meta": {
-      "type": "object",
-      "additionalProperties": "string",
-      "example": {
-        "name": "my route",
-        "network_range": "10.64.0.0/24",
-        "peer_id": "chacbco6lnnbn6cg5s91"
-      }
+      "name": "my route",
+      "network_range": "10.64.0.0/24",
+      "peer_id": "chacbco6lnnbn6cg5s91"
     }
   }
 ]
@@ -75,7 +71,7 @@ curl -X GET https://api.netbird.io/api/events/audit \
 
 
 
-## List all Traffic Events {{ tag: 'GET', label: '/api/events/network-traffic' }}
+## List all Traffic Events  <Badge  status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." />  <Badge  status="experimental" text="experimental" hoverText="This feature is experimental. The endpoint will likely change and we do not guarantee backwards compatibility." /> {{ tag: 'GET', label: '/api/events/network-traffic' }}
 
 
 <Row>
@@ -83,7 +79,7 @@ curl -X GET https://api.netbird.io/api/events/audit \
 <Col>
 Returns a list of all network traffic events
 
-### Path Parameters
+### Query Parameters
 
 
 <Properties>
@@ -133,68 +129,68 @@ curl -X GET https://api.netbird.io/api/events/network-traffic \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/events/network-traffic" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
   "data": [
     {
-      "flow_id": "string",
-      "reporter_id": "string",
+      "flow_id": "61092452-b17c-4b14-b7cf-a2158c549826",
+      "reporter_id": "ch8i4ug6lnn4g9hqv7m0",
       "source": {
-        "id": "string",
-        "type": "string",
-        "name": "string",
+        "id": "ch8i4ug6lnn4g9hqv7m0",
+        "type": "PEER",
+        "name": "My Peer",
         "geo_location": {
-          "city_name": "string",
-          "country_code": "string"
+          "city_name": "Berlin",
+          "country_code": "DE"
         },
-        "os": "string",
-        "address": "string",
-        "dns_label": "string"
+        "os": "Linux",
+        "address": "100.64.0.10:51820",
+        "dns_label": "*.mydomain.com"
       },
       "destination": {
-        "id": "string",
-        "type": "string",
-        "name": "string",
+        "id": "ch8i4ug6lnn4g9hqv7m0",
+        "type": "PEER",
+        "name": "My Peer",
         "geo_location": {
-          "city_name": "string",
-          "country_code": "string"
+          "city_name": "Berlin",
+          "country_code": "DE"
         },
-        "os": "string",
-        "address": "string",
-        "dns_label": "string"
+        "os": "Linux",
+        "address": "100.64.0.10:51820",
+        "dns_label": "*.mydomain.com"
       },
       "user": {
-        "id": "string",
-        "email": "string",
-        "name": "string"
+        "id": "google-oauth2|123456789012345678901",
+        "email": "alice@netbird.io",
+        "name": "Alice Smith"
       },
       "policy": {
-        "id": "string",
-        "name": "string"
+        "id": "ch8i4ug6lnn4g9hqv7m0",
+        "name": "All to All"
       },
       "icmp": {
-        "type": "integer",
-        "code": "integer"
+        "type": 8,
+        "code": 0
       },
-      "protocol": "integer",
-      "direction": "string",
-      "rx_bytes": "integer",
-      "rx_packets": "integer",
-      "tx_bytes": "integer",
-      "tx_packets": "integer",
+      "protocol": 6,
+      "direction": "INGRESS",
+      "rx_bytes": 1234,
+      "rx_packets": 5,
+      "tx_bytes": 1234,
+      "tx_packets": 5,
       "events": [
         {
-          "type": "string",
-          "timestamp": "string"
+          "type": "TYPE_START",
+          "timestamp": "2025-03-20T16:23:58.125397Z"
         }
       ]
     }
   ],
-  "page": "integer",
-  "page_size": "integer",
-  "total_records": "integer",
-  "total_pages": "integer"
+  "page": 0,
+  "page_size": 0,
+  "total_records": 0,
+  "total_pages": 0
 }
 ```
 

--- a/src/pages/ipa/resources/events.mdx
+++ b/src/pages/ipa/resources/events.mdx
@@ -1,183 +1,48 @@
 export const title = 'Events'
 
 
+## List all Audit Events {{ tag: 'GET', label: '/api/events/audit' }}
 
-## List all Audit Events  {{ tag: 'GET' , label: '/api/events/audit' }}
 
 <Row>
-  <Col>
-    Returns a list of all audit events
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/events/audit">
+<Col>
+Returns a list of all audit events
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/events/audit" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/events/audit \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/events/audit',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/events/audit"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/events/audit"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/events/audit")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/events/audit")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/events/audit',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/events/audit" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": 10,
-    "timestamp": "2023-05-05T10:04:37.473542Z",
-    "activity": "Route created",
-    "activity_code": "route.add",
-    "initiator_id": "google-oauth2|123456789012345678901",
-    "initiator_name": "John Doe",
-    "initiator_email": "demo@netbird.io",
-    "target_id": "chad9d86lnnc59g18ou0",
+    "id": "string",
+    "timestamp": "string",
+    "activity": "string",
+    "activity_code": "string",
+    "initiator_id": "string",
+    "initiator_name": "string",
+    "initiator_email": "string",
+    "target_id": "string",
     "meta": {
-      "name": "my route",
-      "network_range": "10.64.0.0/24",
-      "peer_id": "chacbco6lnnbn6cg5s91"
+      "type": "object",
+      "additionalProperties": "string",
+      "example": {
+        "name": "my route",
+        "network_range": "10.64.0.0/24",
+        "peer_id": "chacbco6lnnbn6cg5s91"
+      }
     }
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -190,7 +55,6 @@ echo $response;
     "initiator_email": "string",
     "target_id": "string",
     "meta": {
-      "description": "The metadata of the event",
       "type": "object",
       "additionalProperties": "string",
       "example": {
@@ -202,295 +66,138 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## List all Traffic Events  <Badge status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." />  <Badge status="experimental" text="experimental" hoverText="This feature is experimental. The endpoint will likely change and we do not guarantee backwards compatibility." />  {{ tag: 'GET' , label: '/api/events/network-traffic' }}
+
+## List all Traffic Events {{ tag: 'GET', label: '/api/events/network-traffic' }}
+
 
 <Row>
-  <Col>
-    Returns a list of all network traffic events
-        
-    ### Query Parameters
-    <Properties>
-        
-            <Property name="page" type="integer" required={false}>
-              Page number
-            </Property>
-        
-            <Property name="page_size" type="integer" required={false}>
-              Number of items per page
-            </Property>
-        
-            <Property name="user_id" type="string" required={false}>
-              Filter by user ID
-            </Property>
-        
-            <Property name="reporter_id" type="string" required={false}>
-              Filter by reporter ID
-            </Property>
-        
-            <Property name="protocol" type="integer" required={false}>
-              Filter by protocol
-            </Property>
-        
-            <Property name="type" type="string" required={false}>
-              Filter by event type
-            </Property>
-        
-            <Property name="connection_type" type="string" required={false}>
-              Filter by connection type
-            </Property>
-        
-            <Property name="direction" type="string" required={false}>
-              Filter by direction
-            </Property>
-        
-            <Property name="search" type="string" required={false}>
-              Case-insensitive partial match on user email, source/destination names, and source/destination addresses
-            </Property>
-        
-            <Property name="start_date" type="string" required={false}>
-              Start date for filtering events (ISO 8601 format, e.g., 2024-01-01T00:00:00Z).
-            </Property>
-        
-            <Property name="end_date" type="string" required={false}>
-              End date for filtering events (ISO 8601 format, e.g., 2024-01-31T23:59:59Z).
-            </Property>
-            </Properties>
-          </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/events/network-traffic">
+<Col>
+Returns a list of all network traffic events
+
+### Path Parameters
+
+
+<Properties>
+<Property name="page" type="integer" >
+Page number
+</Property>
+<Property name="page_size" type="integer" >
+Number of items per page
+</Property>
+<Property name="user_id" type="string" >
+Filter by user ID
+</Property>
+<Property name="reporter_id" type="string" >
+Filter by reporter ID
+</Property>
+<Property name="protocol" type="integer" >
+Filter by protocol
+</Property>
+<Property name="type" type="string" >
+Filter by event type
+</Property>
+<Property name="connection_type" type="string" >
+Filter by connection type
+</Property>
+<Property name="direction" type="string" >
+Filter by direction
+</Property>
+<Property name="search" type="string" >
+Case-insensitive partial match on user email, source/destination names, and source/destination addresses
+</Property>
+<Property name="start_date" type="string" >
+Start date for filtering events (ISO 8601 format, e.g., 2024-01-01T00:00:00Z).
+</Property>
+<Property name="end_date" type="string" >
+End date for filtering events (ISO 8601 format, e.g., 2024-01-31T23:59:59Z).
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/events/network-traffic" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/events/network-traffic \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/events/network-traffic',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/events/network-traffic"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/events/network-traffic"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/events/network-traffic")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/events/network-traffic")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/events/network-traffic',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/events/network-traffic" >
 ```json {{ title: 'Example' }}
 {
   "data": [
     {
-      "flow_id": "61092452-b17c-4b14-b7cf-a2158c549826",
-      "reporter_id": "ch8i4ug6lnn4g9hqv7m0",
+      "flow_id": "string",
+      "reporter_id": "string",
       "source": {
-        "id": "ch8i4ug6lnn4g9hqv7m0",
-        "type": "PEER",
-        "name": "My Peer",
+        "id": "string",
+        "type": "string",
+        "name": "string",
         "geo_location": {
-          "city_name": "Berlin",
-          "country_code": "DE"
+          "city_name": "string",
+          "country_code": "string"
         },
-        "os": "Linux",
-        "address": "100.64.0.10:51820",
-        "dns_label": "*.mydomain.com"
+        "os": "string",
+        "address": "string",
+        "dns_label": "string"
       },
       "destination": {
-        "id": "ch8i4ug6lnn4g9hqv7m0",
-        "type": "PEER",
-        "name": "My Peer",
+        "id": "string",
+        "type": "string",
+        "name": "string",
         "geo_location": {
-          "city_name": "Berlin",
-          "country_code": "DE"
+          "city_name": "string",
+          "country_code": "string"
         },
-        "os": "Linux",
-        "address": "100.64.0.10:51820",
-        "dns_label": "*.mydomain.com"
+        "os": "string",
+        "address": "string",
+        "dns_label": "string"
       },
       "user": {
-        "id": "google-oauth2|123456789012345678901",
-        "email": "alice@netbird.io",
-        "name": "Alice Smith"
+        "id": "string",
+        "email": "string",
+        "name": "string"
       },
       "policy": {
-        "id": "ch8i4ug6lnn4g9hqv7m0",
-        "name": "All to All"
+        "id": "string",
+        "name": "string"
       },
       "icmp": {
-        "type": 8,
-        "code": 0
+        "type": "integer",
+        "code": "integer"
       },
-      "protocol": 6,
-      "direction": "INGRESS",
-      "rx_bytes": 1234,
-      "rx_packets": 5,
-      "tx_bytes": 1234,
-      "tx_packets": 5,
+      "protocol": "integer",
+      "direction": "string",
+      "rx_bytes": "integer",
+      "rx_packets": "integer",
+      "tx_bytes": "integer",
+      "tx_packets": "integer",
       "events": [
         {
-          "type": "TYPE_START",
-          "timestamp": {}
+          "type": "string",
+          "timestamp": "string"
         }
       ]
     }
   ],
-  "page": {
-    "type": "integer",
-    "description": "Current page number"
-  },
-  "page_size": {
-    "type": "integer",
-    "description": "Number of items per page"
-  },
-  "total_records": {
-    "type": "integer",
-    "description": "Total number of event records available"
-  },
-  "total_pages": {
-    "type": "integer",
-    "description": "Total number of pages available"
-  }
+  "page": "integer",
+  "page_size": "integer",
+  "total_records": "integer",
+  "total_pages": "integer"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "data": [
@@ -554,10 +261,9 @@ echo $response;
   "total_pages": "integer"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---

--- a/src/pages/ipa/resources/geo-locations.mdx
+++ b/src/pages/ipa/resources/geo-locations.mdx
@@ -5,12 +5,10 @@ export const title = 'Geo Locations'
 
 
 <Row>
-
-<Col>
+ <Col>
 Get list of all country in 2-letter ISO 3166-1 alpha-2 codes
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/locations/countries" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/locations/countries \
@@ -35,6 +33,7 @@ curl -X GET https://api.netbird.io/api/locations/countries \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -43,8 +42,7 @@ curl -X GET https://api.netbird.io/api/locations/countries \
 
 
 <Row>
-
-<Col>
+ <Col>
 Get a list of all English city names for a given country code
 
 ### Path Parameters
@@ -58,8 +56,7 @@ Get a list of all English city names for a given country code
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/locations/countries/{country}/cities" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/locations/countries/{country}/cities \
@@ -86,4 +83,5 @@ curl -X GET https://api.netbird.io/api/locations/countries/{country}/cities \
 </Col>
 
 </Row>
+
 ---

--- a/src/pages/ipa/resources/geo-locations.mdx
+++ b/src/pages/ipa/resources/geo-locations.mdx
@@ -15,6 +15,141 @@ curl -X GET https://api.netbird.io/api/locations/countries \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/locations/countries',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/locations/countries"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/locations/countries"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/locations/countries")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/locations/countries")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/locations/countries',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
 </CodeGroup>
 <CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
@@ -62,6 +197,141 @@ Get a list of all English city names for a given country code
 curl -X GET https://api.netbird.io/api/locations/countries/{country}/cities \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/locations/countries/{country}/cities',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/locations/countries/{country}/cities"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/locations/countries/{country}/cities"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/locations/countries/{country}/cities")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/locations/countries/{country}/cities")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/locations/countries/{country}/cities',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >

--- a/src/pages/ipa/resources/geo-locations.mdx
+++ b/src/pages/ipa/resources/geo-locations.mdx
@@ -18,10 +18,10 @@ curl -X GET https://api.netbird.io/api/locations/countries \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/locations/countries" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
-  "string"
+  "DE"
 ]
 ```
 
@@ -67,11 +67,11 @@ curl -X GET https://api.netbird.io/api/locations/countries/{country}/cities \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/locations/countries/{country}/cities" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "geoname_id": "integer",
-  "city_name": "string"
+  "geoname_id": 2950158,
+  "city_name": "Berlin"
 }
 ```
 

--- a/src/pages/ipa/resources/geo-locations.mdx
+++ b/src/pages/ipa/resources/geo-locations.mdx
@@ -1,364 +1,89 @@
 export const title = 'Geo Locations'
 
 
+## List all country codes {{ tag: 'GET', label: '/api/locations/countries' }}
 
-## List all country codes  {{ tag: 'GET' , label: '/api/locations/countries' }}
 
 <Row>
-  <Col>
-    Get list of all country in 2-letter ISO 3166-1 alpha-2 codes
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/locations/countries">
+<Col>
+Get list of all country in 2-letter ISO 3166-1 alpha-2 codes
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/locations/countries" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/locations/countries \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/locations/countries',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/locations/countries"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/locations/countries"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/locations/countries")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/locations/countries")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/locations/countries',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/locations/countries" >
 ```json {{ title: 'Example' }}
 [
-  "DE"
+  "string"
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   "string"
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## List all city names by country  {{ tag: 'GET' , label: '/api/locations/countries/{country}/cities' }}
+
+## List all city names by country {{ tag: 'GET', label: '/api/locations/countries/{country}/cities' }}
+
 
 <Row>
-  <Col>
-    Get a list of all English city names for a given country code
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="country" type="string" required={true}> 
-            
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/locations/countries/{country}/cities">
+<Col>
+Get a list of all English city names for a given country code
+
+### Path Parameters
+
+
+<Properties>
+<Property name="country" required={true} >
+
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/locations/countries/{country}/cities" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/locations/countries/{country}/cities \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/locations/countries/{country}/cities',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/locations/countries/{country}/cities"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/locations/countries/{country}/cities"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/locations/countries/{country}/cities")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/locations/countries/{country}/cities")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/locations/countries/{country}/cities',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/locations/countries/{country}/cities" >
 ```json {{ title: 'Example' }}
 {
-  "geoname_id": 2950158,
-  "city_name": "Berlin"
+  "geoname_id": "integer",
+  "city_name": "string"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "geoname_id": "integer",
   "city_name": "string"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---

--- a/src/pages/ipa/resources/groups.mdx
+++ b/src/pages/ipa/resources/groups.mdx
@@ -1,187 +1,48 @@
 export const title = 'Groups'
 
 
+## List all Groups {{ tag: 'GET', label: '/api/groups' }}
 
-## List all Groups  {{ tag: 'GET' , label: '/api/groups' }}
 
 <Row>
-  <Col>
-    Returns a list of all groups
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/groups">
+<Col>
+Returns a list of all groups
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/groups" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/groups \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/groups',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/groups"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/groups"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/groups")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/groups")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/groups',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/groups" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "ch8i4ug6lnn4g9hqv7m0",
-    "name": "devs",
-    "peers_count": 2,
-    "resources_count": 5,
-    "issued": "api",
+    "id": "string",
+    "name": "string",
+    "peers_count": "integer",
+    "resources_count": "integer",
+    "issued": "string",
     "peers": [
       {
-        "id": "chacbco6lnnbn6cg5s90",
-        "name": "stage-host-1"
+        "id": "string",
+        "name": "string"
       }
     ],
     "resources": [
       {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
+        "id": "string",
+        "type": "string"
       }
     ]
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -205,71 +66,77 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Create a Group  {{ tag: 'POST' , label: '/api/groups' }}
+
+## Create a Group {{ tag: 'POST', label: '/api/groups' }}
+
 
 <Row>
-  <Col>
-    Creates a group
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true}>
-        
-            Group name identifier
-        
-        </Property>
-    <Property name="peers" type="string[]" required={false}>
-        
-            List of peers ids
-        
-        </Property>
-    <Property name="resources" type="object[]" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>More Information</summary>
-                <Properties>
-                
-                    <Properties><Property name="id" type="string" required={true}>
-        
-            ID of the resource
-        
-        </Property>
-    <Property name="type" type="string" required={true} enumList={["host","subnet","domain"]}>
-        
-            Network resource type based of the address
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Creates a group
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/api/groups">
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="name" type="string" required={true} >
+Group name identifier
+</Property>
+<Property name="peers" type="string[]" >
+List of peers ids
+</Property>
+<Property name="resources" type="object[]" >
+
+<details class="custom-details" open >
+
+<summary>Object list</summary>
+<Properties>
+
+<Properties>
+<Property name="id" type="string" required={true} >
+ID of the resource
+</Property>
+<Property name="type" type="object" required={true} >
+Type of the resource
+</Property>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="POST" label="/api/groups" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/groups \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "id": "ch8i4ug6lnn4g9hqv7m0",
   "name": "devs",
+  "peers_count": 2,
+  "resources_count": 5,
+  "issued": "api",
   "peers": [
-    "ch8i4ug6lnn4g9hqv7m1"
+    {
+      "id": "chacbco6lnnbn6cg5s90",
+      "name": "stage-host-1"
+    }
   ],
   "resources": [
     {
@@ -279,247 +146,30 @@ curl -X POST https://api.netbird.io/api/groups \
   ]
 }'
 ```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "devs",
-  "peers": [
-    "ch8i4ug6lnn4g9hqv7m1"
-  ],
-  "resources": [
-    {
-      "id": "chacdk86lnnboviihd7g",
-      "type": "host"
-    }
-  ]
-});
-let config = {
-  method: 'post',
-  maxBodyLength: Infinity,
-  url: '/api/groups',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/groups"
-payload = json.dumps({
-  "name": "devs",
-  "peers": [
-    "ch8i4ug6lnn4g9hqv7m1"
-  ],
-  "resources": [
-    {
-      "id": "chacdk86lnnboviihd7g",
-      "type": "host"
-    }
-  ]
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("POST", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/groups"
-  method := "POST"
-  
-  payload := strings.NewReader(`{
-  "name": "devs",
-  "peers": [
-    "ch8i4ug6lnn4g9hqv7m1"
-  ],
-  "resources": [
-    {
-      "id": "chacdk86lnnboviihd7g",
-      "type": "host"
-    }
-  ]
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/groups")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Post.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "devs",
-  "peers": [
-    "ch8i4ug6lnn4g9hqv7m1"
-  ],
-  "resources": [
-    {
-      "id": "chacdk86lnnboviihd7g",
-      "type": "host"
-    }
-  ]
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "devs",
-  "peers": [
-    "ch8i4ug6lnn4g9hqv7m1"
-  ],
-  "resources": [
-    {
-      "id": "chacdk86lnnboviihd7g",
-      "type": "host"
-    }
-  ]
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/groups")
-  .method("POST", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/groups',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'POST',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "devs",
-  "peers": [
-    "ch8i4ug6lnn4g9hqv7m1"
-  ],
-  "resources": [
-    {
-      "id": "chacdk86lnnboviihd7g",
-      "type": "host"
-    }
-  ]
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="POST" label="/api/groups" >
 ```json {{ title: 'Example' }}
 {
-  "id": "ch8i4ug6lnn4g9hqv7m0",
-  "name": "devs",
-  "peers_count": 2,
-  "resources_count": 5,
-  "issued": "api",
+  "id": "string",
+  "name": "string",
+  "peers_count": "integer",
+  "resources_count": "integer",
+  "issued": "string",
   "peers": [
     {
-      "id": "chacbco6lnnbn6cg5s90",
-      "name": "stage-host-1"
+      "id": "string",
+      "name": "string"
     }
   ],
   "resources": [
     {
-      "id": "chacdk86lnnboviihd7g",
-      "type": "host"
+      "id": "string",
+      "type": "string"
     }
   ]
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -541,201 +191,66 @@ echo $response;
   ]
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Retrieve a Group  {{ tag: 'GET' , label: '/api/groups/{groupId}' }}
+
+## Retrieve a Group {{ tag: 'GET', label: '/api/groups/{groupId}' }}
+
 
 <Row>
-  <Col>
-    Get information about a group
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="groupId" type="string" required={true}> 
-            The unique identifier of a group
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/groups/{groupId}">
+<Col>
+Get information about a group
+
+### Path Parameters
+
+
+<Properties>
+<Property name="groupId" type="string" required={true} >
+The unique identifier of a group
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/groups/{groupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/groups/{groupId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/groups/{groupId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/groups/{groupId}"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/groups/{groupId}"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/groups/{groupId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/groups/{groupId}")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/groups/{groupId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/groups/{groupId}" >
 ```json {{ title: 'Example' }}
 {
-  "id": "ch8i4ug6lnn4g9hqv7m0",
-  "name": "devs",
-  "peers_count": 2,
-  "resources_count": 5,
-  "issued": "api",
+  "id": "string",
+  "name": "string",
+  "peers_count": "integer",
+  "resources_count": "integer",
+  "issued": "string",
   "peers": [
     {
-      "id": "chacbco6lnnbn6cg5s90",
-      "name": "stage-host-1"
+      "id": "string",
+      "name": "string"
     }
   ],
   "resources": [
     {
-      "id": "chacdk86lnnboviihd7g",
-      "type": "host"
+      "id": "string",
+      "type": "string"
     }
   ]
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -757,310 +272,78 @@ echo $response;
   ]
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Update a Group  {{ tag: 'PUT' , label: '/api/groups/{groupId}' }}
+
+## Update a Group {{ tag: 'PUT', label: '/api/groups/{groupId}' }}
+
 
 <Row>
-  <Col>
-    Update/Replace a group
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="groupId" type="string" required={true}> 
-            The unique identifier of a group
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true}>
-        
-            Group name identifier
-        
-        </Property>
-    <Property name="peers" type="string[]" required={false}>
-        
-            List of peers ids
-        
-        </Property>
-    <Property name="resources" type="object[]" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>More Information</summary>
-                <Properties>
-                
-                    <Properties><Property name="id" type="string" required={true}>
-        
-            ID of the resource
-        
-        </Property>
-    <Property name="type" type="string" required={true} enumList={["host","subnet","domain"]}>
-        
-            Network resource type based of the address
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Update/Replace a group
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="PUT" label="/api/groups/{groupId}">
+### Path Parameters
+
+
+<Properties>
+<Property name="groupId" type="string" required={true} >
+The unique identifier of a group
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="name" type="string" required={true} >
+Group name identifier
+</Property>
+<Property name="peers" type="string[]" >
+List of peers ids
+</Property>
+<Property name="resources" type="object[]" >
+
+<details class="custom-details" open >
+
+<summary>Object list</summary>
+<Properties>
+
+<Properties>
+<Property name="id" type="string" required={true} >
+ID of the resource
+</Property>
+<Property name="type" type="object" required={true} >
+Type of the resource
+</Property>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="PUT" label="/api/groups/{groupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/groups/{groupId} \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "name": "devs",
-  "peers": [
-    "ch8i4ug6lnn4g9hqv7m1"
-  ],
-  "resources": [
-    {
-      "id": "chacdk86lnnboviihd7g",
-      "type": "host"
-    }
-  ]
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "devs",
-  "peers": [
-    "ch8i4ug6lnn4g9hqv7m1"
-  ],
-  "resources": [
-    {
-      "id": "chacdk86lnnboviihd7g",
-      "type": "host"
-    }
-  ]
-});
-let config = {
-  method: 'put',
-  maxBodyLength: Infinity,
-  url: '/api/groups/{groupId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/groups/{groupId}"
-payload = json.dumps({
-  "name": "devs",
-  "peers": [
-    "ch8i4ug6lnn4g9hqv7m1"
-  ],
-  "resources": [
-    {
-      "id": "chacdk86lnnboviihd7g",
-      "type": "host"
-    }
-  ]
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("PUT", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/groups/{groupId}"
-  method := "PUT"
-  
-  payload := strings.NewReader(`{
-  "name": "devs",
-  "peers": [
-    "ch8i4ug6lnn4g9hqv7m1"
-  ],
-  "resources": [
-    {
-      "id": "chacdk86lnnboviihd7g",
-      "type": "host"
-    }
-  ]
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/groups/{groupId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Put.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "devs",
-  "peers": [
-    "ch8i4ug6lnn4g9hqv7m1"
-  ],
-  "resources": [
-    {
-      "id": "chacdk86lnnboviihd7g",
-      "type": "host"
-    }
-  ]
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "devs",
-  "peers": [
-    "ch8i4ug6lnn4g9hqv7m1"
-  ],
-  "resources": [
-    {
-      "id": "chacdk86lnnboviihd7g",
-      "type": "host"
-    }
-  ]
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/groups/{groupId}")
-  .method("PUT", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/groups/{groupId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'PUT',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "devs",
-  "peers": [
-    "ch8i4ug6lnn4g9hqv7m1"
-  ],
-  "resources": [
-    {
-      "id": "chacdk86lnnboviihd7g",
-      "type": "host"
-    }
-  ]
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": "ch8i4ug6lnn4g9hqv7m0",
   "name": "devs",
   "peers_count": 2,
@@ -1078,8 +361,32 @@ echo $response;
       "type": "host"
     }
   ]
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="PUT" label="/api/groups/{groupId}" >
+```json {{ title: 'Example' }}
+{
+  "id": "string",
+  "name": "string",
+  "peers_count": "integer",
+  "resources_count": "integer",
+  "issued": "string",
+  "peers": [
+    {
+      "id": "string",
+      "name": "string"
+    }
+  ],
+  "resources": [
+    {
+      "id": "string",
+      "type": "string"
+    }
+  ]
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -1101,174 +408,44 @@ echo $response;
   ]
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Delete a Group  {{ tag: 'DELETE' , label: '/api/groups/{groupId}' }}
+
+## Delete a Group {{ tag: 'DELETE', label: '/api/groups/{groupId}' }}
+
 
 <Row>
-  <Col>
-    Delete a group
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="groupId" type="string" required={true}> 
-            The unique identifier of a group
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="DELETE" label="/api/groups/{groupId}">
+<Col>
+Delete a group
+
+### Path Parameters
+
+
+<Properties>
+<Property name="groupId" type="string" required={true} >
+The unique identifier of a group
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/groups/{groupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/groups/{groupId} \
--H 'Authorization: Token <TOKEN>' 
+-H 'Authorization: Token <TOKEN>' \
 ```
+</CodeGroup>
 
-```js
-const axios = require('axios');
+</Col>
 
-let config = {
-  method: 'delete',
-  maxBodyLength: Infinity,
-  url: '/api/groups/{groupId}',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/groups/{groupId}"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("DELETE", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/groups/{groupId}"
-  method := "DELETE"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/groups/{groupId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Delete.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/groups/{groupId}")
-  .method("DELETE")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/groups/{groupId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'DELETE',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
 </Row>
-
 ---

--- a/src/pages/ipa/resources/groups.mdx
+++ b/src/pages/ipa/resources/groups.mdx
@@ -5,12 +5,10 @@ export const title = 'Groups'
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all groups
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/groups" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/groups \
@@ -71,6 +69,7 @@ curl -X GET https://api.netbird.io/api/groups \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -79,8 +78,7 @@ curl -X GET https://api.netbird.io/api/groups \
 
 
 <Row>
-
-<Col>
+ <Col>
 Creates a group
 
 ### Request-Body Parameters
@@ -94,8 +92,7 @@ Group name identifier
 List of peers ids
 </Property>
 <Property name="resources" type="object[]" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>More Information</summary>
 <Properties>
@@ -109,13 +106,13 @@ Network resource type based of the address
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="POST" label="/api/groups" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/groups \
@@ -185,6 +182,7 @@ curl -X POST https://api.netbird.io/api/groups \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -193,8 +191,7 @@ curl -X POST https://api.netbird.io/api/groups \
 
 
 <Row>
-
-<Col>
+ <Col>
 Get information about a group
 
 ### Path Parameters
@@ -208,8 +205,7 @@ The unique identifier of a group
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/groups/{groupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/groups/{groupId} \
@@ -266,6 +262,7 @@ curl -X GET https://api.netbird.io/api/groups/{groupId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -274,8 +271,7 @@ curl -X GET https://api.netbird.io/api/groups/{groupId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Update/Replace a group
 
 ### Path Parameters
@@ -300,8 +296,7 @@ Group name identifier
 List of peers ids
 </Property>
 <Property name="resources" type="object[]" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>More Information</summary>
 <Properties>
@@ -315,13 +310,13 @@ Network resource type based of the address
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="PUT" label="/api/groups/{groupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/groups/{groupId} \
@@ -391,6 +386,7 @@ curl -X PUT https://api.netbird.io/api/groups/{groupId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -399,8 +395,7 @@ curl -X PUT https://api.netbird.io/api/groups/{groupId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Delete a group
 
 ### Path Parameters
@@ -414,8 +409,7 @@ The unique identifier of a group
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/groups/{groupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/groups/{groupId} \
@@ -426,4 +420,5 @@ curl -X DELETE https://api.netbird.io/api/groups/{groupId} \
 </Col>
 
 </Row>
+
 ---

--- a/src/pages/ipa/resources/groups.mdx
+++ b/src/pages/ipa/resources/groups.mdx
@@ -18,25 +18,25 @@ curl -X GET https://api.netbird.io/api/groups \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/groups" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
-    "name": "string",
-    "peers_count": "integer",
-    "resources_count": "integer",
-    "issued": "string",
+    "id": "ch8i4ug6lnn4g9hqv7m0",
+    "name": "devs",
+    "peers_count": 2,
+    "resources_count": 5,
+    "issued": "api",
     "peers": [
       {
-        "id": "string",
-        "name": "string"
+        "id": "chacbco6lnnbn6cg5s90",
+        "name": "stage-host-1"
       }
     ],
     "resources": [
       {
-        "id": "string",
-        "type": "string"
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
       }
     ]
   }
@@ -97,18 +97,14 @@ List of peers ids
 
 <details class="custom-details" open >
 
-<summary>Object list</summary>
-<Properties>
-
+<summary>More Information</summary>
 <Properties>
 <Property name="id" type="string" required={true} >
 ID of the resource
 </Property>
-<Property name="type" type="object" required={true} >
-Type of the resource
+<Property name="type" type="string" required={true} >
+Network resource type based of the address
 </Property>
-
-</Properties>
 
 </Properties>
 
@@ -123,10 +119,26 @@ Type of the resource
 <CodeGroup title="Request" tag="POST" label="/api/groups" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/groups \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "name": "devs",
+  "peers": [
+    "ch8i4ug6lnn4g9hqv7m1"
+  ],
+  "resources": [
+    {
+      "id": "chacdk86lnnboviihd7g",
+      "type": "host"
+    }
+  ]
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "ch8i4ug6lnn4g9hqv7m0",
   "name": "devs",
   "peers_count": 2,
@@ -142,29 +154,6 @@ curl -X POST https://api.netbird.io/api/groups \
     {
       "id": "chacdk86lnnboviihd7g",
       "type": "host"
-    }
-  ]
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="POST" label="/api/groups" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "name": "string",
-  "peers_count": "integer",
-  "resources_count": "integer",
-  "issued": "string",
-  "peers": [
-    {
-      "id": "string",
-      "name": "string"
-    }
-  ],
-  "resources": [
-    {
-      "id": "string",
-      "type": "string"
     }
   ]
 }
@@ -228,24 +217,24 @@ curl -X GET https://api.netbird.io/api/groups/{groupId} \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/groups/{groupId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "name": "string",
-  "peers_count": "integer",
-  "resources_count": "integer",
-  "issued": "string",
+  "id": "ch8i4ug6lnn4g9hqv7m0",
+  "name": "devs",
+  "peers_count": 2,
+  "resources_count": 5,
+  "issued": "api",
   "peers": [
     {
-      "id": "string",
-      "name": "string"
+      "id": "chacbco6lnnbn6cg5s90",
+      "name": "stage-host-1"
     }
   ],
   "resources": [
     {
-      "id": "string",
-      "type": "string"
+      "id": "chacdk86lnnboviihd7g",
+      "type": "host"
     }
   ]
 }
@@ -314,18 +303,14 @@ List of peers ids
 
 <details class="custom-details" open >
 
-<summary>Object list</summary>
-<Properties>
-
+<summary>More Information</summary>
 <Properties>
 <Property name="id" type="string" required={true} >
 ID of the resource
 </Property>
-<Property name="type" type="object" required={true} >
-Type of the resource
+<Property name="type" type="string" required={true} >
+Network resource type based of the address
 </Property>
-
-</Properties>
 
 </Properties>
 
@@ -340,10 +325,26 @@ Type of the resource
 <CodeGroup title="Request" tag="PUT" label="/api/groups/{groupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/groups/{groupId} \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "name": "devs",
+  "peers": [
+    "ch8i4ug6lnn4g9hqv7m1"
+  ],
+  "resources": [
+    {
+      "id": "chacdk86lnnboviihd7g",
+      "type": "host"
+    }
+  ]
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "ch8i4ug6lnn4g9hqv7m0",
   "name": "devs",
   "peers_count": 2,
@@ -359,29 +360,6 @@ curl -X PUT https://api.netbird.io/api/groups/{groupId} \
     {
       "id": "chacdk86lnnboviihd7g",
       "type": "host"
-    }
-  ]
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="PUT" label="/api/groups/{groupId}" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "name": "string",
-  "peers_count": "integer",
-  "resources_count": "integer",
-  "issued": "string",
-  "peers": [
-    {
-      "id": "string",
-      "name": "string"
-    }
-  ],
-  "resources": [
-    {
-      "id": "string",
-      "type": "string"
     }
   ]
 }

--- a/src/pages/ipa/resources/groups.mdx
+++ b/src/pages/ipa/resources/groups.mdx
@@ -15,6 +15,141 @@ curl -X GET https://api.netbird.io/api/groups \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/groups',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/groups"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/groups"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/groups")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/groups")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/groups',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
 </CodeGroup>
 <CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
@@ -116,9 +251,9 @@ Network resource type based of the address
 <CodeGroup title="Request" tag="POST" label="/api/groups" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/groups \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "devs",
   "peers": [
@@ -131,6 +266,220 @@ curl -X POST https://api.netbird.io/api/groups \
     }
   ]
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "devs",
+  "peers": [
+    "ch8i4ug6lnn4g9hqv7m1"
+  ],
+  "resources": [
+    {
+      "id": "chacdk86lnnboviihd7g",
+      "type": "host"
+    }
+  ]
+});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/groups',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/groups"
+payload = json.dumps({
+  "name": "devs",
+  "peers": [
+    "ch8i4ug6lnn4g9hqv7m1"
+  ],
+  "resources": [
+    {
+      "id": "chacdk86lnnboviihd7g",
+      "type": "host"
+    }
+  ]
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/groups"
+  method := "POST"
+  
+  payload := strings.NewReader(`{
+  "name": "devs",
+  "peers": [
+    "ch8i4ug6lnn4g9hqv7m1"
+  ],
+  "resources": [
+    {
+      "id": "chacdk86lnnboviihd7g",
+      "type": "host"
+    }
+  ]
+}`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/groups")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "devs",
+  "peers": [
+    "ch8i4ug6lnn4g9hqv7m1"
+  ],
+  "resources": [
+    {
+      "id": "chacdk86lnnboviihd7g",
+      "type": "host"
+    }
+  ]
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{
+  \"name\": \"devs\",
+  \"peers\": [
+    \"ch8i4ug6lnn4g9hqv7m1\"
+  ],
+  \"resources\": [
+    {
+      \"id\": \"chacdk86lnnboviihd7g\",
+      \"type\": \"host\"
+    }
+  ]
+}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/groups")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/groups',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "devs",
+  "peers": [
+    "ch8i4ug6lnn4g9hqv7m1"
+  ],
+  "resources": [
+    {
+      "id": "chacdk86lnnboviihd7g",
+      "type": "host"
+    }
+  ]
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -211,6 +560,141 @@ The unique identifier of a group
 curl -X GET https://api.netbird.io/api/groups/{groupId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/groups/{groupId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/groups/{groupId}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/groups/{groupId}"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/groups/{groupId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/groups/{groupId}")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/groups/{groupId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -320,9 +804,9 @@ Network resource type based of the address
 <CodeGroup title="Request" tag="PUT" label="/api/groups/{groupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/groups/{groupId} \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "devs",
   "peers": [
@@ -335,6 +819,220 @@ curl -X PUT https://api.netbird.io/api/groups/{groupId} \
     }
   ]
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "devs",
+  "peers": [
+    "ch8i4ug6lnn4g9hqv7m1"
+  ],
+  "resources": [
+    {
+      "id": "chacdk86lnnboviihd7g",
+      "type": "host"
+    }
+  ]
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/groups/{groupId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/groups/{groupId}"
+payload = json.dumps({
+  "name": "devs",
+  "peers": [
+    "ch8i4ug6lnn4g9hqv7m1"
+  ],
+  "resources": [
+    {
+      "id": "chacdk86lnnboviihd7g",
+      "type": "host"
+    }
+  ]
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/groups/{groupId}"
+  method := "PUT"
+  
+  payload := strings.NewReader({
+  "name": "devs",
+  "peers": [
+    "ch8i4ug6lnn4g9hqv7m1"
+  ],
+  "resources": [
+    {
+      "id": "chacdk86lnnboviihd7g",
+      "type": "host"
+    }
+  ]
+})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/groups/{groupId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "devs",
+  "peers": [
+    "ch8i4ug6lnn4g9hqv7m1"
+  ],
+  "resources": [
+    {
+      "id": "chacdk86lnnboviihd7g",
+      "type": "host"
+    }
+  ]
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "name": "devs",
+  "peers": [
+    "ch8i4ug6lnn4g9hqv7m1"
+  ],
+  "resources": [
+    {
+      "id": "chacdk86lnnboviihd7g",
+      "type": "host"
+    }
+  ]
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/groups/{groupId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/groups/{groupId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "devs",
+  "peers": [
+    "ch8i4ug6lnn4g9hqv7m1"
+  ],
+  "resources": [
+    {
+      "id": "chacdk86lnnboviihd7g",
+      "type": "host"
+    }
+  ]
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -413,7 +1111,131 @@ The unique identifier of a group
 <CodeGroup title="Request" tag="DELETE" label="/api/groups/{groupId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/groups/{groupId} \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/groups/{groupId}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/groups/{groupId}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/groups/{groupId}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/groups/{groupId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/groups/{groupId}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/groups/{groupId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 

--- a/src/pages/ipa/resources/ingress-ports.mdx
+++ b/src/pages/ipa/resources/ingress-ports.mdx
@@ -1,201 +1,60 @@
 export const title = 'Ingress Ports'
 
 
+## List all Port Allocations {{ tag: 'GET', label: '/api/peers/{peerId}/ingress/ports' }}
 
-## List all Port Allocations  <Badge status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." />  {{ tag: 'GET' , label: '/api/peers/{peerId}/ingress/ports' }}
 
 <Row>
-  <Col>
-    Returns a list of all ingress port allocations for a peer
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="peerId" type="string" required={true}> 
-            The unique identifier of a peer
-          </Property>   
-            </Properties>
-        
-    ### Query Parameters
-    <Properties>
-        
-            <Property name="name" type="string" required={false}>
-              Filters ingress port allocations by name
-            </Property>
-            </Properties>
-          </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/peers/{peerId}/ingress/ports">
+<Col>
+Returns a list of all ingress port allocations for a peer
+
+### Path Parameters
+
+
+<Properties>
+<Property name="peerId" type="string" required={true} >
+The unique identifier of a peer
+</Property>
+<Property name="name" type="string" >
+Filters ingress port allocations by name
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/peers/{peerId}/ingress/ports" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/peers/{peerId}/ingress/ports',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/peers/{peerId}/ingress/ports"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/peers/{peerId}/ingress/ports"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/peers/{peerId}/ingress/ports")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/peers/{peerId}/ingress/ports")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/ingress/ports',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/peers/{peerId}/ingress/ports" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "ch8i4ug6lnn4g9hqv7m0",
-    "name": "Ingress Peer Allocation 1",
-    "ingress_peer_id": "x7p3kqf2rdd8j5zxw4n9",
-    "region": "germany",
-    "enabled": true,
-    "ingress_ip": "192.34.0.123",
+    "id": "string",
+    "name": "string",
+    "ingress_peer_id": "string",
+    "region": "string",
+    "enabled": "boolean",
+    "ingress_ip": "string",
     "port_range_mappings": [
       {
-        "translated_start": 80,
-        "translated_end": 320,
-        "ingress_start": 1080,
-        "ingress_end": 1320,
-        "protocol": "tcp"
+        "translated_start": "integer",
+        "translated_end": "integer",
+        "ingress_start": "integer",
+        "ingress_end": "integer",
+        "protocol": "string"
       }
     ]
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -217,358 +76,102 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Create a Port Allocation  <Badge status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." />  {{ tag: 'POST' , label: '/api/peers/{peerId}/ingress/ports' }}
+
+## Create a Port Allocation {{ tag: 'POST', label: '/api/peers/{peerId}/ingress/ports' }}
+
 
 <Row>
-  <Col>
-    Creates a new ingress port allocation for a peer
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="peerId" type="string" required={true}> 
-            The unique identifier of a peer
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true}>
-        
-            Name of the ingress port allocation
-        
-        </Property>
-    <Property name="enabled" type="boolean" required={true}>
-        
-            Indicates if an ingress port allocation is enabled
-        
-        </Property>
-    <Property name="port_ranges" type="object[]" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>List of port ranges that are forwarded by the ingress peer</summary>
-                <Properties>
-                
-                    <Properties><Property name="start" type="integer" required={true}>
-        
-            The starting port of the range of forwarded ports
-        
-        </Property>
-    <Property name="end" type="integer" required={true}>
-        
-            The ending port of the range of forwarded ports
-        
-        </Property>
-    <Property name="protocol" type="string" required={true} enumList={["tcp","udp","tcp/udp"]}>
-        
-            The protocol accepted by the port range
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="direct_port" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>More Information</summary>
-                <Properties>
-                
-                    <Properties><Property name="count" type="integer" required={true}>
-        
-            The number of ports to be forwarded
-        
-        </Property>
-    <Property name="protocol" type="string" required={true} enumList={["tcp","udp","tcp/udp"]}>
-        
-            The protocol accepted by the port
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Creates a new ingress port allocation for a peer
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/api/peers/{peerId}/ingress/ports">
+### Path Parameters
+
+
+<Properties>
+<Property name="peerId" type="string" required={true} >
+The unique identifier of a peer
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="name" type="string" required={true} >
+Name of the ingress port allocation
+</Property>
+<Property name="enabled" type="boolean" required={true} >
+Indicates if an ingress port allocation is enabled
+</Property>
+<Property name="port_ranges" type="object[]" >
+
+<details class="custom-details" open >
+
+<summary>List of port ranges that are forwarded by the ingress peer</summary>
+<Properties>
+
+<Properties>
+<Property name="start" type="integer" required={true} >
+The starting port of the range of forwarded ports
+</Property>
+<Property name="end" type="integer" required={true} >
+The ending port of the range of forwarded ports
+</Property>
+<Property name="protocol" type="string" required={true} >
+The protocol accepted by the port range
+</Property>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="direct_port" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Direct port allocation</summary>
+<Properties>
+
+<Properties>
+<Property name="count" type="integer" required={true} >
+The number of ports to be forwarded
+</Property>
+<Property name="protocol" type="string" required={true} >
+The protocol accepted by the port
+</Property>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="POST" label="/api/peers/{peerId}/ingress/ports" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/peers/{peerId}/ingress/ports \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "name": "Ingress Port Allocation 1",
-  "enabled": true,
-  "port_ranges": [
-    {
-      "start": 80,
-      "end": 320,
-      "protocol": "tcp"
-    }
-  ],
-  "direct_port": {
-    "count": 5,
-    "protocol": "udp"
-  }
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "Ingress Port Allocation 1",
-  "enabled": true,
-  "port_ranges": [
-    {
-      "start": 80,
-      "end": 320,
-      "protocol": "tcp"
-    }
-  ],
-  "direct_port": {
-    "count": 5,
-    "protocol": "udp"
-  }
-});
-let config = {
-  method: 'post',
-  maxBodyLength: Infinity,
-  url: '/api/peers/{peerId}/ingress/ports',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/peers/{peerId}/ingress/ports"
-payload = json.dumps({
-  "name": "Ingress Port Allocation 1",
-  "enabled": true,
-  "port_ranges": [
-    {
-      "start": 80,
-      "end": 320,
-      "protocol": "tcp"
-    }
-  ],
-  "direct_port": {
-    "count": 5,
-    "protocol": "udp"
-  }
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("POST", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/peers/{peerId}/ingress/ports"
-  method := "POST"
-  
-  payload := strings.NewReader(`{
-  "name": "Ingress Port Allocation 1",
-  "enabled": true,
-  "port_ranges": [
-    {
-      "start": 80,
-      "end": 320,
-      "protocol": "tcp"
-    }
-  ],
-  "direct_port": {
-    "count": 5,
-    "protocol": "udp"
-  }
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/peers/{peerId}/ingress/ports")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Post.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "Ingress Port Allocation 1",
-  "enabled": true,
-  "port_ranges": [
-    {
-      "start": 80,
-      "end": 320,
-      "protocol": "tcp"
-    }
-  ],
-  "direct_port": {
-    "count": 5,
-    "protocol": "udp"
-  }
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "Ingress Port Allocation 1",
-  "enabled": true,
-  "port_ranges": [
-    {
-      "start": 80,
-      "end": 320,
-      "protocol": "tcp"
-    }
-  ],
-  "direct_port": {
-    "count": 5,
-    "protocol": "udp"
-  }
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/peers/{peerId}/ingress/ports")
-  .method("POST", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/ingress/ports',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'POST',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "Ingress Port Allocation 1",
-  "enabled": true,
-  "port_ranges": [
-    {
-      "start": 80,
-      "end": 320,
-      "protocol": "tcp"
-    }
-  ],
-  "direct_port": {
-    "count": 5,
-    "protocol": "udp"
-  }
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": "ch8i4ug6lnn4g9hqv7m0",
   "name": "Ingress Peer Allocation 1",
   "ingress_peer_id": "x7p3kqf2rdd8j5zxw4n9",
@@ -584,8 +187,30 @@ echo $response;
       "protocol": "tcp"
     }
   ]
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="POST" label="/api/peers/{peerId}/ingress/ports" >
+```json {{ title: 'Example' }}
+{
+  "id": "string",
+  "name": "string",
+  "ingress_peer_id": "string",
+  "region": "string",
+  "enabled": "boolean",
+  "ingress_ip": "string",
+  "port_range_mappings": [
+    {
+      "translated_start": "integer",
+      "translated_end": "integer",
+      "ingress_start": "integer",
+      "ingress_end": "integer",
+      "protocol": "string"
+    }
+  ]
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -605,203 +230,67 @@ echo $response;
   ]
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Retrieve a Port Allocation  <Badge status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." />  {{ tag: 'GET' , label: '/api/peers/{peerId}/ingress/ports/{allocationId}' }}
+
+## Retrieve a Port Allocation {{ tag: 'GET', label: '/api/peers/{peerId}/ingress/ports/{allocationId}' }}
+
 
 <Row>
-  <Col>
-    Get information about an ingress port allocation
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="peerId" type="string" required={true}> 
-            The unique identifier of a peer
-          </Property>   
-        
-          <Property name="allocationId" type="string" required={true}> 
-            The unique identifier of an ingress port allocation
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/peers/{peerId}/ingress/ports/{allocationId}">
+<Col>
+Get information about an ingress port allocation
+
+### Path Parameters
+
+
+<Properties>
+<Property name="peerId" type="string" required={true} >
+The unique identifier of a peer
+</Property>
+<Property name="allocationId" type="string" required={true} >
+The unique identifier of an ingress port allocation
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/peers/{peerId}/ingress/ports/{allocationId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/peers/{peerId}/ingress/ports/{allocationId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/peers/{peerId}/ingress/ports/{allocationId}" >
 ```json {{ title: 'Example' }}
 {
-  "id": "ch8i4ug6lnn4g9hqv7m0",
-  "name": "Ingress Peer Allocation 1",
-  "ingress_peer_id": "x7p3kqf2rdd8j5zxw4n9",
-  "region": "germany",
-  "enabled": true,
-  "ingress_ip": "192.34.0.123",
+  "id": "string",
+  "name": "string",
+  "ingress_peer_id": "string",
+  "region": "string",
+  "enabled": "boolean",
+  "ingress_ip": "string",
   "port_range_mappings": [
     {
-      "translated_start": 80,
-      "translated_end": 320,
-      "ingress_start": 1080,
-      "ingress_end": 1320,
-      "protocol": "tcp"
+      "translated_start": "integer",
+      "translated_end": "integer",
+      "ingress_start": "integer",
+      "ingress_end": "integer",
+      "protocol": "string"
     }
   ]
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -821,362 +310,105 @@ echo $response;
   ]
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Update a Port Allocation  <Badge status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." />  {{ tag: 'PUT' , label: '/api/peers/{peerId}/ingress/ports/{allocationId}' }}
+
+## Update a Port Allocation {{ tag: 'PUT', label: '/api/peers/{peerId}/ingress/ports/{allocationId}' }}
+
 
 <Row>
-  <Col>
-    Update information about an ingress port allocation
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="peerId" type="string" required={true}> 
-            The unique identifier of a peer
-          </Property>   
-        
-          <Property name="allocationId" type="string" required={true}> 
-            The unique identifier of an ingress port allocation
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true}>
-        
-            Name of the ingress port allocation
-        
-        </Property>
-    <Property name="enabled" type="boolean" required={true}>
-        
-            Indicates if an ingress port allocation is enabled
-        
-        </Property>
-    <Property name="port_ranges" type="object[]" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>List of port ranges that are forwarded by the ingress peer</summary>
-                <Properties>
-                
-                    <Properties><Property name="start" type="integer" required={true}>
-        
-            The starting port of the range of forwarded ports
-        
-        </Property>
-    <Property name="end" type="integer" required={true}>
-        
-            The ending port of the range of forwarded ports
-        
-        </Property>
-    <Property name="protocol" type="string" required={true} enumList={["tcp","udp","tcp/udp"]}>
-        
-            The protocol accepted by the port range
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="direct_port" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>More Information</summary>
-                <Properties>
-                
-                    <Properties><Property name="count" type="integer" required={true}>
-        
-            The number of ports to be forwarded
-        
-        </Property>
-    <Property name="protocol" type="string" required={true} enumList={["tcp","udp","tcp/udp"]}>
-        
-            The protocol accepted by the port
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Update information about an ingress port allocation
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="PUT" label="/api/peers/{peerId}/ingress/ports/{allocationId}">
+### Path Parameters
+
+
+<Properties>
+<Property name="peerId" type="string" required={true} >
+The unique identifier of a peer
+</Property>
+<Property name="allocationId" type="string" required={true} >
+The unique identifier of an ingress port allocation
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="name" type="string" required={true} >
+Name of the ingress port allocation
+</Property>
+<Property name="enabled" type="boolean" required={true} >
+Indicates if an ingress port allocation is enabled
+</Property>
+<Property name="port_ranges" type="object[]" >
+
+<details class="custom-details" open >
+
+<summary>List of port ranges that are forwarded by the ingress peer</summary>
+<Properties>
+
+<Properties>
+<Property name="start" type="integer" required={true} >
+The starting port of the range of forwarded ports
+</Property>
+<Property name="end" type="integer" required={true} >
+The ending port of the range of forwarded ports
+</Property>
+<Property name="protocol" type="string" required={true} >
+The protocol accepted by the port range
+</Property>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="direct_port" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Direct port allocation</summary>
+<Properties>
+
+<Properties>
+<Property name="count" type="integer" required={true} >
+The number of ports to be forwarded
+</Property>
+<Property name="protocol" type="string" required={true} >
+The protocol accepted by the port
+</Property>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="PUT" label="/api/peers/{peerId}/ingress/ports/{allocationId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId} \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "name": "Ingress Port Allocation 1",
-  "enabled": true,
-  "port_ranges": [
-    {
-      "start": 80,
-      "end": 320,
-      "protocol": "tcp"
-    }
-  ],
-  "direct_port": {
-    "count": 5,
-    "protocol": "udp"
-  }
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "Ingress Port Allocation 1",
-  "enabled": true,
-  "port_ranges": [
-    {
-      "start": 80,
-      "end": 320,
-      "protocol": "tcp"
-    }
-  ],
-  "direct_port": {
-    "count": 5,
-    "protocol": "udp"
-  }
-});
-let config = {
-  method: 'put',
-  maxBodyLength: Infinity,
-  url: '/api/peers/{peerId}/ingress/ports/{allocationId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
-payload = json.dumps({
-  "name": "Ingress Port Allocation 1",
-  "enabled": true,
-  "port_ranges": [
-    {
-      "start": 80,
-      "end": 320,
-      "protocol": "tcp"
-    }
-  ],
-  "direct_port": {
-    "count": 5,
-    "protocol": "udp"
-  }
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("PUT", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
-  method := "PUT"
-  
-  payload := strings.NewReader(`{
-  "name": "Ingress Port Allocation 1",
-  "enabled": true,
-  "port_ranges": [
-    {
-      "start": 80,
-      "end": 320,
-      "protocol": "tcp"
-    }
-  ],
-  "direct_port": {
-    "count": 5,
-    "protocol": "udp"
-  }
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Put.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "Ingress Port Allocation 1",
-  "enabled": true,
-  "port_ranges": [
-    {
-      "start": 80,
-      "end": 320,
-      "protocol": "tcp"
-    }
-  ],
-  "direct_port": {
-    "count": 5,
-    "protocol": "udp"
-  }
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "Ingress Port Allocation 1",
-  "enabled": true,
-  "port_ranges": [
-    {
-      "start": 80,
-      "end": 320,
-      "protocol": "tcp"
-    }
-  ],
-  "direct_port": {
-    "count": 5,
-    "protocol": "udp"
-  }
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
-  .method("PUT", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'PUT',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "Ingress Port Allocation 1",
-  "enabled": true,
-  "port_ranges": [
-    {
-      "start": 80,
-      "end": 320,
-      "protocol": "tcp"
-    }
-  ],
-  "direct_port": {
-    "count": 5,
-    "protocol": "udp"
-  }
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": "ch8i4ug6lnn4g9hqv7m0",
   "name": "Ingress Peer Allocation 1",
   "ingress_peer_id": "x7p3kqf2rdd8j5zxw4n9",
@@ -1192,8 +424,30 @@ echo $response;
       "protocol": "tcp"
     }
   ]
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="PUT" label="/api/peers/{peerId}/ingress/ports/{allocationId}" >
+```json {{ title: 'Example' }}
+{
+  "id": "string",
+  "name": "string",
+  "ingress_peer_id": "string",
+  "region": "string",
+  "enabled": "boolean",
+  "ingress_ip": "string",
+  "port_range_mappings": [
+    {
+      "translated_start": "integer",
+      "translated_end": "integer",
+      "ingress_start": "integer",
+      "ingress_end": "integer",
+      "protocol": "string"
+    }
+  ]
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -1213,357 +467,89 @@ echo $response;
   ]
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Delete a Port Allocation  <Badge status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." />  {{ tag: 'DELETE' , label: '/api/peers/{peerId}/ingress/ports/{allocationId}' }}
+
+## Delete a Port Allocation {{ tag: 'DELETE', label: '/api/peers/{peerId}/ingress/ports/{allocationId}' }}
+
 
 <Row>
-  <Col>
-    Delete an ingress port allocation
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="peerId" type="string" required={true}> 
-            The unique identifier of a peer
-          </Property>   
-        
-          <Property name="allocationId" type="string" required={true}> 
-            The unique identifier of an ingress port allocation
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="DELETE" label="/api/peers/{peerId}/ingress/ports/{allocationId}">
+<Col>
+Delete an ingress port allocation
+
+### Path Parameters
+
+
+<Properties>
+<Property name="peerId" type="string" required={true} >
+The unique identifier of a peer
+</Property>
+<Property name="allocationId" type="string" required={true} >
+The unique identifier of an ingress port allocation
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/peers/{peerId}/ingress/ports/{allocationId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId} \
--H 'Authorization: Token <TOKEN>' 
+-H 'Authorization: Token <TOKEN>' \
 ```
+</CodeGroup>
 
-```js
-const axios = require('axios');
+</Col>
 
-let config = {
-  method: 'delete',
-  maxBodyLength: Infinity,
-  url: '/api/peers/{peerId}/ingress/ports/{allocationId}',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("DELETE", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
-  method := "DELETE"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Delete.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
-  .method("DELETE")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'DELETE',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
 </Row>
-
 ---
 
 
-## List all Ingress Peers  <Badge status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." />  {{ tag: 'GET' , label: '/api/ingress/peers' }}
+
+## List all Ingress Peers {{ tag: 'GET', label: '/api/ingress/peers' }}
+
 
 <Row>
-  <Col>
-    Returns a list of all ingress peers
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/ingress/peers">
+<Col>
+Returns a list of all ingress peers
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/ingress/peers" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/ingress/peers \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/ingress/peers',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/ingress/peers"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/ingress/peers"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/ingress/peers")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/ingress/peers")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/ingress/peers',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/ingress/peers" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "ch8i4ug6lnn4g9hqv7m0",
-    "peer_id": "x7p3kqf2rdd8j5zxw4n9",
-    "ingress_ip": "192.34.0.123",
+    "id": "string",
+    "peer_id": "string",
+    "ingress_ip": "string",
     "available_ports": {
-      "tcp": 45765,
-      "udp": 50000
+      "tcp": "integer",
+      "udp": "integer"
     },
-    "enabled": true,
-    "connected": true,
-    "fallback": true,
-    "region": "germany"
+    "enabled": "boolean",
+    "connected": "boolean",
+    "fallback": "boolean",
+    "region": "string"
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -1581,236 +567,49 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Create a Ingress Peer  <Badge status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." />  {{ tag: 'POST' , label: '/api/ingress/peers' }}
+
+## Create a Ingress Peer {{ tag: 'POST', label: '/api/ingress/peers' }}
+
 
 <Row>
-  <Col>
-    Creates a new ingress peer
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="peer_id" type="string" required={true}>
-        
-            ID of the peer that is used as an ingress peer
-        
-        </Property>
-    <Property name="enabled" type="boolean" required={true}>
-        
-            Defines if an ingress peer is enabled
-        
-        </Property>
-    <Property name="fallback" type="boolean" required={true}>
-        
-            Defines if an ingress peer can be used as a fallback if no ingress peer can be found in the region of the forwarded peer
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Creates a new ingress peer
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/api/ingress/peers">
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="peer_id" type="string" required={true} >
+ID of the peer that is used as an ingress peer
+</Property>
+<Property name="enabled" type="boolean" required={true} >
+Defines if an ingress peer is enabled
+</Property>
+<Property name="fallback" type="boolean" required={true} >
+Defines if an ingress peer can be used as a fallback if no ingress peer can be found in the region of the forwarded peer
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="POST" label="/api/ingress/peers" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/ingress/peers \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
-  "enabled": true,
-  "fallback": true
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
-  "enabled": true,
-  "fallback": true
-});
-let config = {
-  method: 'post',
-  maxBodyLength: Infinity,
-  url: '/api/ingress/peers',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/ingress/peers"
-payload = json.dumps({
-  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
-  "enabled": true,
-  "fallback": true
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("POST", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/ingress/peers"
-  method := "POST"
-  
-  payload := strings.NewReader(`{
-  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
-  "enabled": true,
-  "fallback": true
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/ingress/peers")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Post.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
-  "enabled": true,
-  "fallback": true
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
-  "enabled": true,
-  "fallback": true
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/ingress/peers")
-  .method("POST", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/ingress/peers',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'POST',  
-  CURLOPT_POSTFIELDS => '{
-  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
-  "enabled": true,
-  "fallback": true
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": "ch8i4ug6lnn4g9hqv7m0",
   "peer_id": "x7p3kqf2rdd8j5zxw4n9",
   "ingress_ip": "192.34.0.123",
@@ -1822,8 +621,26 @@ echo $response;
   "connected": true,
   "fallback": true,
   "region": "germany"
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="POST" label="/api/ingress/peers" >
+```json {{ title: 'Example' }}
+{
+  "id": "string",
+  "peer_id": "string",
+  "ingress_ip": "string",
+  "available_ports": {
+    "tcp": "integer",
+    "udp": "integer"
+  },
+  "enabled": "boolean",
+  "connected": "boolean",
+  "fallback": "boolean",
+  "region": "string"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -1839,195 +656,60 @@ echo $response;
   "region": "string"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Retrieve a Ingress Peer  <Badge status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." />  {{ tag: 'GET' , label: '/api/ingress/peers/{ingressPeerId}' }}
+
+## Retrieve a Ingress Peer {{ tag: 'GET', label: '/api/ingress/peers/{ingressPeerId}' }}
+
 
 <Row>
-  <Col>
-    Get information about an ingress peer
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="ingressPeerId" type="string" required={true}> 
-            The unique identifier of an ingress peer
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/ingress/peers/{ingressPeerId}">
+<Col>
+Get information about an ingress peer
+
+### Path Parameters
+
+
+<Properties>
+<Property name="ingressPeerId" type="string" required={true} >
+The unique identifier of an ingress peer
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/ingress/peers/{ingressPeerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/ingress/peers/{ingressPeerId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/ingress/peers/{ingressPeerId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/ingress/peers/{ingressPeerId}" >
 ```json {{ title: 'Example' }}
 {
-  "id": "ch8i4ug6lnn4g9hqv7m0",
-  "peer_id": "x7p3kqf2rdd8j5zxw4n9",
-  "ingress_ip": "192.34.0.123",
+  "id": "string",
+  "peer_id": "string",
+  "ingress_ip": "string",
   "available_ports": {
-    "tcp": 45765,
-    "udp": 50000
+    "tcp": "integer",
+    "udp": "integer"
   },
-  "enabled": true,
-  "connected": true,
-  "fallback": true,
-  "region": "germany"
+  "enabled": "boolean",
+  "connected": "boolean",
+  "fallback": "boolean",
+  "region": "string"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -2043,232 +725,57 @@ echo $response;
   "region": "string"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Update a Ingress Peer  <Badge status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." />  {{ tag: 'PUT' , label: '/api/ingress/peers/{ingressPeerId}' }}
+
+## Update a Ingress Peer {{ tag: 'PUT', label: '/api/ingress/peers/{ingressPeerId}' }}
+
 
 <Row>
-  <Col>
-    Update information about an ingress peer
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="ingressPeerId" type="string" required={true}> 
-            The unique identifier of an ingress peer
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="enabled" type="boolean" required={true}>
-        
-            Defines if an ingress peer is enabled
-        
-        </Property>
-    <Property name="fallback" type="boolean" required={true}>
-        
-            Defines if an ingress peer can be used as a fallback if no ingress peer can be found in the region of the forwarded peer
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Update information about an ingress peer
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="PUT" label="/api/ingress/peers/{ingressPeerId}">
+### Path Parameters
+
+
+<Properties>
+<Property name="ingressPeerId" type="string" required={true} >
+The unique identifier of an ingress peer
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="enabled" type="boolean" required={true} >
+Defines if an ingress peer is enabled
+</Property>
+<Property name="fallback" type="boolean" required={true} >
+Defines if an ingress peer can be used as a fallback if no ingress peer can be found in the region of the forwarded peer
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="PUT" label="/api/ingress/peers/{ingressPeerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "enabled": true,
-  "fallback": true
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "enabled": true,
-  "fallback": true
-});
-let config = {
-  method: 'put',
-  maxBodyLength: Infinity,
-  url: '/api/ingress/peers/{ingressPeerId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
-payload = json.dumps({
-  "enabled": true,
-  "fallback": true
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("PUT", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
-  method := "PUT"
-  
-  payload := strings.NewReader(`{
-  "enabled": true,
-  "fallback": true
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Put.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "enabled": true,
-  "fallback": true
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "enabled": true,
-  "fallback": true
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
-  .method("PUT", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/ingress/peers/{ingressPeerId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'PUT',  
-  CURLOPT_POSTFIELDS => '{
-  "enabled": true,
-  "fallback": true
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": "ch8i4ug6lnn4g9hqv7m0",
   "peer_id": "x7p3kqf2rdd8j5zxw4n9",
   "ingress_ip": "192.34.0.123",
@@ -2280,8 +787,26 @@ echo $response;
   "connected": true,
   "fallback": true,
   "region": "germany"
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="PUT" label="/api/ingress/peers/{ingressPeerId}" >
+```json {{ title: 'Example' }}
+{
+  "id": "string",
+  "peer_id": "string",
+  "ingress_ip": "string",
+  "available_ports": {
+    "tcp": "integer",
+    "udp": "integer"
+  },
+  "enabled": "boolean",
+  "connected": "boolean",
+  "fallback": "boolean",
+  "region": "string"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -2297,174 +822,44 @@ echo $response;
   "region": "string"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Delete a Ingress Peer  <Badge status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." />  {{ tag: 'DELETE' , label: '/api/ingress/peers/{ingressPeerId}' }}
+
+## Delete a Ingress Peer {{ tag: 'DELETE', label: '/api/ingress/peers/{ingressPeerId}' }}
+
 
 <Row>
-  <Col>
-    Delete an ingress peer
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="ingressPeerId" type="string" required={true}> 
-            The unique identifier of an ingress peer
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="DELETE" label="/api/ingress/peers/{ingressPeerId}">
+<Col>
+Delete an ingress peer
+
+### Path Parameters
+
+
+<Properties>
+<Property name="ingressPeerId" type="string" required={true} >
+The unique identifier of an ingress peer
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/ingress/peers/{ingressPeerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
--H 'Authorization: Token <TOKEN>' 
+-H 'Authorization: Token <TOKEN>' \
 ```
+</CodeGroup>
 
-```js
-const axios = require('axios');
+</Col>
 
-let config = {
-  method: 'delete',
-  maxBodyLength: Infinity,
-  url: '/api/ingress/peers/{ingressPeerId}',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("DELETE", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
-  method := "DELETE"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Delete.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
-  .method("DELETE")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/ingress/peers/{ingressPeerId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'DELETE',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
 </Row>
-
 ---

--- a/src/pages/ipa/resources/ingress-ports.mdx
+++ b/src/pages/ipa/resources/ingress-ports.mdx
@@ -5,8 +5,7 @@ export const title = 'Ingress Ports'
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all ingress port allocations for a peer
 
 ### Path Parameters
@@ -31,8 +30,7 @@ Filters ingress port allocations by name
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/peers/{peerId}/ingress/ports" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports \
@@ -89,6 +87,7 @@ curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -97,8 +96,7 @@ curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports \
 
 
 <Row>
-
-<Col>
+ <Col>
 Creates a new ingress port allocation for a peer
 
 ### Path Parameters
@@ -123,8 +121,7 @@ Name of the ingress port allocation
 Indicates if an ingress port allocation is enabled
 </Property>
 <Property name="port_ranges" type="object[]" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>List of port ranges that are forwarded by the ingress peer</summary>
 <Properties>
@@ -141,10 +138,10 @@ The protocol accepted by the port range
 </Properties>
 
 </details>
+
 </Property>
 <Property name="direct_port" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>More Information</summary>
 <Properties>
@@ -158,13 +155,13 @@ The protocol accepted by the port
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="POST" label="/api/peers/{peerId}/ingress/ports" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/peers/{peerId}/ingress/ports \
@@ -233,6 +230,7 @@ curl -X POST https://api.netbird.io/api/peers/{peerId}/ingress/ports \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -241,8 +239,7 @@ curl -X POST https://api.netbird.io/api/peers/{peerId}/ingress/ports \
 
 
 <Row>
-
-<Col>
+ <Col>
 Get information about an ingress port allocation
 
 ### Path Parameters
@@ -259,8 +256,7 @@ The unique identifier of an ingress port allocation
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/peers/{peerId}/ingress/ports/{allocationId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId} \
@@ -313,6 +309,7 @@ curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationI
 </Col>
 
 </Row>
+
 ---
 
 
@@ -321,8 +318,7 @@ curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationI
 
 
 <Row>
-
-<Col>
+ <Col>
 Update information about an ingress port allocation
 
 ### Path Parameters
@@ -350,8 +346,7 @@ Name of the ingress port allocation
 Indicates if an ingress port allocation is enabled
 </Property>
 <Property name="port_ranges" type="object[]" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>List of port ranges that are forwarded by the ingress peer</summary>
 <Properties>
@@ -368,10 +363,10 @@ The protocol accepted by the port range
 </Properties>
 
 </details>
+
 </Property>
 <Property name="direct_port" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>More Information</summary>
 <Properties>
@@ -385,13 +380,13 @@ The protocol accepted by the port
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="PUT" label="/api/peers/{peerId}/ingress/ports/{allocationId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId} \
@@ -460,6 +455,7 @@ curl -X PUT https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationI
 </Col>
 
 </Row>
+
 ---
 
 
@@ -468,8 +464,7 @@ curl -X PUT https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationI
 
 
 <Row>
-
-<Col>
+ <Col>
 Delete an ingress port allocation
 
 ### Path Parameters
@@ -486,8 +481,7 @@ The unique identifier of an ingress port allocation
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/peers/{peerId}/ingress/ports/{allocationId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId} \
@@ -498,6 +492,7 @@ curl -X DELETE https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocati
 </Col>
 
 </Row>
+
 ---
 
 
@@ -506,12 +501,10 @@ curl -X DELETE https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocati
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all ingress peers
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/ingress/peers" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/ingress/peers \
@@ -560,6 +553,7 @@ curl -X GET https://api.netbird.io/api/ingress/peers \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -568,8 +562,7 @@ curl -X GET https://api.netbird.io/api/ingress/peers \
 
 
 <Row>
-
-<Col>
+ <Col>
 Creates a new ingress peer
 
 ### Request-Body Parameters
@@ -589,8 +582,7 @@ Defines if an ingress peer can be used as a fallback if no ingress peer can be f
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="POST" label="/api/ingress/peers" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/ingress/peers \
@@ -641,6 +633,7 @@ curl -X POST https://api.netbird.io/api/ingress/peers \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -649,8 +642,7 @@ curl -X POST https://api.netbird.io/api/ingress/peers \
 
 
 <Row>
-
-<Col>
+ <Col>
 Get information about an ingress peer
 
 ### Path Parameters
@@ -664,8 +656,7 @@ The unique identifier of an ingress peer
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/ingress/peers/{ingressPeerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
@@ -710,6 +701,7 @@ curl -X GET https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -718,8 +710,7 @@ curl -X GET https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Update information about an ingress peer
 
 ### Path Parameters
@@ -747,8 +738,7 @@ Defines if an ingress peer can be used as a fallback if no ingress peer can be f
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="PUT" label="/api/ingress/peers/{ingressPeerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
@@ -798,6 +788,7 @@ curl -X PUT https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -806,8 +797,7 @@ curl -X PUT https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Delete an ingress peer
 
 ### Path Parameters
@@ -821,8 +811,7 @@ The unique identifier of an ingress peer
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/ingress/peers/{ingressPeerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
@@ -833,4 +822,5 @@ curl -X DELETE https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
 </Col>
 
 </Row>
+
 ---

--- a/src/pages/ipa/resources/ingress-ports.mdx
+++ b/src/pages/ipa/resources/ingress-ports.mdx
@@ -1,7 +1,7 @@
 export const title = 'Ingress Ports'
 
 
-## List all Port Allocations {{ tag: 'GET', label: '/api/peers/{peerId}/ingress/ports' }}
+## List all Port Allocations  <Badge  status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." /> {{ tag: 'GET', label: '/api/peers/{peerId}/ingress/ports' }}
 
 
 <Row>
@@ -16,6 +16,14 @@ Returns a list of all ingress port allocations for a peer
 <Property name="peerId" type="string" required={true} >
 The unique identifier of a peer
 </Property>
+
+</Properties>
+
+
+### Query Parameters
+
+
+<Properties>
 <Property name="name" type="string" >
 Filters ingress port allocations by name
 </Property>
@@ -32,23 +40,23 @@ curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/peers/{peerId}/ingress/ports" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
-    "name": "string",
-    "ingress_peer_id": "string",
-    "region": "string",
-    "enabled": "boolean",
-    "ingress_ip": "string",
+    "id": "ch8i4ug6lnn4g9hqv7m0",
+    "name": "Ingress Peer Allocation 1",
+    "ingress_peer_id": "x7p3kqf2rdd8j5zxw4n9",
+    "region": "germany",
+    "enabled": true,
+    "ingress_ip": "192.34.0.123",
     "port_range_mappings": [
       {
-        "translated_start": "integer",
-        "translated_end": "integer",
-        "ingress_start": "integer",
-        "ingress_end": "integer",
-        "protocol": "string"
+        "translated_start": 80,
+        "translated_end": 320,
+        "ingress_start": 1080,
+        "ingress_end": 1320,
+        "protocol": "tcp"
       }
     ]
   }
@@ -85,7 +93,7 @@ curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports \
 
 
 
-## Create a Port Allocation {{ tag: 'POST', label: '/api/peers/{peerId}/ingress/ports' }}
+## Create a Port Allocation  <Badge  status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." /> {{ tag: 'POST', label: '/api/peers/{peerId}/ingress/ports' }}
 
 
 <Row>
@@ -120,8 +128,6 @@ Indicates if an ingress port allocation is enabled
 
 <summary>List of port ranges that are forwarded by the ingress peer</summary>
 <Properties>
-
-<Properties>
 <Property name="start" type="integer" required={true} >
 The starting port of the range of forwarded ports
 </Property>
@@ -134,17 +140,13 @@ The protocol accepted by the port range
 
 </Properties>
 
-</Properties>
-
 </details>
 </Property>
 <Property name="direct_port" type="object" >
 
 <details class="custom-details" open >
 
-<summary>Direct port allocation</summary>
-<Properties>
-
+<summary>More Information</summary>
 <Properties>
 <Property name="count" type="integer" required={true} >
 The number of ports to be forwarded
@@ -152,8 +154,6 @@ The number of ports to be forwarded
 <Property name="protocol" type="string" required={true} >
 The protocol accepted by the port
 </Property>
-
-</Properties>
 
 </Properties>
 
@@ -168,10 +168,29 @@ The protocol accepted by the port
 <CodeGroup title="Request" tag="POST" label="/api/peers/{peerId}/ingress/ports" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/peers/{peerId}/ingress/ports \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "ch8i4ug6lnn4g9hqv7m0",
   "name": "Ingress Peer Allocation 1",
   "ingress_peer_id": "x7p3kqf2rdd8j5zxw4n9",
@@ -185,27 +204,6 @@ curl -X POST https://api.netbird.io/api/peers/{peerId}/ingress/ports \
       "ingress_start": 1080,
       "ingress_end": 1320,
       "protocol": "tcp"
-    }
-  ]
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="POST" label="/api/peers/{peerId}/ingress/ports" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "name": "string",
-  "ingress_peer_id": "string",
-  "region": "string",
-  "enabled": "boolean",
-  "ingress_ip": "string",
-  "port_range_mappings": [
-    {
-      "translated_start": "integer",
-      "translated_end": "integer",
-      "ingress_start": "integer",
-      "ingress_end": "integer",
-      "protocol": "string"
     }
   ]
 }
@@ -239,7 +237,7 @@ curl -X POST https://api.netbird.io/api/peers/{peerId}/ingress/ports \
 
 
 
-## Retrieve a Port Allocation {{ tag: 'GET', label: '/api/peers/{peerId}/ingress/ports/{allocationId}' }}
+## Retrieve a Port Allocation  <Badge  status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." /> {{ tag: 'GET', label: '/api/peers/{peerId}/ingress/ports/{allocationId}' }}
 
 
 <Row>
@@ -270,22 +268,22 @@ curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationI
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/peers/{peerId}/ingress/ports/{allocationId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "name": "string",
-  "ingress_peer_id": "string",
-  "region": "string",
-  "enabled": "boolean",
-  "ingress_ip": "string",
+  "id": "ch8i4ug6lnn4g9hqv7m0",
+  "name": "Ingress Peer Allocation 1",
+  "ingress_peer_id": "x7p3kqf2rdd8j5zxw4n9",
+  "region": "germany",
+  "enabled": true,
+  "ingress_ip": "192.34.0.123",
   "port_range_mappings": [
     {
-      "translated_start": "integer",
-      "translated_end": "integer",
-      "ingress_start": "integer",
-      "ingress_end": "integer",
-      "protocol": "string"
+      "translated_start": 80,
+      "translated_end": 320,
+      "ingress_start": 1080,
+      "ingress_end": 1320,
+      "protocol": "tcp"
     }
   ]
 }
@@ -319,7 +317,7 @@ curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationI
 
 
 
-## Update a Port Allocation {{ tag: 'PUT', label: '/api/peers/{peerId}/ingress/ports/{allocationId}' }}
+## Update a Port Allocation  <Badge  status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." /> {{ tag: 'PUT', label: '/api/peers/{peerId}/ingress/ports/{allocationId}' }}
 
 
 <Row>
@@ -357,8 +355,6 @@ Indicates if an ingress port allocation is enabled
 
 <summary>List of port ranges that are forwarded by the ingress peer</summary>
 <Properties>
-
-<Properties>
 <Property name="start" type="integer" required={true} >
 The starting port of the range of forwarded ports
 </Property>
@@ -371,17 +367,13 @@ The protocol accepted by the port range
 
 </Properties>
 
-</Properties>
-
 </details>
 </Property>
 <Property name="direct_port" type="object" >
 
 <details class="custom-details" open >
 
-<summary>Direct port allocation</summary>
-<Properties>
-
+<summary>More Information</summary>
 <Properties>
 <Property name="count" type="integer" required={true} >
 The number of ports to be forwarded
@@ -389,8 +381,6 @@ The number of ports to be forwarded
 <Property name="protocol" type="string" required={true} >
 The protocol accepted by the port
 </Property>
-
-</Properties>
 
 </Properties>
 
@@ -405,10 +395,29 @@ The protocol accepted by the port
 <CodeGroup title="Request" tag="PUT" label="/api/peers/{peerId}/ingress/ports/{allocationId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId} \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "ch8i4ug6lnn4g9hqv7m0",
   "name": "Ingress Peer Allocation 1",
   "ingress_peer_id": "x7p3kqf2rdd8j5zxw4n9",
@@ -422,27 +431,6 @@ curl -X PUT https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationI
       "ingress_start": 1080,
       "ingress_end": 1320,
       "protocol": "tcp"
-    }
-  ]
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="PUT" label="/api/peers/{peerId}/ingress/ports/{allocationId}" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "name": "string",
-  "ingress_peer_id": "string",
-  "region": "string",
-  "enabled": "boolean",
-  "ingress_ip": "string",
-  "port_range_mappings": [
-    {
-      "translated_start": "integer",
-      "translated_end": "integer",
-      "ingress_start": "integer",
-      "ingress_end": "integer",
-      "protocol": "string"
     }
   ]
 }
@@ -476,7 +464,7 @@ curl -X PUT https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationI
 
 
 
-## Delete a Port Allocation {{ tag: 'DELETE', label: '/api/peers/{peerId}/ingress/ports/{allocationId}' }}
+## Delete a Port Allocation  <Badge  status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." /> {{ tag: 'DELETE', label: '/api/peers/{peerId}/ingress/ports/{allocationId}' }}
 
 
 <Row>
@@ -514,7 +502,7 @@ curl -X DELETE https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocati
 
 
 
-## List all Ingress Peers {{ tag: 'GET', label: '/api/ingress/peers' }}
+## List all Ingress Peers  <Badge  status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." /> {{ tag: 'GET', label: '/api/ingress/peers' }}
 
 
 <Row>
@@ -531,21 +519,21 @@ curl -X GET https://api.netbird.io/api/ingress/peers \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/ingress/peers" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
-    "peer_id": "string",
-    "ingress_ip": "string",
+    "id": "ch8i4ug6lnn4g9hqv7m0",
+    "peer_id": "x7p3kqf2rdd8j5zxw4n9",
+    "ingress_ip": "192.34.0.123",
     "available_ports": {
-      "tcp": "integer",
-      "udp": "integer"
+      "tcp": 45765,
+      "udp": 50000
     },
-    "enabled": "boolean",
-    "connected": "boolean",
-    "fallback": "boolean",
-    "region": "string"
+    "enabled": true,
+    "connected": true,
+    "fallback": true,
+    "region": "germany"
   }
 ]
 ```
@@ -576,7 +564,7 @@ curl -X GET https://api.netbird.io/api/ingress/peers \
 
 
 
-## Create a Ingress Peer {{ tag: 'POST', label: '/api/ingress/peers' }}
+## Create a Ingress Peer  <Badge  status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." /> {{ tag: 'POST', label: '/api/ingress/peers' }}
 
 
 <Row>
@@ -606,10 +594,19 @@ Defines if an ingress peer can be used as a fallback if no ingress peer can be f
 <CodeGroup title="Request" tag="POST" label="/api/ingress/peers" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/ingress/peers \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
+  "enabled": true,
+  "fallback": true
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "ch8i4ug6lnn4g9hqv7m0",
   "peer_id": "x7p3kqf2rdd8j5zxw4n9",
   "ingress_ip": "192.34.0.123",
@@ -621,23 +618,6 @@ curl -X POST https://api.netbird.io/api/ingress/peers \
   "connected": true,
   "fallback": true,
   "region": "germany"
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="POST" label="/api/ingress/peers" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "peer_id": "string",
-  "ingress_ip": "string",
-  "available_ports": {
-    "tcp": "integer",
-    "udp": "integer"
-  },
-  "enabled": "boolean",
-  "connected": "boolean",
-  "fallback": "boolean",
-  "region": "string"
 }
 ```
 
@@ -665,7 +645,7 @@ curl -X POST https://api.netbird.io/api/ingress/peers \
 
 
 
-## Retrieve a Ingress Peer {{ tag: 'GET', label: '/api/ingress/peers/{ingressPeerId}' }}
+## Retrieve a Ingress Peer  <Badge  status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." /> {{ tag: 'GET', label: '/api/ingress/peers/{ingressPeerId}' }}
 
 
 <Row>
@@ -693,20 +673,20 @@ curl -X GET https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/ingress/peers/{ingressPeerId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "peer_id": "string",
-  "ingress_ip": "string",
+  "id": "ch8i4ug6lnn4g9hqv7m0",
+  "peer_id": "x7p3kqf2rdd8j5zxw4n9",
+  "ingress_ip": "192.34.0.123",
   "available_ports": {
-    "tcp": "integer",
-    "udp": "integer"
+    "tcp": 45765,
+    "udp": 50000
   },
-  "enabled": "boolean",
-  "connected": "boolean",
-  "fallback": "boolean",
-  "region": "string"
+  "enabled": true,
+  "connected": true,
+  "fallback": true,
+  "region": "germany"
 }
 ```
 
@@ -734,7 +714,7 @@ curl -X GET https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
 
 
 
-## Update a Ingress Peer {{ tag: 'PUT', label: '/api/ingress/peers/{ingressPeerId}' }}
+## Update a Ingress Peer  <Badge  status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." /> {{ tag: 'PUT', label: '/api/ingress/peers/{ingressPeerId}' }}
 
 
 <Row>
@@ -772,10 +752,18 @@ Defines if an ingress peer can be used as a fallback if no ingress peer can be f
 <CodeGroup title="Request" tag="PUT" label="/api/ingress/peers/{ingressPeerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "enabled": true,
+  "fallback": true
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "ch8i4ug6lnn4g9hqv7m0",
   "peer_id": "x7p3kqf2rdd8j5zxw4n9",
   "ingress_ip": "192.34.0.123",
@@ -787,23 +775,6 @@ curl -X PUT https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
   "connected": true,
   "fallback": true,
   "region": "germany"
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="PUT" label="/api/ingress/peers/{ingressPeerId}" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "peer_id": "string",
-  "ingress_ip": "string",
-  "available_ports": {
-    "tcp": "integer",
-    "udp": "integer"
-  },
-  "enabled": "boolean",
-  "connected": "boolean",
-  "fallback": "boolean",
-  "region": "string"
 }
 ```
 
@@ -831,7 +802,7 @@ curl -X PUT https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
 
 
 
-## Delete a Ingress Peer {{ tag: 'DELETE', label: '/api/ingress/peers/{ingressPeerId}' }}
+## Delete a Ingress Peer  <Badge  status="cloud-only" text="cloud-only" hoverText="This feature is only available in the cloud version of NetBird." /> {{ tag: 'DELETE', label: '/api/ingress/peers/{ingressPeerId}' }}
 
 
 <Row>

--- a/src/pages/ipa/resources/ingress-ports.mdx
+++ b/src/pages/ipa/resources/ingress-ports.mdx
@@ -37,6 +37,141 @@ curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/peers/{peerId}/ingress/ports',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/peers/{peerId}/ingress/ports"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/peers/{peerId}/ingress/ports"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/peers/{peerId}/ingress/ports")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/peers/{peerId}/ingress/ports")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/ingress/ports',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
 </CodeGroup>
 <CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
@@ -165,9 +300,9 @@ The protocol accepted by the port
 <CodeGroup title="Request" tag="POST" label="/api/peers/{peerId}/ingress/ports" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/peers/{peerId}/ingress/ports \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "Ingress Port Allocation 1",
   "enabled": true,
@@ -183,6 +318,238 @@ curl -X POST https://api.netbird.io/api/peers/{peerId}/ingress/ports \
     "protocol": "udp"
   }
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/peers/{peerId}/ingress/ports',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/peers/{peerId}/ingress/ports"
+payload = json.dumps({
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/peers/{peerId}/ingress/ports"
+  method := "POST"
+  
+  payload := strings.NewReader(`{
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+}`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/peers/{peerId}/ingress/ports")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{
+  \"name\": \"Ingress Port Allocation 1\",
+  \"enabled\": true,
+  \"port_ranges\": [
+    {
+      \"start\": 80,
+      \"end\": 320,
+      \"protocol\": \"tcp\"
+    }
+  ],
+  \"direct_port\": {
+    \"count\": 5,
+    \"protocol\": \"udp\"
+  }
+}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/peers/{peerId}/ingress/ports")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/ingress/ports',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -262,6 +629,141 @@ The unique identifier of an ingress port allocation
 curl -X GET https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -390,9 +892,9 @@ The protocol accepted by the port
 <CodeGroup title="Request" tag="PUT" label="/api/peers/{peerId}/ingress/ports/{allocationId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId} \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "Ingress Port Allocation 1",
   "enabled": true,
@@ -408,6 +910,238 @@ curl -X PUT https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationI
     "protocol": "udp"
   }
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
+payload = json.dumps({
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
+  method := "PUT"
+  
+  payload := strings.NewReader({
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "Ingress Port Allocation 1",
+  "enabled": true,
+  "port_ranges": [
+    {
+      "start": 80,
+      "end": 320,
+      "protocol": "tcp"
+    }
+  ],
+  "direct_port": {
+    "count": 5,
+    "protocol": "udp"
+  }
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -485,7 +1219,131 @@ The unique identifier of an ingress port allocation
 <CodeGroup title="Request" tag="DELETE" label="/api/peers/{peerId}/ingress/ports/{allocationId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId} \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/ingress/ports/{allocationId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 
@@ -510,6 +1368,141 @@ Returns a list of all ingress peers
 curl -X GET https://api.netbird.io/api/ingress/peers \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/ingress/peers',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/ingress/peers"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/ingress/peers"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/ingress/peers")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/ingress/peers")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/ingress/peers',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -586,14 +1579,186 @@ Defines if an ingress peer can be used as a fallback if no ingress peer can be f
 <CodeGroup title="Request" tag="POST" label="/api/ingress/peers" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/ingress/peers \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "peer_id": "ch8i4ug6lnn4g9hqv7m0",
   "enabled": true,
   "fallback": true
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
+  "enabled": true,
+  "fallback": true
+});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/ingress/peers',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/ingress/peers"
+payload = json.dumps({
+  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
+  "enabled": true,
+  "fallback": true
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/ingress/peers"
+  method := "POST"
+  
+  payload := strings.NewReader(`{
+  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
+  "enabled": true,
+  "fallback": true
+}`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/ingress/peers")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
+  "enabled": true,
+  "fallback": true
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{
+  \"peer_id\": \"ch8i4ug6lnn4g9hqv7m0\",
+  \"enabled\": true,
+  \"fallback\": true
+}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/ingress/peers")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/ingress/peers',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{
+  "peer_id": "ch8i4ug6lnn4g9hqv7m0",
+  "enabled": true,
+  "fallback": true
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -662,6 +1827,141 @@ The unique identifier of an ingress peer
 curl -X GET https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/ingress/peers/{ingressPeerId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/ingress/peers/{ingressPeerId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -742,13 +2042,179 @@ Defines if an ingress peer can be used as a fallback if no ingress peer can be f
 <CodeGroup title="Request" tag="PUT" label="/api/ingress/peers/{ingressPeerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "enabled": true,
   "fallback": true
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "enabled": true,
+  "fallback": true
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/ingress/peers/{ingressPeerId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
+payload = json.dumps({
+  "enabled": true,
+  "fallback": true
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
+  method := "PUT"
+  
+  payload := strings.NewReader({
+  "enabled": true,
+  "fallback": true
+})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "enabled": true,
+  "fallback": true
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "enabled": true,
+  "fallback": true
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/ingress/peers/{ingressPeerId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "enabled": true,
+  "fallback": true
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -815,7 +2281,131 @@ The unique identifier of an ingress peer
 <CodeGroup title="Request" tag="DELETE" label="/api/ingress/peers/{ingressPeerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/ingress/peers/{ingressPeerId} \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/ingress/peers/{ingressPeerId}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/ingress/peers/{ingressPeerId}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/ingress/peers/{ingressPeerId}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/ingress/peers/{ingressPeerId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 

--- a/src/pages/ipa/resources/networks.mdx
+++ b/src/pages/ipa/resources/networks.mdx
@@ -1,183 +1,44 @@
 export const title = 'Networks'
 
 
+## List all Networks {{ tag: 'GET', label: '/api/networks' }}
 
-## List all Networks  {{ tag: 'GET' , label: '/api/networks' }}
 
 <Row>
-  <Col>
-    Returns a list of all networks
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/networks">
+<Col>
+Returns a list of all networks
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/networks" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/networks \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/networks',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/networks" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "chacdk86lnnboviihd7g",
+    "id": "string",
     "routers": [
-      "ch8i4ug6lnn4g9hqv7m0"
+      "string"
     ],
-    "routing_peers_count": 2,
+    "routing_peers_count": "integer",
     "resources": [
-      "ch8i4ug6lnn4g9hqv7m1"
+      "string"
     ],
     "policies": [
-      "ch8i4ug6lnn4g9hqv7m2"
+      "string"
     ],
-    "name": "Remote Network 1",
-    "description": "A remote network that needs to be accessed"
+    "name": "string",
+    "description": "string"
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -197,224 +58,46 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Create a Network  {{ tag: 'POST' , label: '/api/networks' }}
+
+## Create a Network {{ tag: 'POST', label: '/api/networks' }}
+
 
 <Row>
-  <Col>
-    Creates a Network
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true}>
-        
-            Network name
-        
-        </Property>
-    <Property name="description" type="string" required={false}>
-        
-            Network description
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Creates a Network
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/api/networks">
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="name" type="string" required={true} >
+Network name
+</Property>
+<Property name="description" type="string" >
+Network description
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="POST" label="/api/networks" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/networks \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "name": "Remote Network 1",
-  "description": "A remote network that needs to be accessed"
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "Remote Network 1",
-  "description": "A remote network that needs to be accessed"
-});
-let config = {
-  method: 'post',
-  maxBodyLength: Infinity,
-  url: '/api/networks',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks"
-payload = json.dumps({
-  "name": "Remote Network 1",
-  "description": "A remote network that needs to be accessed"
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("POST", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks"
-  method := "POST"
-  
-  payload := strings.NewReader(`{
-  "name": "Remote Network 1",
-  "description": "A remote network that needs to be accessed"
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Post.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "Remote Network 1",
-  "description": "A remote network that needs to be accessed"
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "Remote Network 1",
-  "description": "A remote network that needs to be accessed"
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks")
-  .method("POST", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'POST',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "Remote Network 1",
-  "description": "A remote network that needs to be accessed"
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": "chacdk86lnnboviihd7g",
   "routers": [
     "ch8i4ug6lnn4g9hqv7m0"
@@ -428,8 +111,28 @@ echo $response;
   ],
   "name": "Remote Network 1",
   "description": "A remote network that needs to be accessed"
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="POST" label="/api/networks" >
+```json {{ title: 'Example' }}
+{
+  "id": "string",
+  "routers": [
+    "string"
+  ],
+  "routing_peers_count": "integer",
+  "resources": [
+    "string"
+  ],
+  "policies": [
+    "string"
+  ],
+  "name": "string",
+  "description": "string"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -447,197 +150,62 @@ echo $response;
   "description": "string"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Retrieve a Network  {{ tag: 'GET' , label: '/api/networks/{networkId}' }}
+
+## Retrieve a Network {{ tag: 'GET', label: '/api/networks/{networkId}' }}
+
 
 <Row>
-  <Col>
-    Get information about a Network
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="networkId" type="string" required={true}> 
-            The unique identifier of a network
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/networks/{networkId}">
+<Col>
+Get information about a Network
+
+### Path Parameters
+
+
+<Properties>
+<Property name="networkId" type="string" required={true} >
+The unique identifier of a network
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/networks/{networkId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/networks/{networkId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/networks/{networkId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks/{networkId}"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks/{networkId}"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks/{networkId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks/{networkId}")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/networks/{networkId}" >
 ```json {{ title: 'Example' }}
 {
-  "id": "chacdk86lnnboviihd7g",
+  "id": "string",
   "routers": [
-    "ch8i4ug6lnn4g9hqv7m0"
+    "string"
   ],
-  "routing_peers_count": 2,
+  "routing_peers_count": "integer",
   "resources": [
-    "ch8i4ug6lnn4g9hqv7m1"
+    "string"
   ],
   "policies": [
-    "ch8i4ug6lnn4g9hqv7m2"
+    "string"
   ],
-  "name": "Remote Network 1",
-  "description": "A remote network that needs to be accessed"
+  "name": "string",
+  "description": "string"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -655,232 +223,57 @@ echo $response;
   "description": "string"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Update a Network  {{ tag: 'PUT' , label: '/api/networks/{networkId}' }}
+
+## Update a Network {{ tag: 'PUT', label: '/api/networks/{networkId}' }}
+
 
 <Row>
-  <Col>
-    Update/Replace a Network
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="networkId" type="string" required={true}> 
-            The unique identifier of a network
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true}>
-        
-            Network name
-        
-        </Property>
-    <Property name="description" type="string" required={false}>
-        
-            Network description
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Update/Replace a Network
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="PUT" label="/api/networks/{networkId}">
+### Path Parameters
+
+
+<Properties>
+<Property name="networkId" type="string" required={true} >
+The unique identifier of a network
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="name" type="string" required={true} >
+Network name
+</Property>
+<Property name="description" type="string" >
+Network description
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="PUT" label="/api/networks/{networkId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/networks/{networkId} \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "name": "Remote Network 1",
-  "description": "A remote network that needs to be accessed"
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "Remote Network 1",
-  "description": "A remote network that needs to be accessed"
-});
-let config = {
-  method: 'put',
-  maxBodyLength: Infinity,
-  url: '/api/networks/{networkId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks/{networkId}"
-payload = json.dumps({
-  "name": "Remote Network 1",
-  "description": "A remote network that needs to be accessed"
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("PUT", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks/{networkId}"
-  method := "PUT"
-  
-  payload := strings.NewReader(`{
-  "name": "Remote Network 1",
-  "description": "A remote network that needs to be accessed"
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks/{networkId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Put.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "Remote Network 1",
-  "description": "A remote network that needs to be accessed"
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "Remote Network 1",
-  "description": "A remote network that needs to be accessed"
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks/{networkId}")
-  .method("PUT", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'PUT',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "Remote Network 1",
-  "description": "A remote network that needs to be accessed"
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": "chacdk86lnnboviihd7g",
   "routers": [
     "ch8i4ug6lnn4g9hqv7m0"
@@ -894,8 +287,28 @@ echo $response;
   ],
   "name": "Remote Network 1",
   "description": "A remote network that needs to be accessed"
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="PUT" label="/api/networks/{networkId}" >
+```json {{ title: 'Example' }}
+{
+  "id": "string",
+  "routers": [
+    "string"
+  ],
+  "routing_peers_count": "integer",
+  "resources": [
+    "string"
+  ],
+  "policies": [
+    "string"
+  ],
+  "name": "string",
+  "description": "string"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -913,365 +326,101 @@ echo $response;
   "description": "string"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Delete a Network  {{ tag: 'DELETE' , label: '/api/networks/{networkId}' }}
+
+## Delete a Network {{ tag: 'DELETE', label: '/api/networks/{networkId}' }}
+
 
 <Row>
-  <Col>
-    Delete a network
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="networkId" type="string" required={true}> 
-            The unique identifier of a network
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="DELETE" label="/api/networks/{networkId}">
+<Col>
+Delete a network
+
+### Path Parameters
+
+
+<Properties>
+<Property name="networkId" type="string" required={true} >
+The unique identifier of a network
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/networks/{networkId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/networks/{networkId} \
--H 'Authorization: Token <TOKEN>' 
+-H 'Authorization: Token <TOKEN>' \
 ```
+</CodeGroup>
 
-```js
-const axios = require('axios');
+</Col>
 
-let config = {
-  method: 'delete',
-  maxBodyLength: Infinity,
-  url: '/api/networks/{networkId}',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks/{networkId}"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("DELETE", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks/{networkId}"
-  method := "DELETE"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks/{networkId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Delete.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks/{networkId}")
-  .method("DELETE")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'DELETE',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
 </Row>
-
 ---
 
 
-## List all Network Resources  {{ tag: 'GET' , label: '/api/networks/{networkId}/resources' }}
+
+## List all Network Resources {{ tag: 'GET', label: '/api/networks/{networkId}/resources' }}
+
 
 <Row>
-  <Col>
-    Returns a list of all resources in a network
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="networkId" type="string" required={true}> 
-            The unique identifier of a network
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/networks/{networkId}/resources">
+<Col>
+Returns a list of all resources in a network
+
+### Path Parameters
+
+
+<Properties>
+<Property name="networkId" type="string" required={true} >
+The unique identifier of a network
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/networks/{networkId}/resources" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/networks/{networkId}/resources \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/networks/{networkId}/resources',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks/{networkId}/resources"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks/{networkId}/resources"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks/{networkId}/resources")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks/{networkId}/resources")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/resources',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/networks/{networkId}/resources" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "chacdk86lnnboviihd7g",
-    "type": "host",
+    "id": "string",
+    "type": "string",
     "groups": [
       {
-        "id": "ch8i4ug6lnn4g9hqv7m0",
-        "name": "devs",
-        "peers_count": 2,
-        "resources_count": 5,
-        "issued": "api"
+        "id": "string",
+        "name": "string",
+        "peers_count": "integer",
+        "resources_count": "integer",
+        "issued": "string"
       }
     ],
-    "name": "Remote Resource 1",
-    "description": "A remote resource inside network 1",
-    "address": "1.1.1.1",
-    "enabled": true
+    "name": "string",
+    "description": "string",
+    "address": "string",
+    "enabled": "boolean"
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -1293,282 +442,66 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Create a Network Resource  {{ tag: 'POST' , label: '/api/networks/{networkId}/resources' }}
+
+## Create a Network Resource {{ tag: 'POST', label: '/api/networks/{networkId}/resources' }}
+
 
 <Row>
-  <Col>
-    Creates a Network Resource
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="networkId" type="string" required={true}> 
-            The unique identifier of a network
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true}>
-        
-            Network resource name
-        
-        </Property>
-    <Property name="description" type="string" required={false}>
-        
-            Network resource description
-        
-        </Property>
-    <Property name="address" type="string" required={true}>
-        
-            Network resource address (either a direct host like 1.1.1.1 or 1.1.1.1/32, or a subnet like 192.168.178.0/24, or domains like example.com and *.example.com)
-        
-        </Property>
-    <Property name="enabled" type="boolean" required={true}>
-        
-            Network resource status
-        
-        </Property>
-    <Property name="groups" type="string[]" required={true}>
-        
-            Group IDs containing the resource
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Creates a Network Resource
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/api/networks/{networkId}/resources">
+### Path Parameters
+
+
+<Properties>
+<Property name="networkId" type="string" required={true} >
+The unique identifier of a network
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="body" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Object list</summary>
+<Properties>
+
+<Properties>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="POST" label="/api/networks/{networkId}/resources" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/networks/{networkId}/resources \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "name": "Remote Resource 1",
-  "description": "A remote resource inside network 1",
-  "address": "1.1.1.1",
-  "enabled": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ]
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "Remote Resource 1",
-  "description": "A remote resource inside network 1",
-  "address": "1.1.1.1",
-  "enabled": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ]
-});
-let config = {
-  method: 'post',
-  maxBodyLength: Infinity,
-  url: '/api/networks/{networkId}/resources',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks/{networkId}/resources"
-payload = json.dumps({
-  "name": "Remote Resource 1",
-  "description": "A remote resource inside network 1",
-  "address": "1.1.1.1",
-  "enabled": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ]
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("POST", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks/{networkId}/resources"
-  method := "POST"
-  
-  payload := strings.NewReader(`{
-  "name": "Remote Resource 1",
-  "description": "A remote resource inside network 1",
-  "address": "1.1.1.1",
-  "enabled": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ]
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks/{networkId}/resources")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Post.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "Remote Resource 1",
-  "description": "A remote resource inside network 1",
-  "address": "1.1.1.1",
-  "enabled": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ]
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "Remote Resource 1",
-  "description": "A remote resource inside network 1",
-  "address": "1.1.1.1",
-  "enabled": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ]
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks/{networkId}/resources")
-  .method("POST", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/resources',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'POST',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "Remote Resource 1",
-  "description": "A remote resource inside network 1",
-  "address": "1.1.1.1",
-  "enabled": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ]
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": "chacdk86lnnboviihd7g",
   "type": "host",
   "groups": [
@@ -1584,8 +517,30 @@ echo $response;
   "description": "A remote resource inside network 1",
   "address": "1.1.1.1",
   "enabled": true
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="POST" label="/api/networks/{networkId}/resources" >
+```json {{ title: 'Example' }}
+{
+  "id": "string",
+  "type": "string",
+  "groups": [
+    {
+      "id": "string",
+      "name": "string",
+      "peers_count": "integer",
+      "resources_count": "integer",
+      "issued": "string"
+    }
+  ],
+  "name": "string",
+  "description": "string",
+  "address": "string",
+  "enabled": "boolean"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -1605,203 +560,67 @@ echo $response;
   "enabled": "boolean"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Retrieve a Network Resource  {{ tag: 'GET' , label: '/api/networks/{networkId}/resources/{resourceId}' }}
+
+## Retrieve a Network Resource {{ tag: 'GET', label: '/api/networks/{networkId}/resources/{resourceId}' }}
+
 
 <Row>
-  <Col>
-    Get information about a Network Resource
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="networkId" type="string" required={true}> 
-            The unique identifier of a network
-          </Property>   
-        
-          <Property name="resourceId" type="string" required={true}> 
-            The unique identifier of a network resource
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/networks/{networkId}/resources/{resourceId}">
+<Col>
+Get information about a Network Resource
+
+### Path Parameters
+
+
+<Properties>
+<Property name="networkId" type="string" required={true} >
+The unique identifier of a network
+</Property>
+<Property name="resourceId" type="string" required={true} >
+The unique identifier of a network resource
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/networks/{networkId}/resources/{resourceId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/networks/{networkId}/resources/{resourceId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/networks/{networkId}/resources/{resourceId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/networks/{networkId}/resources/{resourceId}" >
 ```json {{ title: 'Example' }}
 {
-  "id": "chacdk86lnnboviihd7g",
-  "type": "host",
+  "id": "string",
+  "type": "string",
   "groups": [
     {
-      "id": "ch8i4ug6lnn4g9hqv7m0",
-      "name": "devs",
-      "peers_count": 2,
-      "resources_count": 5,
-      "issued": "api"
+      "id": "string",
+      "name": "string",
+      "peers_count": "integer",
+      "resources_count": "integer",
+      "issued": "string"
     }
   ],
-  "name": "Remote Resource 1",
-  "description": "A remote resource inside network 1",
-  "address": "1.1.1.1",
-  "enabled": true
+  "name": "string",
+  "description": "string",
+  "address": "string",
+  "enabled": "boolean"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -1821,286 +640,69 @@ echo $response;
   "enabled": "boolean"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Update a Network Resource  {{ tag: 'PUT' , label: '/api/networks/{networkId}/resources/{resourceId}' }}
+
+## Update a Network Resource {{ tag: 'PUT', label: '/api/networks/{networkId}/resources/{resourceId}' }}
+
 
 <Row>
-  <Col>
-    Update a Network Resource
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="networkId" type="string" required={true}> 
-            The unique identifier of a network
-          </Property>   
-        
-          <Property name="resourceId" type="string" required={true}> 
-            The unique identifier of a resource
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true}>
-        
-            Network resource name
-        
-        </Property>
-    <Property name="description" type="string" required={false}>
-        
-            Network resource description
-        
-        </Property>
-    <Property name="address" type="string" required={true}>
-        
-            Network resource address (either a direct host like 1.1.1.1 or 1.1.1.1/32, or a subnet like 192.168.178.0/24, or domains like example.com and *.example.com)
-        
-        </Property>
-    <Property name="enabled" type="boolean" required={true}>
-        
-            Network resource status
-        
-        </Property>
-    <Property name="groups" type="string[]" required={true}>
-        
-            Group IDs containing the resource
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Update a Network Resource
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="PUT" label="/api/networks/{networkId}/resources/{resourceId}">
+### Path Parameters
+
+
+<Properties>
+<Property name="networkId" type="string" required={true} >
+The unique identifier of a network
+</Property>
+<Property name="resourceId" type="string" required={true} >
+The unique identifier of a resource
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="body" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Object list</summary>
+<Properties>
+
+<Properties>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="PUT" label="/api/networks/{networkId}/resources/{resourceId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/networks/{networkId}/resources/{resourceId} \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "name": "Remote Resource 1",
-  "description": "A remote resource inside network 1",
-  "address": "1.1.1.1",
-  "enabled": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ]
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "Remote Resource 1",
-  "description": "A remote resource inside network 1",
-  "address": "1.1.1.1",
-  "enabled": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ]
-});
-let config = {
-  method: 'put',
-  maxBodyLength: Infinity,
-  url: '/api/networks/{networkId}/resources/{resourceId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}"
-payload = json.dumps({
-  "name": "Remote Resource 1",
-  "description": "A remote resource inside network 1",
-  "address": "1.1.1.1",
-  "enabled": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ]
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("PUT", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}"
-  method := "PUT"
-  
-  payload := strings.NewReader(`{
-  "name": "Remote Resource 1",
-  "description": "A remote resource inside network 1",
-  "address": "1.1.1.1",
-  "enabled": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ]
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Put.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "Remote Resource 1",
-  "description": "A remote resource inside network 1",
-  "address": "1.1.1.1",
-  "enabled": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ]
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "Remote Resource 1",
-  "description": "A remote resource inside network 1",
-  "address": "1.1.1.1",
-  "enabled": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ]
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}")
-  .method("PUT", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'PUT',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "Remote Resource 1",
-  "description": "A remote resource inside network 1",
-  "address": "1.1.1.1",
-  "enabled": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ]
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": "chacdk86lnnboviihd7g",
   "type": "host",
   "groups": [
@@ -2116,8 +718,30 @@ echo $response;
   "description": "A remote resource inside network 1",
   "address": "1.1.1.1",
   "enabled": true
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="PUT" label="/api/networks/{networkId}/resources/{resourceId}" >
+```json {{ title: 'Example' }}
+{
+  "id": "string",
+  "type": "string",
+  "groups": [
+    {
+      "id": "string",
+      "name": "string",
+      "peers_count": "integer",
+      "resources_count": "integer",
+      "issued": "string"
+    }
+  ],
+  "name": "string",
+  "description": "string",
+  "address": "string",
+  "enabled": "boolean"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -2137,362 +761,97 @@ echo $response;
   "enabled": "boolean"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Delete a Network Resource  {{ tag: 'DELETE' , label: '/api/networks/{networkId}/resources/{resourceId}' }}
+
+## Delete a Network Resource {{ tag: 'DELETE', label: '/api/networks/{networkId}/resources/{resourceId}' }}
+
 
 <Row>
-  <Col>
-    Delete a network resource
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="networkId" type="string" required={true}> 
-            
-          </Property>   
-        
-          <Property name="resourceId" type="string" required={true}> 
-            
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="DELETE" label="/api/networks/{networkId}/resources/{resourceId}">
+<Col>
+Delete a network resource
+
+### Path Parameters
+
+
+<Properties>
+<Property name="networkId" type="string" required={true} >
+
+</Property>
+<Property name="resourceId" type="string" required={true} >
+
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/networks/{networkId}/resources/{resourceId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/networks/{networkId}/resources/{resourceId} \
--H 'Authorization: Token <TOKEN>' 
+-H 'Authorization: Token <TOKEN>' \
 ```
+</CodeGroup>
 
-```js
-const axios = require('axios');
+</Col>
 
-let config = {
-  method: 'delete',
-  maxBodyLength: Infinity,
-  url: '/api/networks/{networkId}/resources/{resourceId}',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("DELETE", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}"
-  method := "DELETE"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Delete.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}")
-  .method("DELETE")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'DELETE',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
 </Row>
-
 ---
 
 
-## List all Network Routers  {{ tag: 'GET' , label: '/api/networks/{networkId}/routers' }}
+
+## List all Network Routers {{ tag: 'GET', label: '/api/networks/{networkId}/routers' }}
+
 
 <Row>
-  <Col>
-    Returns a list of all routers in a network
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="networkId" type="string" required={true}> 
-            The unique identifier of a network
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/networks/{networkId}/routers">
+<Col>
+Returns a list of all routers in a network
+
+### Path Parameters
+
+
+<Properties>
+<Property name="networkId" type="string" required={true} >
+The unique identifier of a network
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/networks/{networkId}/routers" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/networks/{networkId}/routers \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/networks/{networkId}/routers',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks/{networkId}/routers"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks/{networkId}/routers"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks/{networkId}/routers")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks/{networkId}/routers")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/routers',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/networks/{networkId}/routers" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "chacdk86lnnboviihd7g",
-    "peer": "chacbco6lnnbn6cg5s91",
+    "id": "string",
+    "peer": "string",
     "peer_groups": [
-      "chacbco6lnnbn6cg5s91"
+      "string"
     ],
-    "metric": 9999,
-    "masquerade": true,
-    "enabled": true
+    "metric": "integer",
+    "masquerade": "boolean",
+    "enabled": "boolean"
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -2507,69 +866,67 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Create a Network Router  {{ tag: 'POST' , label: '/api/networks/{networkId}/routers' }}
+
+## Create a Network Router {{ tag: 'POST', label: '/api/networks/{networkId}/routers' }}
+
 
 <Row>
-  <Col>
-    Creates a Network Router
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="networkId" type="string" required={true}> 
-            The unique identifier of a network
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="peer" type="string" required={false}>
-        
-            Peer Identifier associated with route. This property can not be set together with `peer_groups`
-        
-        </Property>
-    <Property name="peer_groups" type="string[]" required={false}>
-        
-            Peers Group Identifier associated with route. This property can not be set together with `peer`
-        
-        </Property>
-    <Property name="metric" type="integer" required={true} min={1} max={9999}>
-        
-            Route metric number. Lowest number has higher priority
-        
-        </Property>
-    <Property name="masquerade" type="boolean" required={true}>
-        
-            Indicate if peer should masquerade traffic to this route's prefix
-        
-        </Property>
-    <Property name="enabled" type="boolean" required={true}>
-        
-            Network router status
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Creates a Network Router
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/api/networks/{networkId}/routers">
+### Path Parameters
+
+
+<Properties>
+<Property name="networkId" type="string" required={true} >
+The unique identifier of a network
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="peer" type="string" >
+Peer Identifier associated with route. This property can not be set together with `peer_groups`
+</Property>
+<Property name="peer_groups" type="string[]" >
+Peers Group Identifier associated with route. This property can not be set together with `peer`
+</Property>
+<Property name="metric" type="integer" required={true} >
+Route metric number. Lowest number has higher priority
+</Property>
+<Property name="masquerade" type="boolean" required={true} >
+Indicate if peer should masquerade traffic to this route's prefix
+</Property>
+<Property name="enabled" type="boolean" required={true} >
+Network router status
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="POST" label="/api/networks/{networkId}/routers" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/networks/{networkId}/routers \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "id": "chacdk86lnnboviihd7g",
   "peer": "chacbco6lnnbn6cg5s91",
   "peer_groups": [
     "chacbco6lnnbn6cg5s91"
@@ -2579,220 +936,21 @@ curl -X POST https://api.netbird.io/api/networks/{networkId}/routers \
   "enabled": true
 }'
 ```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "enabled": true
-});
-let config = {
-  method: 'post',
-  maxBodyLength: Infinity,
-  url: '/api/networks/{networkId}/routers',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks/{networkId}/routers"
-payload = json.dumps({
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "enabled": true
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("POST", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks/{networkId}/routers"
-  method := "POST"
-  
-  payload := strings.NewReader(`{
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "enabled": true
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks/{networkId}/routers")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Post.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "enabled": true
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "enabled": true
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks/{networkId}/routers")
-  .method("POST", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/routers',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'POST',  
-  CURLOPT_POSTFIELDS => '{
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "enabled": true
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="POST" label="/api/networks/{networkId}/routers" >
 ```json {{ title: 'Example' }}
 {
-  "id": "chacdk86lnnboviihd7g",
-  "peer": "chacbco6lnnbn6cg5s91",
+  "id": "string",
+  "peer": "string",
   "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
+    "string"
   ],
-  "metric": 9999,
-  "masquerade": true,
-  "enabled": true
+  "metric": "integer",
+  "masquerade": "boolean",
+  "enabled": "boolean"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -2805,196 +963,60 @@ echo $response;
   "enabled": "boolean"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Retrieve a Network Router  {{ tag: 'GET' , label: '/api/networks/{networkId}/routers/{routerId}' }}
+
+## Retrieve a Network Router {{ tag: 'GET', label: '/api/networks/{networkId}/routers/{routerId}' }}
+
 
 <Row>
-  <Col>
-    Get information about a Network Router
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="networkId" type="string" required={true}> 
-            The unique identifier of a network
-          </Property>   
-        
-          <Property name="routerId" type="string" required={true}> 
-            The unique identifier of a router
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/networks/{networkId}/routers/{routerId}">
+<Col>
+Get information about a Network Router
+
+### Path Parameters
+
+
+<Properties>
+<Property name="networkId" type="string" required={true} >
+The unique identifier of a network
+</Property>
+<Property name="routerId" type="string" required={true} >
+The unique identifier of a router
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/networks/{networkId}/routers/{routerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/networks/{networkId}/routers/{routerId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks/{networkId}/routers/{routerId}"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks/{networkId}/routers/{routerId}"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks/{networkId}/routers/{routerId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks/{networkId}/routers/{routerId}")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/routers/{routerId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/networks/{networkId}/routers/{routerId}" >
 ```json {{ title: 'Example' }}
 {
-  "id": "chacdk86lnnboviihd7g",
-  "peer": "chacbco6lnnbn6cg5s91",
+  "id": "string",
+  "peer": "string",
   "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
+    "string"
   ],
-  "metric": 9999,
-  "masquerade": true,
-  "enabled": true
+  "metric": "integer",
+  "masquerade": "boolean",
+  "enabled": "boolean"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -3007,73 +1029,70 @@ echo $response;
   "enabled": "boolean"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Update a Network Router  {{ tag: 'PUT' , label: '/api/networks/{networkId}/routers/{routerId}' }}
+
+## Update a Network Router {{ tag: 'PUT', label: '/api/networks/{networkId}/routers/{routerId}' }}
+
 
 <Row>
-  <Col>
-    Update a Network Router
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="networkId" type="string" required={true}> 
-            The unique identifier of a network
-          </Property>   
-        
-          <Property name="routerId" type="string" required={true}> 
-            The unique identifier of a router
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="peer" type="string" required={false}>
-        
-            Peer Identifier associated with route. This property can not be set together with `peer_groups`
-        
-        </Property>
-    <Property name="peer_groups" type="string[]" required={false}>
-        
-            Peers Group Identifier associated with route. This property can not be set together with `peer`
-        
-        </Property>
-    <Property name="metric" type="integer" required={true} min={1} max={9999}>
-        
-            Route metric number. Lowest number has higher priority
-        
-        </Property>
-    <Property name="masquerade" type="boolean" required={true}>
-        
-            Indicate if peer should masquerade traffic to this route's prefix
-        
-        </Property>
-    <Property name="enabled" type="boolean" required={true}>
-        
-            Network router status
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Update a Network Router
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="PUT" label="/api/networks/{networkId}/routers/{routerId}">
+### Path Parameters
+
+
+<Properties>
+<Property name="networkId" type="string" required={true} >
+The unique identifier of a network
+</Property>
+<Property name="routerId" type="string" required={true} >
+The unique identifier of a router
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="peer" type="string" >
+Peer Identifier associated with route. This property can not be set together with `peer_groups`
+</Property>
+<Property name="peer_groups" type="string[]" >
+Peers Group Identifier associated with route. This property can not be set together with `peer`
+</Property>
+<Property name="metric" type="integer" required={true} >
+Route metric number. Lowest number has higher priority
+</Property>
+<Property name="masquerade" type="boolean" required={true} >
+Indicate if peer should masquerade traffic to this route's prefix
+</Property>
+<Property name="enabled" type="boolean" required={true} >
+Network router status
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="PUT" label="/api/networks/{networkId}/routers/{routerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "id": "chacdk86lnnboviihd7g",
   "peer": "chacbco6lnnbn6cg5s91",
   "peer_groups": [
     "chacbco6lnnbn6cg5s91"
@@ -3083,220 +1102,21 @@ curl -X PUT https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
   "enabled": true
 }'
 ```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "enabled": true
-});
-let config = {
-  method: 'put',
-  maxBodyLength: Infinity,
-  url: '/api/networks/{networkId}/routers/{routerId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks/{networkId}/routers/{routerId}"
-payload = json.dumps({
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "enabled": true
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("PUT", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks/{networkId}/routers/{routerId}"
-  method := "PUT"
-  
-  payload := strings.NewReader(`{
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "enabled": true
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks/{networkId}/routers/{routerId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Put.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "enabled": true
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "enabled": true
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks/{networkId}/routers/{routerId}")
-  .method("PUT", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/routers/{routerId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'PUT',  
-  CURLOPT_POSTFIELDS => '{
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "enabled": true
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="PUT" label="/api/networks/{networkId}/routers/{routerId}" >
 ```json {{ title: 'Example' }}
 {
-  "id": "chacdk86lnnboviihd7g",
-  "peer": "chacbco6lnnbn6cg5s91",
+  "id": "string",
+  "peer": "string",
   "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
+    "string"
   ],
-  "metric": 9999,
-  "masquerade": true,
-  "enabled": true
+  "metric": "integer",
+  "masquerade": "boolean",
+  "enabled": "boolean"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -3309,354 +1129,86 @@ echo $response;
   "enabled": "boolean"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Delete a Network Router  {{ tag: 'DELETE' , label: '/api/networks/{networkId}/routers/{routerId}' }}
+
+## Delete a Network Router {{ tag: 'DELETE', label: '/api/networks/{networkId}/routers/{routerId}' }}
+
 
 <Row>
-  <Col>
-    Delete a network router
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="networkId" type="string" required={true}> 
-            
-          </Property>   
-        
-          <Property name="routerId" type="string" required={true}> 
-            
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="DELETE" label="/api/networks/{networkId}/routers/{routerId}">
+<Col>
+Delete a network router
+
+### Path Parameters
+
+
+<Properties>
+<Property name="networkId" type="string" required={true} >
+
+</Property>
+<Property name="routerId" type="string" required={true} >
+
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/networks/{networkId}/routers/{routerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
--H 'Authorization: Token <TOKEN>' 
+-H 'Authorization: Token <TOKEN>' \
 ```
+</CodeGroup>
 
-```js
-const axios = require('axios');
+</Col>
 
-let config = {
-  method: 'delete',
-  maxBodyLength: Infinity,
-  url: '/api/networks/{networkId}/routers/{routerId}',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks/{networkId}/routers/{routerId}"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("DELETE", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks/{networkId}/routers/{routerId}"
-  method := "DELETE"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks/{networkId}/routers/{routerId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Delete.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks/{networkId}/routers/{routerId}")
-  .method("DELETE")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/routers/{routerId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'DELETE',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
 </Row>
-
 ---
 
 
-## List all Network Routers  {{ tag: 'GET' , label: '/api/networks/routers' }}
+
+## List all Network Routers {{ tag: 'GET', label: '/api/networks/routers' }}
+
 
 <Row>
-  <Col>
-    Returns a list of all routers in a network
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/networks/routers">
+<Col>
+Returns a list of all routers in a network
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/networks/routers" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/networks/routers \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/networks/routers',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/networks/routers"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/networks/routers"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/networks/routers")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/networks/routers")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/networks/routers',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/networks/routers" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "chacdk86lnnboviihd7g",
-    "peer": "chacbco6lnnbn6cg5s91",
+    "id": "string",
+    "peer": "string",
     "peer_groups": [
-      "chacbco6lnnbn6cg5s91"
+      "string"
     ],
-    "metric": 9999,
-    "masquerade": true,
-    "enabled": true
+    "metric": "integer",
+    "masquerade": "boolean",
+    "enabled": "boolean"
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -3671,10 +1223,9 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---

--- a/src/pages/ipa/resources/networks.mdx
+++ b/src/pages/ipa/resources/networks.mdx
@@ -18,23 +18,23 @@ curl -X GET https://api.netbird.io/api/networks \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/networks" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
+    "id": "chacdk86lnnboviihd7g",
     "routers": [
-      "string"
+      "ch8i4ug6lnn4g9hqv7m0"
     ],
-    "routing_peers_count": "integer",
+    "routing_peers_count": 2,
     "resources": [
-      "string"
+      "ch8i4ug6lnn4g9hqv7m1"
     ],
     "policies": [
-      "string"
+      "ch8i4ug6lnn4g9hqv7m2"
     ],
-    "name": "string",
-    "description": "string"
+    "name": "Remote Network 1",
+    "description": "A remote network that needs to be accessed"
   }
 ]
 ```
@@ -94,10 +94,18 @@ Network description
 <CodeGroup title="Request" tag="POST" label="/api/networks" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/networks \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "name": "Remote Network 1",
+  "description": "A remote network that needs to be accessed"
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "chacdk86lnnboviihd7g",
   "routers": [
     "ch8i4ug6lnn4g9hqv7m0"
@@ -111,25 +119,6 @@ curl -X POST https://api.netbird.io/api/networks \
   ],
   "name": "Remote Network 1",
   "description": "A remote network that needs to be accessed"
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="POST" label="/api/networks" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "routers": [
-    "string"
-  ],
-  "routing_peers_count": "integer",
-  "resources": [
-    "string"
-  ],
-  "policies": [
-    "string"
-  ],
-  "name": "string",
-  "description": "string"
 }
 ```
 
@@ -187,22 +176,22 @@ curl -X GET https://api.netbird.io/api/networks/{networkId} \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/networks/{networkId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
+  "id": "chacdk86lnnboviihd7g",
   "routers": [
-    "string"
+    "ch8i4ug6lnn4g9hqv7m0"
   ],
-  "routing_peers_count": "integer",
+  "routing_peers_count": 2,
   "resources": [
-    "string"
+    "ch8i4ug6lnn4g9hqv7m1"
   ],
   "policies": [
-    "string"
+    "ch8i4ug6lnn4g9hqv7m2"
   ],
-  "name": "string",
-  "description": "string"
+  "name": "Remote Network 1",
+  "description": "A remote network that needs to be accessed"
 }
 ```
 
@@ -270,10 +259,18 @@ Network description
 <CodeGroup title="Request" tag="PUT" label="/api/networks/{networkId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/networks/{networkId} \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "name": "Remote Network 1",
+  "description": "A remote network that needs to be accessed"
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "chacdk86lnnboviihd7g",
   "routers": [
     "ch8i4ug6lnn4g9hqv7m0"
@@ -287,25 +284,6 @@ curl -X PUT https://api.netbird.io/api/networks/{networkId} \
   ],
   "name": "Remote Network 1",
   "description": "A remote network that needs to be accessed"
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="PUT" label="/api/networks/{networkId}" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "routers": [
-    "string"
-  ],
-  "routing_peers_count": "integer",
-  "resources": [
-    "string"
-  ],
-  "policies": [
-    "string"
-  ],
-  "name": "string",
-  "description": "string"
 }
 ```
 
@@ -398,25 +376,25 @@ curl -X GET https://api.netbird.io/api/networks/{networkId}/resources \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/networks/{networkId}/resources" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
-    "type": "string",
+    "id": "chacdk86lnnboviihd7g",
+    "type": "host",
     "groups": [
       {
-        "id": "string",
-        "name": "string",
-        "peers_count": "integer",
-        "resources_count": "integer",
-        "issued": "string"
+        "id": "ch8i4ug6lnn4g9hqv7m0",
+        "name": "devs",
+        "peers_count": 2,
+        "resources_count": 5,
+        "issued": "api"
       }
     ],
-    "name": "string",
-    "description": "string",
-    "address": "string",
-    "enabled": "boolean"
+    "name": "Remote Resource 1",
+    "description": "A remote resource inside network 1",
+    "address": "1.1.1.1",
+    "enabled": true
   }
 ]
 ```
@@ -474,20 +452,20 @@ The unique identifier of a network
 
 
 <Properties>
-<Property name="body" type="object" >
-
-<details class="custom-details" open >
-
-<summary>Object list</summary>
-<Properties>
-
-<Properties>
-
-</Properties>
-
-</Properties>
-
-</details>
+<Property name="name" type="string" required={true} >
+Network resource name
+</Property>
+<Property name="description" type="string" >
+Network resource description
+</Property>
+<Property name="address" type="string" required={true} >
+Network resource address (either a direct host like 1.1.1.1 or 1.1.1.1/32, or a subnet like 192.168.178.0/24, or domains like example.com and *.example.com)
+</Property>
+<Property name="enabled" type="boolean" required={true} >
+Network resource status
+</Property>
+<Property name="groups" type="string[]" required={true} >
+Group IDs containing the resource
 </Property>
 
 </Properties>
@@ -498,10 +476,23 @@ The unique identifier of a network
 <CodeGroup title="Request" tag="POST" label="/api/networks/{networkId}/resources" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/networks/{networkId}/resources \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "name": "Remote Resource 1",
+  "description": "A remote resource inside network 1",
+  "address": "1.1.1.1",
+  "enabled": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ]
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "chacdk86lnnboviihd7g",
   "type": "host",
   "groups": [
@@ -517,27 +508,6 @@ curl -X POST https://api.netbird.io/api/networks/{networkId}/resources \
   "description": "A remote resource inside network 1",
   "address": "1.1.1.1",
   "enabled": true
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="POST" label="/api/networks/{networkId}/resources" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "type": "string",
-  "groups": [
-    {
-      "id": "string",
-      "name": "string",
-      "peers_count": "integer",
-      "resources_count": "integer",
-      "issued": "string"
-    }
-  ],
-  "name": "string",
-  "description": "string",
-  "address": "string",
-  "enabled": "boolean"
 }
 ```
 
@@ -600,24 +570,24 @@ curl -X GET https://api.netbird.io/api/networks/{networkId}/resources/{resourceI
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/networks/{networkId}/resources/{resourceId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "type": "string",
+  "id": "chacdk86lnnboviihd7g",
+  "type": "host",
   "groups": [
     {
-      "id": "string",
-      "name": "string",
-      "peers_count": "integer",
-      "resources_count": "integer",
-      "issued": "string"
+      "id": "ch8i4ug6lnn4g9hqv7m0",
+      "name": "devs",
+      "peers_count": 2,
+      "resources_count": 5,
+      "issued": "api"
     }
   ],
-  "name": "string",
-  "description": "string",
-  "address": "string",
-  "enabled": "boolean"
+  "name": "Remote Resource 1",
+  "description": "A remote resource inside network 1",
+  "address": "1.1.1.1",
+  "enabled": true
 }
 ```
 
@@ -675,20 +645,20 @@ The unique identifier of a resource
 
 
 <Properties>
-<Property name="body" type="object" >
-
-<details class="custom-details" open >
-
-<summary>Object list</summary>
-<Properties>
-
-<Properties>
-
-</Properties>
-
-</Properties>
-
-</details>
+<Property name="name" type="string" required={true} >
+Network resource name
+</Property>
+<Property name="description" type="string" >
+Network resource description
+</Property>
+<Property name="address" type="string" required={true} >
+Network resource address (either a direct host like 1.1.1.1 or 1.1.1.1/32, or a subnet like 192.168.178.0/24, or domains like example.com and *.example.com)
+</Property>
+<Property name="enabled" type="boolean" required={true} >
+Network resource status
+</Property>
+<Property name="groups" type="string[]" required={true} >
+Group IDs containing the resource
 </Property>
 
 </Properties>
@@ -699,10 +669,23 @@ The unique identifier of a resource
 <CodeGroup title="Request" tag="PUT" label="/api/networks/{networkId}/resources/{resourceId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/networks/{networkId}/resources/{resourceId} \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "name": "Remote Resource 1",
+  "description": "A remote resource inside network 1",
+  "address": "1.1.1.1",
+  "enabled": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ]
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "chacdk86lnnboviihd7g",
   "type": "host",
   "groups": [
@@ -718,27 +701,6 @@ curl -X PUT https://api.netbird.io/api/networks/{networkId}/resources/{resourceI
   "description": "A remote resource inside network 1",
   "address": "1.1.1.1",
   "enabled": true
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="PUT" label="/api/networks/{networkId}/resources/{resourceId}" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "type": "string",
-  "groups": [
-    {
-      "id": "string",
-      "name": "string",
-      "peers_count": "integer",
-      "resources_count": "integer",
-      "issued": "string"
-    }
-  ],
-  "name": "string",
-  "description": "string",
-  "address": "string",
-  "enabled": "boolean"
 }
 ```
 
@@ -836,18 +798,18 @@ curl -X GET https://api.netbird.io/api/networks/{networkId}/routers \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/networks/{networkId}/routers" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
-    "peer": "string",
+    "id": "chacdk86lnnboviihd7g",
+    "peer": "chacbco6lnnbn6cg5s91",
     "peer_groups": [
-      "string"
+      "chacbco6lnnbn6cg5s91"
     ],
-    "metric": "integer",
-    "masquerade": "boolean",
-    "enabled": "boolean"
+    "metric": 9999,
+    "masquerade": true,
+    "enabled": true
   }
 ]
 ```
@@ -904,7 +866,7 @@ Peer Identifier associated with route. This property can not be set together wit
 <Property name="peer_groups" type="string[]" >
 Peers Group Identifier associated with route. This property can not be set together with `peer`
 </Property>
-<Property name="metric" type="integer" required={true} >
+<Property name="metric" type="integer" required={true} min={1} max={9999} >
 Route metric number. Lowest number has higher priority
 </Property>
 <Property name="masquerade" type="boolean" required={true} >
@@ -922,11 +884,10 @@ Network router status
 <CodeGroup title="Request" tag="POST" label="/api/networks/{networkId}/routers" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/networks/{networkId}/routers \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "id": "chacdk86lnnboviihd7g",
   "peer": "chacbco6lnnbn6cg5s91",
   "peer_groups": [
     "chacbco6lnnbn6cg5s91"
@@ -937,17 +898,17 @@ curl -X POST https://api.netbird.io/api/networks/{networkId}/routers \
 }'
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="POST" label="/api/networks/{networkId}/routers" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "peer": "string",
+  "id": "chacdk86lnnboviihd7g",
+  "peer": "chacbco6lnnbn6cg5s91",
   "peer_groups": [
-    "string"
+    "chacbco6lnnbn6cg5s91"
   ],
-  "metric": "integer",
-  "masquerade": "boolean",
-  "enabled": "boolean"
+  "metric": 9999,
+  "masquerade": true,
+  "enabled": true
 }
 ```
 
@@ -1003,17 +964,17 @@ curl -X GET https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/networks/{networkId}/routers/{routerId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "peer": "string",
+  "id": "chacdk86lnnboviihd7g",
+  "peer": "chacbco6lnnbn6cg5s91",
   "peer_groups": [
-    "string"
+    "chacbco6lnnbn6cg5s91"
   ],
-  "metric": "integer",
-  "masquerade": "boolean",
-  "enabled": "boolean"
+  "metric": 9999,
+  "masquerade": true,
+  "enabled": true
 }
 ```
 
@@ -1070,7 +1031,7 @@ Peer Identifier associated with route. This property can not be set together wit
 <Property name="peer_groups" type="string[]" >
 Peers Group Identifier associated with route. This property can not be set together with `peer`
 </Property>
-<Property name="metric" type="integer" required={true} >
+<Property name="metric" type="integer" required={true} min={1} max={9999} >
 Route metric number. Lowest number has higher priority
 </Property>
 <Property name="masquerade" type="boolean" required={true} >
@@ -1088,11 +1049,10 @@ Network router status
 <CodeGroup title="Request" tag="PUT" label="/api/networks/{networkId}/routers/{routerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "id": "chacdk86lnnboviihd7g",
   "peer": "chacbco6lnnbn6cg5s91",
   "peer_groups": [
     "chacbco6lnnbn6cg5s91"
@@ -1103,17 +1063,17 @@ curl -X PUT https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
 }'
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="PUT" label="/api/networks/{networkId}/routers/{routerId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "peer": "string",
+  "id": "chacdk86lnnboviihd7g",
+  "peer": "chacbco6lnnbn6cg5s91",
   "peer_groups": [
-    "string"
+    "chacbco6lnnbn6cg5s91"
   ],
-  "metric": "integer",
-  "masquerade": "boolean",
-  "enabled": "boolean"
+  "metric": 9999,
+  "masquerade": true,
+  "enabled": true
 }
 ```
 
@@ -1193,18 +1153,18 @@ curl -X GET https://api.netbird.io/api/networks/routers \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/networks/routers" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
-    "peer": "string",
+    "id": "chacdk86lnnboviihd7g",
+    "peer": "chacbco6lnnbn6cg5s91",
     "peer_groups": [
-      "string"
+      "chacbco6lnnbn6cg5s91"
     ],
-    "metric": "integer",
-    "masquerade": "boolean",
-    "enabled": "boolean"
+    "metric": 9999,
+    "masquerade": true,
+    "enabled": true
   }
 ]
 ```

--- a/src/pages/ipa/resources/networks.mdx
+++ b/src/pages/ipa/resources/networks.mdx
@@ -5,12 +5,10 @@ export const title = 'Networks'
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all networks
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/networks" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/networks \
@@ -63,6 +61,7 @@ curl -X GET https://api.netbird.io/api/networks \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -71,8 +70,7 @@ curl -X GET https://api.netbird.io/api/networks \
 
 
 <Row>
-
-<Col>
+ <Col>
 Creates a Network
 
 ### Request-Body Parameters
@@ -89,8 +87,7 @@ Network description
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="POST" label="/api/networks" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/networks \
@@ -144,6 +141,7 @@ curl -X POST https://api.netbird.io/api/networks \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -152,8 +150,7 @@ curl -X POST https://api.netbird.io/api/networks \
 
 
 <Row>
-
-<Col>
+ <Col>
 Get information about a Network
 
 ### Path Parameters
@@ -167,8 +164,7 @@ The unique identifier of a network
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/networks/{networkId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/networks/{networkId} \
@@ -217,6 +213,7 @@ curl -X GET https://api.netbird.io/api/networks/{networkId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -225,8 +222,7 @@ curl -X GET https://api.netbird.io/api/networks/{networkId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Update/Replace a Network
 
 ### Path Parameters
@@ -254,8 +250,7 @@ Network description
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="PUT" label="/api/networks/{networkId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/networks/{networkId} \
@@ -309,6 +304,7 @@ curl -X PUT https://api.netbird.io/api/networks/{networkId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -317,8 +313,7 @@ curl -X PUT https://api.netbird.io/api/networks/{networkId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Delete a network
 
 ### Path Parameters
@@ -332,8 +327,7 @@ The unique identifier of a network
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/networks/{networkId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/networks/{networkId} \
@@ -344,6 +338,7 @@ curl -X DELETE https://api.netbird.io/api/networks/{networkId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -352,8 +347,7 @@ curl -X DELETE https://api.netbird.io/api/networks/{networkId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all resources in a network
 
 ### Path Parameters
@@ -367,8 +361,7 @@ The unique identifier of a network
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/networks/{networkId}/resources" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/networks/{networkId}/resources \
@@ -425,6 +418,7 @@ curl -X GET https://api.netbird.io/api/networks/{networkId}/resources \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -433,8 +427,7 @@ curl -X GET https://api.netbird.io/api/networks/{networkId}/resources \
 
 
 <Row>
-
-<Col>
+ <Col>
 Creates a Network Resource
 
 ### Path Parameters
@@ -471,8 +464,7 @@ Group IDs containing the resource
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="POST" label="/api/networks/{networkId}/resources" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/networks/{networkId}/resources \
@@ -535,6 +527,7 @@ curl -X POST https://api.netbird.io/api/networks/{networkId}/resources \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -543,8 +536,7 @@ curl -X POST https://api.netbird.io/api/networks/{networkId}/resources \
 
 
 <Row>
-
-<Col>
+ <Col>
 Get information about a Network Resource
 
 ### Path Parameters
@@ -561,8 +553,7 @@ The unique identifier of a network resource
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/networks/{networkId}/resources/{resourceId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/networks/{networkId}/resources/{resourceId} \
@@ -615,6 +606,7 @@ curl -X GET https://api.netbird.io/api/networks/{networkId}/resources/{resourceI
 </Col>
 
 </Row>
+
 ---
 
 
@@ -623,8 +615,7 @@ curl -X GET https://api.netbird.io/api/networks/{networkId}/resources/{resourceI
 
 
 <Row>
-
-<Col>
+ <Col>
 Update a Network Resource
 
 ### Path Parameters
@@ -664,8 +655,7 @@ Group IDs containing the resource
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="PUT" label="/api/networks/{networkId}/resources/{resourceId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/networks/{networkId}/resources/{resourceId} \
@@ -728,6 +718,7 @@ curl -X PUT https://api.netbird.io/api/networks/{networkId}/resources/{resourceI
 </Col>
 
 </Row>
+
 ---
 
 
@@ -736,8 +727,7 @@ curl -X PUT https://api.netbird.io/api/networks/{networkId}/resources/{resourceI
 
 
 <Row>
-
-<Col>
+ <Col>
 Delete a network resource
 
 ### Path Parameters
@@ -754,8 +744,7 @@ Delete a network resource
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/networks/{networkId}/resources/{resourceId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/networks/{networkId}/resources/{resourceId} \
@@ -766,6 +755,7 @@ curl -X DELETE https://api.netbird.io/api/networks/{networkId}/resources/{resour
 </Col>
 
 </Row>
+
 ---
 
 
@@ -774,8 +764,7 @@ curl -X DELETE https://api.netbird.io/api/networks/{networkId}/resources/{resour
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all routers in a network
 
 ### Path Parameters
@@ -789,8 +778,7 @@ The unique identifier of a network
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/networks/{networkId}/routers" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/networks/{networkId}/routers \
@@ -833,6 +821,7 @@ curl -X GET https://api.netbird.io/api/networks/{networkId}/routers \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -841,8 +830,7 @@ curl -X GET https://api.netbird.io/api/networks/{networkId}/routers \
 
 
 <Row>
-
-<Col>
+ <Col>
 Creates a Network Router
 
 ### Path Parameters
@@ -879,8 +867,7 @@ Network router status
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="POST" label="/api/networks/{networkId}/routers" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/networks/{networkId}/routers \
@@ -929,6 +916,7 @@ curl -X POST https://api.netbird.io/api/networks/{networkId}/routers \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -937,8 +925,7 @@ curl -X POST https://api.netbird.io/api/networks/{networkId}/routers \
 
 
 <Row>
-
-<Col>
+ <Col>
 Get information about a Network Router
 
 ### Path Parameters
@@ -955,8 +942,7 @@ The unique identifier of a router
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/networks/{networkId}/routers/{routerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
@@ -995,6 +981,7 @@ curl -X GET https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -1003,8 +990,7 @@ curl -X GET https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Update a Network Router
 
 ### Path Parameters
@@ -1044,8 +1030,7 @@ Network router status
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="PUT" label="/api/networks/{networkId}/routers/{routerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
@@ -1094,6 +1079,7 @@ curl -X PUT https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -1102,8 +1088,7 @@ curl -X PUT https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Delete a network router
 
 ### Path Parameters
@@ -1120,8 +1105,7 @@ Delete a network router
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/networks/{networkId}/routers/{routerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
@@ -1132,6 +1116,7 @@ curl -X DELETE https://api.netbird.io/api/networks/{networkId}/routers/{routerId
 </Col>
 
 </Row>
+
 ---
 
 
@@ -1140,12 +1125,10 @@ curl -X DELETE https://api.netbird.io/api/networks/{networkId}/routers/{routerId
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all routers in a network
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/networks/routers" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/networks/routers \
@@ -1188,4 +1171,5 @@ curl -X GET https://api.netbird.io/api/networks/routers \
 </Col>
 
 </Row>
+
 ---

--- a/src/pages/ipa/resources/networks.mdx
+++ b/src/pages/ipa/resources/networks.mdx
@@ -15,6 +15,141 @@ curl -X GET https://api.netbird.io/api/networks \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/networks"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/networks"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
 </CodeGroup>
 <CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
@@ -91,13 +226,179 @@ Network description
 <CodeGroup title="Request" tag="POST" label="/api/networks" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/networks \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "Remote Network 1",
   "description": "A remote network that needs to be accessed"
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "Remote Network 1",
+  "description": "A remote network that needs to be accessed"
+});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/networks"
+payload = json.dumps({
+  "name": "Remote Network 1",
+  "description": "A remote network that needs to be accessed"
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/networks"
+  method := "POST"
+  
+  payload := strings.NewReader(`{
+  "name": "Remote Network 1",
+  "description": "A remote network that needs to be accessed"
+}`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "Remote Network 1",
+  "description": "A remote network that needs to be accessed"
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{
+  \"name\": \"Remote Network 1\",
+  \"description\": \"A remote network that needs to be accessed\"
+}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "Remote Network 1",
+  "description": "A remote network that needs to be accessed"
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -170,6 +471,141 @@ The unique identifier of a network
 curl -X GET https://api.netbird.io/api/networks/{networkId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks/{networkId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/networks/{networkId}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/networks/{networkId}"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks/{networkId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks/{networkId}")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -254,13 +690,179 @@ Network description
 <CodeGroup title="Request" tag="PUT" label="/api/networks/{networkId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/networks/{networkId} \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "Remote Network 1",
   "description": "A remote network that needs to be accessed"
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "Remote Network 1",
+  "description": "A remote network that needs to be accessed"
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks/{networkId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/networks/{networkId}"
+payload = json.dumps({
+  "name": "Remote Network 1",
+  "description": "A remote network that needs to be accessed"
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/networks/{networkId}"
+  method := "PUT"
+  
+  payload := strings.NewReader({
+  "name": "Remote Network 1",
+  "description": "A remote network that needs to be accessed"
+})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks/{networkId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "Remote Network 1",
+  "description": "A remote network that needs to be accessed"
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "name": "Remote Network 1",
+  "description": "A remote network that needs to be accessed"
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks/{networkId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "Remote Network 1",
+  "description": "A remote network that needs to be accessed"
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -331,7 +933,131 @@ The unique identifier of a network
 <CodeGroup title="Request" tag="DELETE" label="/api/networks/{networkId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/networks/{networkId} \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks/{networkId}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/networks/{networkId}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/networks/{networkId}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks/{networkId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks/{networkId}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 
@@ -367,6 +1093,141 @@ The unique identifier of a network
 curl -X GET https://api.netbird.io/api/networks/{networkId}/resources \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks/{networkId}/resources',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/networks/{networkId}/resources"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/networks/{networkId}/resources"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks/{networkId}/resources")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks/{networkId}/resources")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/resources',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -468,9 +1329,9 @@ Group IDs containing the resource
 <CodeGroup title="Request" tag="POST" label="/api/networks/{networkId}/resources" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/networks/{networkId}/resources \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "Remote Resource 1",
   "description": "A remote resource inside network 1",
@@ -480,6 +1341,202 @@ curl -X POST https://api.netbird.io/api/networks/{networkId}/resources \
     "chacdk86lnnboviihd70"
   ]
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "Remote Resource 1",
+  "description": "A remote resource inside network 1",
+  "address": "1.1.1.1",
+  "enabled": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ]
+});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks/{networkId}/resources',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/networks/{networkId}/resources"
+payload = json.dumps({
+  "name": "Remote Resource 1",
+  "description": "A remote resource inside network 1",
+  "address": "1.1.1.1",
+  "enabled": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ]
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/networks/{networkId}/resources"
+  method := "POST"
+  
+  payload := strings.NewReader(`{
+  "name": "Remote Resource 1",
+  "description": "A remote resource inside network 1",
+  "address": "1.1.1.1",
+  "enabled": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ]
+}`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks/{networkId}/resources")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "Remote Resource 1",
+  "description": "A remote resource inside network 1",
+  "address": "1.1.1.1",
+  "enabled": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ]
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{
+  \"name\": \"Remote Resource 1\",
+  \"description\": \"A remote resource inside network 1\",
+  \"address\": \"1.1.1.1\",
+  \"enabled\": true,
+  \"groups\": [
+    \"chacdk86lnnboviihd70\"
+  ]
+}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks/{networkId}/resources")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/resources',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "Remote Resource 1",
+  "description": "A remote resource inside network 1",
+  "address": "1.1.1.1",
+  "enabled": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ]
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -559,6 +1616,141 @@ The unique identifier of a network resource
 curl -X GET https://api.netbird.io/api/networks/{networkId}/resources/{resourceId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -659,9 +1851,9 @@ Group IDs containing the resource
 <CodeGroup title="Request" tag="PUT" label="/api/networks/{networkId}/resources/{resourceId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/networks/{networkId}/resources/{resourceId} \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "Remote Resource 1",
   "description": "A remote resource inside network 1",
@@ -671,6 +1863,202 @@ curl -X PUT https://api.netbird.io/api/networks/{networkId}/resources/{resourceI
     "chacdk86lnnboviihd70"
   ]
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "Remote Resource 1",
+  "description": "A remote resource inside network 1",
+  "address": "1.1.1.1",
+  "enabled": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ]
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}"
+payload = json.dumps({
+  "name": "Remote Resource 1",
+  "description": "A remote resource inside network 1",
+  "address": "1.1.1.1",
+  "enabled": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ]
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}"
+  method := "PUT"
+  
+  payload := strings.NewReader({
+  "name": "Remote Resource 1",
+  "description": "A remote resource inside network 1",
+  "address": "1.1.1.1",
+  "enabled": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ]
+})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "Remote Resource 1",
+  "description": "A remote resource inside network 1",
+  "address": "1.1.1.1",
+  "enabled": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ]
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "name": "Remote Resource 1",
+  "description": "A remote resource inside network 1",
+  "address": "1.1.1.1",
+  "enabled": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ]
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "Remote Resource 1",
+  "description": "A remote resource inside network 1",
+  "address": "1.1.1.1",
+  "enabled": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ]
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -748,7 +2136,131 @@ Delete a network resource
 <CodeGroup title="Request" tag="DELETE" label="/api/networks/{networkId}/resources/{resourceId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/networks/{networkId}/resources/{resourceId} \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/resources/{resourceId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 
@@ -784,6 +2296,141 @@ The unique identifier of a network
 curl -X GET https://api.netbird.io/api/networks/{networkId}/routers \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks/{networkId}/routers',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/networks/{networkId}/routers"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/networks/{networkId}/routers"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks/{networkId}/routers")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks/{networkId}/routers")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/routers',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -871,9 +2518,9 @@ Network router status
 <CodeGroup title="Request" tag="POST" label="/api/networks/{networkId}/routers" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/networks/{networkId}/routers \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "peer": "chacbco6lnnbn6cg5s91",
   "peer_groups": [
@@ -883,6 +2530,202 @@ curl -X POST https://api.netbird.io/api/networks/{networkId}/routers \
   "masquerade": true,
   "enabled": true
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "enabled": true
+});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks/{networkId}/routers',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/networks/{networkId}/routers"
+payload = json.dumps({
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "enabled": true
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/networks/{networkId}/routers"
+  method := "POST"
+  
+  payload := strings.NewReader(`{
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "enabled": true
+}`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks/{networkId}/routers")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "enabled": true
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{
+  \"peer\": \"chacbco6lnnbn6cg5s91\",
+  \"peer_groups\": [
+    \"chacbco6lnnbn6cg5s91\"
+  ],
+  \"metric\": 9999,
+  \"masquerade\": true,
+  \"enabled\": true
+}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks/{networkId}/routers")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/routers',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "enabled": true
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -948,6 +2791,141 @@ The unique identifier of a router
 curl -X GET https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks/{networkId}/routers/{routerId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/networks/{networkId}/routers/{routerId}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/networks/{networkId}/routers/{routerId}"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks/{networkId}/routers/{routerId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks/{networkId}/routers/{routerId}")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/routers/{routerId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -1034,9 +3012,9 @@ Network router status
 <CodeGroup title="Request" tag="PUT" label="/api/networks/{networkId}/routers/{routerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "peer": "chacbco6lnnbn6cg5s91",
   "peer_groups": [
@@ -1046,6 +3024,202 @@ curl -X PUT https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
   "masquerade": true,
   "enabled": true
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "enabled": true
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks/{networkId}/routers/{routerId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/networks/{networkId}/routers/{routerId}"
+payload = json.dumps({
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "enabled": true
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/networks/{networkId}/routers/{routerId}"
+  method := "PUT"
+  
+  payload := strings.NewReader({
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "enabled": true
+})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks/{networkId}/routers/{routerId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "enabled": true
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "enabled": true
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks/{networkId}/routers/{routerId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/routers/{routerId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "enabled": true
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -1109,7 +3283,131 @@ Delete a network router
 <CodeGroup title="Request" tag="DELETE" label="/api/networks/{networkId}/routers/{routerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/networks/{networkId}/routers/{routerId} \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks/{networkId}/routers/{routerId}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/networks/{networkId}/routers/{routerId}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/networks/{networkId}/routers/{routerId}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks/{networkId}/routers/{routerId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks/{networkId}/routers/{routerId}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks/{networkId}/routers/{routerId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 
@@ -1134,6 +3432,141 @@ Returns a list of all routers in a network
 curl -X GET https://api.netbird.io/api/networks/routers \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/networks/routers',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/networks/routers"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/networks/routers"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/networks/routers")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/networks/routers")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/networks/routers',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >

--- a/src/pages/ipa/resources/peers.mdx
+++ b/src/pages/ipa/resources/peers.mdx
@@ -29,6 +29,141 @@ curl -X GET https://api.netbird.io/api/peers \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/peers',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/peers"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/peers"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/peers")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/peers")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/peers',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
 </CodeGroup>
 <CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
@@ -154,6 +289,141 @@ The unique identifier of a peer
 curl -X GET https://api.netbird.io/api/peers/{peerId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/peers/{peerId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/peers/{peerId}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/peers/{peerId}"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/peers/{peerId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/peers/{peerId}")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -298,9 +568,9 @@ Peer's IP address
 <CodeGroup title="Request" tag="PUT" label="/api/peers/{peerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/peers/{peerId} \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "stage-host-1",
   "ssh_enabled": true,
@@ -309,6 +579,196 @@ curl -X PUT https://api.netbird.io/api/peers/{peerId} \
   "approval_required": true,
   "ip": "100.64.0.15"
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "stage-host-1",
+  "ssh_enabled": true,
+  "login_expiration_enabled": false,
+  "inactivity_expiration_enabled": false,
+  "approval_required": true,
+  "ip": "100.64.0.15"
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/peers/{peerId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/peers/{peerId}"
+payload = json.dumps({
+  "name": "stage-host-1",
+  "ssh_enabled": true,
+  "login_expiration_enabled": false,
+  "inactivity_expiration_enabled": false,
+  "approval_required": true,
+  "ip": "100.64.0.15"
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/peers/{peerId}"
+  method := "PUT"
+  
+  payload := strings.NewReader({
+  "name": "stage-host-1",
+  "ssh_enabled": true,
+  "login_expiration_enabled": false,
+  "inactivity_expiration_enabled": false,
+  "approval_required": true,
+  "ip": "100.64.0.15"
+})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/peers/{peerId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "stage-host-1",
+  "ssh_enabled": true,
+  "login_expiration_enabled": false,
+  "inactivity_expiration_enabled": false,
+  "approval_required": true,
+  "ip": "100.64.0.15"
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "name": "stage-host-1",
+  "ssh_enabled": true,
+  "login_expiration_enabled": false,
+  "inactivity_expiration_enabled": false,
+  "approval_required": true,
+  "ip": "100.64.0.15"
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/peers/{peerId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "stage-host-1",
+  "ssh_enabled": true,
+  "login_expiration_enabled": false,
+  "inactivity_expiration_enabled": false,
+  "approval_required": true,
+  "ip": "100.64.0.15"
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -427,7 +887,131 @@ The unique identifier of a peer
 <CodeGroup title="Request" tag="DELETE" label="/api/peers/{peerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/peers/{peerId} \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/peers/{peerId}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/peers/{peerId}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/peers/{peerId}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/peers/{peerId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/peers/{peerId}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 
@@ -463,6 +1047,141 @@ The unique identifier of a peer
 curl -X GET https://api.netbird.io/api/peers/{peerId}/accessible-peers \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/peers/{peerId}/accessible-peers',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/peers/{peerId}/accessible-peers"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/peers/{peerId}/accessible-peers"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/peers/{peerId}/accessible-peers")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/peers/{peerId}/accessible-peers")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/accessible-peers',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >

--- a/src/pages/ipa/resources/peers.mdx
+++ b/src/pages/ipa/resources/peers.mdx
@@ -1,224 +1,44 @@
 export const title = 'Peers'
 
 
+## List all Peers {{ tag: 'GET', label: '/api/peers' }}
 
-## List all Peers  {{ tag: 'GET' , label: '/api/peers' }}
 
 <Row>
-  <Col>
-    Returns a list of all peers
-        
-    ### Query Parameters
-    <Properties>
-        
-            <Property name="name" type="string" required={false}>
-              Filter peers by name
-            </Property>
-        
-            <Property name="ip" type="string" required={false}>
-              Filter peers by IP address
-            </Property>
-            </Properties>
-          </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/peers">
+<Col>
+Returns a list of all peers
+
+### Path Parameters
+
+
+<Properties>
+<Property name="name" type="string" >
+Filter peers by name
+</Property>
+<Property name="ip" type="string" >
+Filter peers by IP address
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/peers" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/peers \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/peers',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/peers"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/peers"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/peers")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/peers")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/peers',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/peers" >
 ```json {{ title: 'Example' }}
-[
-  {
-    "id": "chacbco6lnnbn6cg5s90",
-    "name": "stage-host-1",
-    "ip": "10.64.0.1",
-    "connection_ip": "35.64.0.1",
-    "connected": true,
-    "last_seen": "2023-05-05T10:05:26.420578Z",
-    "os": "Darwin 13.2.1",
-    "kernel_version": "23.2.0",
-    "geoname_id": 2643743,
-    "version": "0.14.0",
-    "groups": [
-      {
-        "id": "ch8i4ug6lnn4g9hqv7m0",
-        "name": "devs",
-        "peers_count": 2,
-        "resources_count": 5,
-        "issued": "api"
-      }
-    ],
-    "ssh_enabled": true,
-    "user_id": "google-oauth2|277474792786460067937",
-    "hostname": "stage-host-1",
-    "ui_version": "0.14.0",
-    "dns_label": "stage-host-1.netbird.cloud",
-    "login_expiration_enabled": false,
-    "login_expired": false,
-    "last_login": "2023-05-05T09:00:35.477782Z",
-    "inactivity_expiration_enabled": false,
-    "approval_required": true,
-    "country_code": "DE",
-    "city_name": "Berlin",
-    "serial_number": "C02XJ0J0JGH7",
-    "extra_dns_labels": [
-      "stage-host-1"
-    ],
-    "ephemeral": false,
-    "accessible_peers_count": 5
-  }
-]
-```
-```json {{ title: 'Schema' }}
 [
   {
     "id": "string",
     "name": "string",
+    "created_at": "string",
     "ip": "string",
     "connection_ip": "string",
     "connected": "boolean",
@@ -257,224 +77,94 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
 
+```json {{ title: 'Schema' }}
+[
+  {
+    "id": "string",
+    "name": "string",
+    "created_at": "string",
+    "ip": "string",
+    "connection_ip": "string",
+    "connected": "boolean",
+    "last_seen": "string",
+    "os": "string",
+    "kernel_version": "string",
+    "geoname_id": "integer",
+    "version": "string",
+    "groups": [
+      {
+        "id": "string",
+        "name": "string",
+        "peers_count": "integer",
+        "resources_count": "integer",
+        "issued": "string"
+      }
+    ],
+    "ssh_enabled": "boolean",
+    "user_id": "string",
+    "hostname": "string",
+    "ui_version": "string",
+    "dns_label": "string",
+    "login_expiration_enabled": "boolean",
+    "login_expired": "boolean",
+    "last_login": "string",
+    "inactivity_expiration_enabled": "boolean",
+    "approval_required": "boolean",
+    "country_code": "string",
+    "city_name": "string",
+    "serial_number": "string",
+    "extra_dns_labels": [
+      "string"
+    ],
+    "ephemeral": "boolean",
+    "accessible_peers_count": "integer"
+  }
+]
+```
+</CodeGroup>
+
+</Col>
+
+</Row>
 ---
 
 
-## Retrieve a Peer  {{ tag: 'GET' , label: '/api/peers/{peerId}' }}
+
+## Retrieve a Peer {{ tag: 'GET', label: '/api/peers/{peerId}' }}
+
 
 <Row>
-  <Col>
-    Get information about a peer
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="peerId" type="string" required={true}> 
-            The unique identifier of a peer
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/peers/{peerId}">
+<Col>
+Get information about a peer
+
+### Path Parameters
+
+
+<Properties>
+<Property name="peerId" type="string" required={true} >
+The unique identifier of a peer
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/peers/{peerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/peers/{peerId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/peers/{peerId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/peers/{peerId}"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/peers/{peerId}"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/peers/{peerId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/peers/{peerId}")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/peers/{peerId}" >
 ```json {{ title: 'Example' }}
-{
-  "id": "chacbco6lnnbn6cg5s90",
-  "name": "stage-host-1",
-  "ip": "10.64.0.1",
-  "connection_ip": "35.64.0.1",
-  "connected": true,
-  "last_seen": "2023-05-05T10:05:26.420578Z",
-  "os": "Darwin 13.2.1",
-  "kernel_version": "23.2.0",
-  "geoname_id": 2643743,
-  "version": "0.14.0",
-  "groups": [
-    {
-      "id": "ch8i4ug6lnn4g9hqv7m0",
-      "name": "devs",
-      "peers_count": 2,
-      "resources_count": 5,
-      "issued": "api"
-    }
-  ],
-  "ssh_enabled": true,
-  "user_id": "google-oauth2|277474792786460067937",
-  "hostname": "stage-host-1",
-  "ui_version": "0.14.0",
-  "dns_label": "stage-host-1.netbird.cloud",
-  "login_expiration_enabled": false,
-  "login_expired": false,
-  "last_login": "2023-05-05T09:00:35.477782Z",
-  "inactivity_expiration_enabled": false,
-  "approval_required": true,
-  "country_code": "DE",
-  "city_name": "Berlin",
-  "serial_number": "C02XJ0J0JGH7",
-  "extra_dns_labels": [
-    "stage-host-1"
-  ],
-  "ephemeral": false
-}
-```
-```json {{ title: 'Schema' }}
 {
   "id": "string",
   "name": "string",
+  "created_at": "string",
   "ip": "string",
   "connection_ip": "string",
   "connected": "boolean",
@@ -511,282 +201,114 @@ echo $response;
   "ephemeral": "boolean"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
 
+```json {{ title: 'Schema' }}
+{
+  "id": "string",
+  "name": "string",
+  "created_at": "string",
+  "ip": "string",
+  "connection_ip": "string",
+  "connected": "boolean",
+  "last_seen": "string",
+  "os": "string",
+  "kernel_version": "string",
+  "geoname_id": "integer",
+  "version": "string",
+  "groups": [
+    {
+      "id": "string",
+      "name": "string",
+      "peers_count": "integer",
+      "resources_count": "integer",
+      "issued": "string"
+    }
+  ],
+  "ssh_enabled": "boolean",
+  "user_id": "string",
+  "hostname": "string",
+  "ui_version": "string",
+  "dns_label": "string",
+  "login_expiration_enabled": "boolean",
+  "login_expired": "boolean",
+  "last_login": "string",
+  "inactivity_expiration_enabled": "boolean",
+  "approval_required": "boolean",
+  "country_code": "string",
+  "city_name": "string",
+  "serial_number": "string",
+  "extra_dns_labels": [
+    "string"
+  ],
+  "ephemeral": "boolean"
+}
+```
+</CodeGroup>
+
+</Col>
+
+</Row>
 ---
 
 
-## Update a Peer  {{ tag: 'PUT' , label: '/api/peers/{peerId}' }}
+
+## Update a Peer {{ tag: 'PUT', label: '/api/peers/{peerId}' }}
+
 
 <Row>
-  <Col>
-    Update information about a peer
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="peerId" type="string" required={true}> 
-            The unique identifier of a peer
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true}>
-        
-            
-        
-        </Property>
-    <Property name="ssh_enabled" type="boolean" required={true}>
-        
-            
-        
-        </Property>
-    <Property name="login_expiration_enabled" type="boolean" required={true}>
-        
-            
-        
-        </Property>
-    <Property name="inactivity_expiration_enabled" type="boolean" required={true}>
-        
-            
-        
-        </Property>
-    <Property name="approval_required" type="boolean" required={false}>
-        
-            (Cloud only) Indicates whether peer needs approval
-        
-        </Property>
-    <Property name="ip" type="string" required={false}>
-        
-            Peer's IP address
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Update information about a peer
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="PUT" label="/api/peers/{peerId}">
+### Path Parameters
+
+
+<Properties>
+<Property name="peerId" type="string" required={true} >
+The unique identifier of a peer
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="name" type="string" required={true} >
+
+</Property>
+<Property name="ssh_enabled" type="boolean" required={true} >
+
+</Property>
+<Property name="login_expiration_enabled" type="boolean" required={true} >
+
+</Property>
+<Property name="inactivity_expiration_enabled" type="boolean" required={true} >
+
+</Property>
+<Property name="approval_required" type="boolean" >
+(Cloud only) Indicates whether peer needs approval
+</Property>
+<Property name="ip" type="string" >
+Peer's IP address
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="PUT" label="/api/peers/{peerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/peers/{peerId} \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "name": "stage-host-1",
-  "ssh_enabled": true,
-  "login_expiration_enabled": false,
-  "inactivity_expiration_enabled": false,
-  "approval_required": true,
-  "ip": "100.64.0.15"
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "stage-host-1",
-  "ssh_enabled": true,
-  "login_expiration_enabled": false,
-  "inactivity_expiration_enabled": false,
-  "approval_required": true,
-  "ip": "100.64.0.15"
-});
-let config = {
-  method: 'put',
-  maxBodyLength: Infinity,
-  url: '/api/peers/{peerId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/peers/{peerId}"
-payload = json.dumps({
-  "name": "stage-host-1",
-  "ssh_enabled": true,
-  "login_expiration_enabled": false,
-  "inactivity_expiration_enabled": false,
-  "approval_required": true,
-  "ip": "100.64.0.15"
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("PUT", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/peers/{peerId}"
-  method := "PUT"
-  
-  payload := strings.NewReader(`{
-  "name": "stage-host-1",
-  "ssh_enabled": true,
-  "login_expiration_enabled": false,
-  "inactivity_expiration_enabled": false,
-  "approval_required": true,
-  "ip": "100.64.0.15"
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/peers/{peerId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Put.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "stage-host-1",
-  "ssh_enabled": true,
-  "login_expiration_enabled": false,
-  "inactivity_expiration_enabled": false,
-  "approval_required": true,
-  "ip": "100.64.0.15"
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "stage-host-1",
-  "ssh_enabled": true,
-  "login_expiration_enabled": false,
-  "inactivity_expiration_enabled": false,
-  "approval_required": true,
-  "ip": "100.64.0.15"
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/peers/{peerId}")
-  .method("PUT", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'PUT',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "stage-host-1",
-  "ssh_enabled": true,
-  "login_expiration_enabled": false,
-  "inactivity_expiration_enabled": false,
-  "approval_required": true,
-  "ip": "100.64.0.15"
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": "chacbco6lnnbn6cg5s90",
   "name": "stage-host-1",
+  "created_at": "2023-05-05T09:00:35.477782Z",
   "ip": "10.64.0.1",
   "connection_ip": "35.64.0.1",
   "connected": true,
@@ -821,12 +343,15 @@ echo $response;
     "stage-host-1"
   ],
   "ephemeral": false
-}
+}'
 ```
-```json {{ title: 'Schema' }}
+</CodeGroup>
+<CodeGroup title="Response" tag="PUT" label="/api/peers/{peerId}" >
+```json {{ title: 'Example' }}
 {
   "id": "string",
   "name": "string",
+  "created_at": "string",
   "ip": "string",
   "connection_ip": "string",
   "connected": "boolean",
@@ -863,361 +388,139 @@ echo $response;
   "ephemeral": "boolean"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
 
+```json {{ title: 'Schema' }}
+{
+  "id": "string",
+  "name": "string",
+  "created_at": "string",
+  "ip": "string",
+  "connection_ip": "string",
+  "connected": "boolean",
+  "last_seen": "string",
+  "os": "string",
+  "kernel_version": "string",
+  "geoname_id": "integer",
+  "version": "string",
+  "groups": [
+    {
+      "id": "string",
+      "name": "string",
+      "peers_count": "integer",
+      "resources_count": "integer",
+      "issued": "string"
+    }
+  ],
+  "ssh_enabled": "boolean",
+  "user_id": "string",
+  "hostname": "string",
+  "ui_version": "string",
+  "dns_label": "string",
+  "login_expiration_enabled": "boolean",
+  "login_expired": "boolean",
+  "last_login": "string",
+  "inactivity_expiration_enabled": "boolean",
+  "approval_required": "boolean",
+  "country_code": "string",
+  "city_name": "string",
+  "serial_number": "string",
+  "extra_dns_labels": [
+    "string"
+  ],
+  "ephemeral": "boolean"
+}
+```
+</CodeGroup>
+
+</Col>
+
+</Row>
 ---
 
 
-## Delete a Peer  {{ tag: 'DELETE' , label: '/api/peers/{peerId}' }}
+
+## Delete a Peer {{ tag: 'DELETE', label: '/api/peers/{peerId}' }}
+
 
 <Row>
-  <Col>
-    Delete a peer
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="peerId" type="string" required={true}> 
-            The unique identifier of a peer
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="DELETE" label="/api/peers/{peerId}">
+<Col>
+Delete a peer
+
+### Path Parameters
+
+
+<Properties>
+<Property name="peerId" type="string" required={true} >
+The unique identifier of a peer
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/peers/{peerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/peers/{peerId} \
--H 'Authorization: Token <TOKEN>' 
+-H 'Authorization: Token <TOKEN>' \
 ```
+</CodeGroup>
 
-```js
-const axios = require('axios');
+</Col>
 
-let config = {
-  method: 'delete',
-  maxBodyLength: Infinity,
-  url: '/api/peers/{peerId}',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/peers/{peerId}"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("DELETE", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/peers/{peerId}"
-  method := "DELETE"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/peers/{peerId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Delete.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/peers/{peerId}")
-  .method("DELETE")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'DELETE',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
 </Row>
-
 ---
 
 
-## List accessible Peers  {{ tag: 'GET' , label: '/api/peers/{peerId}/accessible-peers' }}
+
+## List accessible Peers {{ tag: 'GET', label: '/api/peers/{peerId}/accessible-peers' }}
+
 
 <Row>
-  <Col>
-    Returns a list of peers that the specified peer can connect to within the network.
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="peerId" type="string" required={true}> 
-            The unique identifier of a peer
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/peers/{peerId}/accessible-peers">
+<Col>
+Returns a list of peers that the specified peer can connect to within the network.
+
+### Path Parameters
+
+
+<Properties>
+<Property name="peerId" type="string" required={true} >
+The unique identifier of a peer
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/peers/{peerId}/accessible-peers" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/peers/{peerId}/accessible-peers \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/peers/{peerId}/accessible-peers',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/peers/{peerId}/accessible-peers"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/peers/{peerId}/accessible-peers"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/peers/{peerId}/accessible-peers")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/peers/{peerId}/accessible-peers")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/peers/{peerId}/accessible-peers',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/peers/{peerId}/accessible-peers" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "chacbco6lnnbn6cg5s90",
-    "name": "stage-host-1",
-    "ip": "10.64.0.1",
-    "dns_label": "stage-host-1.netbird.cloud",
-    "user_id": "google-oauth2|277474792786460067937",
-    "os": "linux",
-    "country_code": "DE",
-    "city_name": "Berlin",
-    "geoname_id": 2643743,
-    "connected": true,
-    "last_seen": "2023-05-05T10:05:26.420578Z"
+    "id": "string",
+    "name": "string",
+    "ip": "string",
+    "dns_label": "string",
+    "user_id": "string",
+    "os": "string",
+    "country_code": "string",
+    "city_name": "string",
+    "geoname_id": "integer",
+    "connected": "boolean",
+    "last_seen": "string"
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -1235,10 +538,9 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---

--- a/src/pages/ipa/resources/peers.mdx
+++ b/src/pages/ipa/resources/peers.mdx
@@ -5,8 +5,7 @@ export const title = 'Peers'
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all peers
 
 ### Query Parameters
@@ -23,8 +22,7 @@ Filter peers by IP address
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/peers" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/peers \
@@ -127,6 +125,7 @@ curl -X GET https://api.netbird.io/api/peers \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -135,8 +134,7 @@ curl -X GET https://api.netbird.io/api/peers \
 
 
 <Row>
-
-<Col>
+ <Col>
 Get information about a peer
 
 ### Path Parameters
@@ -150,8 +148,7 @@ The unique identifier of a peer
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/peers/{peerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/peers/{peerId} \
@@ -248,6 +245,7 @@ curl -X GET https://api.netbird.io/api/peers/{peerId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -256,8 +254,7 @@ curl -X GET https://api.netbird.io/api/peers/{peerId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Update information about a peer
 
 ### Path Parameters
@@ -297,8 +294,7 @@ Peer's IP address
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="PUT" label="/api/peers/{peerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/peers/{peerId} \
@@ -404,6 +400,7 @@ curl -X PUT https://api.netbird.io/api/peers/{peerId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -412,8 +409,7 @@ curl -X PUT https://api.netbird.io/api/peers/{peerId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Delete a peer
 
 ### Path Parameters
@@ -427,8 +423,7 @@ The unique identifier of a peer
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/peers/{peerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/peers/{peerId} \
@@ -439,6 +434,7 @@ curl -X DELETE https://api.netbird.io/api/peers/{peerId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -447,8 +443,7 @@ curl -X DELETE https://api.netbird.io/api/peers/{peerId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of peers that the specified peer can connect to within the network.
 
 ### Path Parameters
@@ -462,8 +457,7 @@ The unique identifier of a peer
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/peers/{peerId}/accessible-peers" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/peers/{peerId}/accessible-peers \
@@ -512,4 +506,5 @@ curl -X GET https://api.netbird.io/api/peers/{peerId}/accessible-peers \
 </Col>
 
 </Row>
+
 ---

--- a/src/pages/ipa/resources/peers.mdx
+++ b/src/pages/ipa/resources/peers.mdx
@@ -9,7 +9,7 @@ export const title = 'Peers'
 <Col>
 Returns a list of all peers
 
-### Path Parameters
+### Query Parameters
 
 
 <Properties>
@@ -32,48 +32,48 @@ curl -X GET https://api.netbird.io/api/peers \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/peers" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
-    "name": "string",
-    "created_at": "string",
-    "ip": "string",
-    "connection_ip": "string",
-    "connected": "boolean",
-    "last_seen": "string",
-    "os": "string",
-    "kernel_version": "string",
-    "geoname_id": "integer",
-    "version": "string",
+    "id": "chacbco6lnnbn6cg5s90",
+    "name": "stage-host-1",
+    "created_at": "2023-05-05T09:00:35.477782Z",
+    "ip": "10.64.0.1",
+    "connection_ip": "35.64.0.1",
+    "connected": true,
+    "last_seen": "2023-05-05T10:05:26.420578Z",
+    "os": "Darwin 13.2.1",
+    "kernel_version": "23.2.0",
+    "geoname_id": 2643743,
+    "version": "0.14.0",
     "groups": [
       {
-        "id": "string",
-        "name": "string",
-        "peers_count": "integer",
-        "resources_count": "integer",
-        "issued": "string"
+        "id": "ch8i4ug6lnn4g9hqv7m0",
+        "name": "devs",
+        "peers_count": 2,
+        "resources_count": 5,
+        "issued": "api"
       }
     ],
-    "ssh_enabled": "boolean",
-    "user_id": "string",
-    "hostname": "string",
-    "ui_version": "string",
-    "dns_label": "string",
-    "login_expiration_enabled": "boolean",
-    "login_expired": "boolean",
-    "last_login": "string",
-    "inactivity_expiration_enabled": "boolean",
-    "approval_required": "boolean",
-    "country_code": "string",
-    "city_name": "string",
-    "serial_number": "string",
+    "ssh_enabled": true,
+    "user_id": "google-oauth2|277474792786460067937",
+    "hostname": "stage-host-1",
+    "ui_version": "0.14.0",
+    "dns_label": "stage-host-1.netbird.cloud",
+    "login_expiration_enabled": false,
+    "login_expired": false,
+    "last_login": "2023-05-05T09:00:35.477782Z",
+    "inactivity_expiration_enabled": false,
+    "approval_required": true,
+    "country_code": "DE",
+    "city_name": "Berlin",
+    "serial_number": "C02XJ0J0JGH7",
     "extra_dns_labels": [
-      "string"
+      "stage-host-1"
     ],
-    "ephemeral": "boolean",
-    "accessible_peers_count": "integer"
+    "ephemeral": false,
+    "accessible_peers_count": 5
   }
 ]
 ```
@@ -159,46 +159,46 @@ curl -X GET https://api.netbird.io/api/peers/{peerId} \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/peers/{peerId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "name": "string",
-  "created_at": "string",
-  "ip": "string",
-  "connection_ip": "string",
-  "connected": "boolean",
-  "last_seen": "string",
-  "os": "string",
-  "kernel_version": "string",
-  "geoname_id": "integer",
-  "version": "string",
+  "id": "chacbco6lnnbn6cg5s90",
+  "name": "stage-host-1",
+  "created_at": "2023-05-05T09:00:35.477782Z",
+  "ip": "10.64.0.1",
+  "connection_ip": "35.64.0.1",
+  "connected": true,
+  "last_seen": "2023-05-05T10:05:26.420578Z",
+  "os": "Darwin 13.2.1",
+  "kernel_version": "23.2.0",
+  "geoname_id": 2643743,
+  "version": "0.14.0",
   "groups": [
     {
-      "id": "string",
-      "name": "string",
-      "peers_count": "integer",
-      "resources_count": "integer",
-      "issued": "string"
+      "id": "ch8i4ug6lnn4g9hqv7m0",
+      "name": "devs",
+      "peers_count": 2,
+      "resources_count": 5,
+      "issued": "api"
     }
   ],
-  "ssh_enabled": "boolean",
-  "user_id": "string",
-  "hostname": "string",
-  "ui_version": "string",
-  "dns_label": "string",
-  "login_expiration_enabled": "boolean",
-  "login_expired": "boolean",
-  "last_login": "string",
-  "inactivity_expiration_enabled": "boolean",
-  "approval_required": "boolean",
-  "country_code": "string",
-  "city_name": "string",
-  "serial_number": "string",
+  "ssh_enabled": true,
+  "user_id": "google-oauth2|277474792786460067937",
+  "hostname": "stage-host-1",
+  "ui_version": "0.14.0",
+  "dns_label": "stage-host-1.netbird.cloud",
+  "login_expiration_enabled": false,
+  "login_expired": false,
+  "last_login": "2023-05-05T09:00:35.477782Z",
+  "inactivity_expiration_enabled": false,
+  "approval_required": true,
+  "country_code": "DE",
+  "city_name": "Berlin",
+  "serial_number": "C02XJ0J0JGH7",
   "extra_dns_labels": [
-    "string"
+    "stage-host-1"
   ],
-  "ephemeral": "boolean"
+  "ephemeral": false
 }
 ```
 
@@ -302,10 +302,22 @@ Peer's IP address
 <CodeGroup title="Request" tag="PUT" label="/api/peers/{peerId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/peers/{peerId} \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "name": "stage-host-1",
+  "ssh_enabled": true,
+  "login_expiration_enabled": false,
+  "inactivity_expiration_enabled": false,
+  "approval_required": true,
+  "ip": "100.64.0.15"
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "chacbco6lnnbn6cg5s90",
   "name": "stage-host-1",
   "created_at": "2023-05-05T09:00:35.477782Z",
@@ -343,49 +355,6 @@ curl -X PUT https://api.netbird.io/api/peers/{peerId} \
     "stage-host-1"
   ],
   "ephemeral": false
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="PUT" label="/api/peers/{peerId}" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "name": "string",
-  "created_at": "string",
-  "ip": "string",
-  "connection_ip": "string",
-  "connected": "boolean",
-  "last_seen": "string",
-  "os": "string",
-  "kernel_version": "string",
-  "geoname_id": "integer",
-  "version": "string",
-  "groups": [
-    {
-      "id": "string",
-      "name": "string",
-      "peers_count": "integer",
-      "resources_count": "integer",
-      "issued": "string"
-    }
-  ],
-  "ssh_enabled": "boolean",
-  "user_id": "string",
-  "hostname": "string",
-  "ui_version": "string",
-  "dns_label": "string",
-  "login_expiration_enabled": "boolean",
-  "login_expired": "boolean",
-  "last_login": "string",
-  "inactivity_expiration_enabled": "boolean",
-  "approval_required": "boolean",
-  "country_code": "string",
-  "city_name": "string",
-  "serial_number": "string",
-  "extra_dns_labels": [
-    "string"
-  ],
-  "ephemeral": "boolean"
 }
 ```
 
@@ -502,21 +471,21 @@ curl -X GET https://api.netbird.io/api/peers/{peerId}/accessible-peers \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/peers/{peerId}/accessible-peers" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
-    "name": "string",
-    "ip": "string",
-    "dns_label": "string",
-    "user_id": "string",
-    "os": "string",
-    "country_code": "string",
-    "city_name": "string",
-    "geoname_id": "integer",
-    "connected": "boolean",
-    "last_seen": "string"
+    "id": "chacbco6lnnbn6cg5s90",
+    "name": "stage-host-1",
+    "ip": "10.64.0.1",
+    "dns_label": "stage-host-1.netbird.cloud",
+    "user_id": "google-oauth2|277474792786460067937",
+    "os": "linux",
+    "country_code": "DE",
+    "city_name": "Berlin",
+    "geoname_id": 2643743,
+    "connected": true,
+    "last_seen": "2023-05-05T10:05:26.420578Z"
   }
 ]
 ```

--- a/src/pages/ipa/resources/policies.mdx
+++ b/src/pages/ipa/resources/policies.mdx
@@ -5,12 +5,10 @@ export const title = 'Policies'
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all policies
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/policies" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/policies \
@@ -143,6 +141,7 @@ curl -X GET https://api.netbird.io/api/policies \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -151,8 +150,7 @@ curl -X GET https://api.netbird.io/api/policies \
 
 
 <Row>
-
-<Col>
+ <Col>
 Creates a policy
 
 ### Request-Body Parameters
@@ -172,8 +170,7 @@ Policy status
 Posture checks ID's applied to policy source groups
 </Property>
 <Property name="rules" type="object[]" required={true} >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Policy rule object for policy UI editor</summary>
 <Properties>
@@ -199,8 +196,7 @@ Policy rule type of the traffic
 Policy rule affected ports
 </Property>
 <Property name="port_ranges" type="object[]" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Policy rule affected ports ranges list</summary>
 <Properties>
@@ -214,6 +210,7 @@ The ending port of the range
 </Properties>
 
 </details>
+
 </Property>
 <Property name="id" type="string" >
 Policy rule ID
@@ -222,8 +219,7 @@ Policy rule ID
 Policy rule source group IDs
 </Property>
 <Property name="sourceResource" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>More Information</summary>
 <Properties>
@@ -237,13 +233,13 @@ Network resource type based of the address
 </Properties>
 
 </details>
+
 </Property>
 <Property name="destinations" type="string[]" >
 Policy rule destination group IDs
 </Property>
 <Property name="destinationResource" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>More Information</summary>
 <Properties>
@@ -257,18 +253,19 @@ Network resource type based of the address
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="POST" label="/api/policies" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/policies \
@@ -440,6 +437,7 @@ curl -X POST https://api.netbird.io/api/policies \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -448,8 +446,7 @@ curl -X POST https://api.netbird.io/api/policies \
 
 
 <Row>
-
-<Col>
+ <Col>
 Get information about a Policies
 
 ### Path Parameters
@@ -463,8 +460,7 @@ The unique identifier of a policy
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/policies/{policyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/policies/{policyId} \
@@ -593,6 +589,7 @@ curl -X GET https://api.netbird.io/api/policies/{policyId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -601,8 +598,7 @@ curl -X GET https://api.netbird.io/api/policies/{policyId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Update/Replace a Policy
 
 ### Path Parameters
@@ -633,8 +629,7 @@ Policy status
 Posture checks ID's applied to policy source groups
 </Property>
 <Property name="rules" type="object[]" required={true} >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Policy rule object for policy UI editor</summary>
 <Properties>
@@ -660,8 +655,7 @@ Policy rule type of the traffic
 Policy rule affected ports
 </Property>
 <Property name="port_ranges" type="object[]" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Policy rule affected ports ranges list</summary>
 <Properties>
@@ -675,6 +669,7 @@ The ending port of the range
 </Properties>
 
 </details>
+
 </Property>
 <Property name="id" type="string" >
 Policy rule ID
@@ -683,8 +678,7 @@ Policy rule ID
 Policy rule source group IDs
 </Property>
 <Property name="sourceResource" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>More Information</summary>
 <Properties>
@@ -698,13 +692,13 @@ Network resource type based of the address
 </Properties>
 
 </details>
+
 </Property>
 <Property name="destinations" type="string[]" >
 Policy rule destination group IDs
 </Property>
 <Property name="destinationResource" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>More Information</summary>
 <Properties>
@@ -718,18 +712,19 @@ Network resource type based of the address
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="PUT" label="/api/policies/{policyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/policies/{policyId} \
@@ -901,6 +896,7 @@ curl -X PUT https://api.netbird.io/api/policies/{policyId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -909,8 +905,7 @@ curl -X PUT https://api.netbird.io/api/policies/{policyId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Delete a policy
 
 ### Path Parameters
@@ -924,8 +919,7 @@ The unique identifier of a policy
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/policies/{policyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/policies/{policyId} \
@@ -936,4 +930,5 @@ curl -X DELETE https://api.netbird.io/api/policies/{policyId} \
 </Col>
 
 </Row>
+
 ---

--- a/src/pages/ipa/resources/policies.mdx
+++ b/src/pages/ipa/resources/policies.mdx
@@ -15,6 +15,141 @@ curl -X GET https://api.netbird.io/api/policies \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/policies',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/policies"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/policies"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/policies")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/policies")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/policies',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
 </CodeGroup>
 <CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
@@ -269,9 +404,9 @@ Network resource type based of the address
 <CodeGroup title="Request" tag="POST" label="/api/policies" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/policies \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "ch8i4ug6lnn4g9hqv7mg",
   "description": "This is a default policy that allows connections between all the resources",
@@ -314,6 +449,400 @@ curl -X POST https://api.netbird.io/api/policies \
     }
   ]
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "ch8i4ug6lnn4g9hqv7mg",
+  "description": "This is a default policy that allows connections between all the resources",
+  "enabled": true,
+  "source_posture_checks": [
+    "chacdk86lnnboviihd70"
+  ],
+  "rules": [
+    {
+      "name": "Default",
+      "description": "This is a default rule that allows connections between all the resources",
+      "enabled": true,
+      "action": "accept",
+      "bidirectional": true,
+      "protocol": "tcp",
+      "ports": [
+        "80"
+      ],
+      "port_ranges": [
+        {
+          "start": 80,
+          "end": 320
+        }
+      ],
+      "id": "ch8i4ug6lnn4g9hqv7mg",
+      "sources": [
+        "ch8i4ug6lnn4g9hqv797"
+      ],
+      "sourceResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      },
+      "destinations": [
+        "ch8i4ug6lnn4g9h7v7m0"
+      ],
+      "destinationResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      }
+    }
+  ]
+});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/policies',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/policies"
+payload = json.dumps({
+  "name": "ch8i4ug6lnn4g9hqv7mg",
+  "description": "This is a default policy that allows connections between all the resources",
+  "enabled": true,
+  "source_posture_checks": [
+    "chacdk86lnnboviihd70"
+  ],
+  "rules": [
+    {
+      "name": "Default",
+      "description": "This is a default rule that allows connections between all the resources",
+      "enabled": true,
+      "action": "accept",
+      "bidirectional": true,
+      "protocol": "tcp",
+      "ports": [
+        "80"
+      ],
+      "port_ranges": [
+        {
+          "start": 80,
+          "end": 320
+        }
+      ],
+      "id": "ch8i4ug6lnn4g9hqv7mg",
+      "sources": [
+        "ch8i4ug6lnn4g9hqv797"
+      ],
+      "sourceResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      },
+      "destinations": [
+        "ch8i4ug6lnn4g9h7v7m0"
+      ],
+      "destinationResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      }
+    }
+  ]
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/policies"
+  method := "POST"
+  
+  payload := strings.NewReader(`{
+  "name": "ch8i4ug6lnn4g9hqv7mg",
+  "description": "This is a default policy that allows connections between all the resources",
+  "enabled": true,
+  "source_posture_checks": [
+    "chacdk86lnnboviihd70"
+  ],
+  "rules": [
+    {
+      "name": "Default",
+      "description": "This is a default rule that allows connections between all the resources",
+      "enabled": true,
+      "action": "accept",
+      "bidirectional": true,
+      "protocol": "tcp",
+      "ports": [
+        "80"
+      ],
+      "port_ranges": [
+        {
+          "start": 80,
+          "end": 320
+        }
+      ],
+      "id": "ch8i4ug6lnn4g9hqv7mg",
+      "sources": [
+        "ch8i4ug6lnn4g9hqv797"
+      ],
+      "sourceResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      },
+      "destinations": [
+        "ch8i4ug6lnn4g9h7v7m0"
+      ],
+      "destinationResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      }
+    }
+  ]
+}`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/policies")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "ch8i4ug6lnn4g9hqv7mg",
+  "description": "This is a default policy that allows connections between all the resources",
+  "enabled": true,
+  "source_posture_checks": [
+    "chacdk86lnnboviihd70"
+  ],
+  "rules": [
+    {
+      "name": "Default",
+      "description": "This is a default rule that allows connections between all the resources",
+      "enabled": true,
+      "action": "accept",
+      "bidirectional": true,
+      "protocol": "tcp",
+      "ports": [
+        "80"
+      ],
+      "port_ranges": [
+        {
+          "start": 80,
+          "end": 320
+        }
+      ],
+      "id": "ch8i4ug6lnn4g9hqv7mg",
+      "sources": [
+        "ch8i4ug6lnn4g9hqv797"
+      ],
+      "sourceResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      },
+      "destinations": [
+        "ch8i4ug6lnn4g9h7v7m0"
+      ],
+      "destinationResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      }
+    }
+  ]
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{
+  \"name\": \"ch8i4ug6lnn4g9hqv7mg\",
+  \"description\": \"This is a default policy that allows connections between all the resources\",
+  \"enabled\": true,
+  \"source_posture_checks\": [
+    \"chacdk86lnnboviihd70\"
+  ],
+  \"rules\": [
+    {
+      \"name\": \"Default\",
+      \"description\": \"This is a default rule that allows connections between all the resources\",
+      \"enabled\": true,
+      \"action\": \"accept\",
+      \"bidirectional\": true,
+      \"protocol\": \"tcp\",
+      \"ports\": [
+        \"80\"
+      ],
+      \"port_ranges\": [
+        {
+          \"start\": 80,
+          \"end\": 320
+        }
+      ],
+      \"id\": \"ch8i4ug6lnn4g9hqv7mg\",
+      \"sources\": [
+        \"ch8i4ug6lnn4g9hqv797\"
+      ],
+      \"sourceResource\": {
+        \"id\": \"chacdk86lnnboviihd7g\",
+        \"type\": \"host\"
+      },
+      \"destinations\": [
+        \"ch8i4ug6lnn4g9h7v7m0\"
+      ],
+      \"destinationResource\": {
+        \"id\": \"chacdk86lnnboviihd7g\",
+        \"type\": \"host\"
+      }
+    }
+  ]
+}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/policies")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/policies',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "ch8i4ug6lnn4g9hqv7mg",
+  "description": "This is a default policy that allows connections between all the resources",
+  "enabled": true,
+  "source_posture_checks": [
+    "chacdk86lnnboviihd70"
+  ],
+  "rules": [
+    {
+      "name": "Default",
+      "description": "This is a default rule that allows connections between all the resources",
+      "enabled": true,
+      "action": "accept",
+      "bidirectional": true,
+      "protocol": "tcp",
+      "ports": [
+        "80"
+      ],
+      "port_ranges": [
+        {
+          "start": 80,
+          "end": 320
+        }
+      ],
+      "id": "ch8i4ug6lnn4g9hqv7mg",
+      "sources": [
+        "ch8i4ug6lnn4g9hqv797"
+      ],
+      "sourceResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      },
+      "destinations": [
+        "ch8i4ug6lnn4g9h7v7m0"
+      ],
+      "destinationResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      }
+    }
+  ]
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -466,6 +995,141 @@ The unique identifier of a policy
 curl -X GET https://api.netbird.io/api/policies/{policyId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/policies/{policyId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/policies/{policyId}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/policies/{policyId}"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/policies/{policyId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/policies/{policyId}")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/policies/{policyId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -728,9 +1392,9 @@ Network resource type based of the address
 <CodeGroup title="Request" tag="PUT" label="/api/policies/{policyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/policies/{policyId} \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "ch8i4ug6lnn4g9hqv7mg",
   "description": "This is a default policy that allows connections between all the resources",
@@ -773,6 +1437,400 @@ curl -X PUT https://api.netbird.io/api/policies/{policyId} \
     }
   ]
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "ch8i4ug6lnn4g9hqv7mg",
+  "description": "This is a default policy that allows connections between all the resources",
+  "enabled": true,
+  "source_posture_checks": [
+    "chacdk86lnnboviihd70"
+  ],
+  "rules": [
+    {
+      "name": "Default",
+      "description": "This is a default rule that allows connections between all the resources",
+      "enabled": true,
+      "action": "accept",
+      "bidirectional": true,
+      "protocol": "tcp",
+      "ports": [
+        "80"
+      ],
+      "port_ranges": [
+        {
+          "start": 80,
+          "end": 320
+        }
+      ],
+      "id": "ch8i4ug6lnn4g9hqv7mg",
+      "sources": [
+        "ch8i4ug6lnn4g9hqv797"
+      ],
+      "sourceResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      },
+      "destinations": [
+        "ch8i4ug6lnn4g9h7v7m0"
+      ],
+      "destinationResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      }
+    }
+  ]
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/policies/{policyId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/policies/{policyId}"
+payload = json.dumps({
+  "name": "ch8i4ug6lnn4g9hqv7mg",
+  "description": "This is a default policy that allows connections between all the resources",
+  "enabled": true,
+  "source_posture_checks": [
+    "chacdk86lnnboviihd70"
+  ],
+  "rules": [
+    {
+      "name": "Default",
+      "description": "This is a default rule that allows connections between all the resources",
+      "enabled": true,
+      "action": "accept",
+      "bidirectional": true,
+      "protocol": "tcp",
+      "ports": [
+        "80"
+      ],
+      "port_ranges": [
+        {
+          "start": 80,
+          "end": 320
+        }
+      ],
+      "id": "ch8i4ug6lnn4g9hqv7mg",
+      "sources": [
+        "ch8i4ug6lnn4g9hqv797"
+      ],
+      "sourceResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      },
+      "destinations": [
+        "ch8i4ug6lnn4g9h7v7m0"
+      ],
+      "destinationResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      }
+    }
+  ]
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/policies/{policyId}"
+  method := "PUT"
+  
+  payload := strings.NewReader({
+  "name": "ch8i4ug6lnn4g9hqv7mg",
+  "description": "This is a default policy that allows connections between all the resources",
+  "enabled": true,
+  "source_posture_checks": [
+    "chacdk86lnnboviihd70"
+  ],
+  "rules": [
+    {
+      "name": "Default",
+      "description": "This is a default rule that allows connections between all the resources",
+      "enabled": true,
+      "action": "accept",
+      "bidirectional": true,
+      "protocol": "tcp",
+      "ports": [
+        "80"
+      ],
+      "port_ranges": [
+        {
+          "start": 80,
+          "end": 320
+        }
+      ],
+      "id": "ch8i4ug6lnn4g9hqv7mg",
+      "sources": [
+        "ch8i4ug6lnn4g9hqv797"
+      ],
+      "sourceResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      },
+      "destinations": [
+        "ch8i4ug6lnn4g9h7v7m0"
+      ],
+      "destinationResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      }
+    }
+  ]
+})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/policies/{policyId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "ch8i4ug6lnn4g9hqv7mg",
+  "description": "This is a default policy that allows connections between all the resources",
+  "enabled": true,
+  "source_posture_checks": [
+    "chacdk86lnnboviihd70"
+  ],
+  "rules": [
+    {
+      "name": "Default",
+      "description": "This is a default rule that allows connections between all the resources",
+      "enabled": true,
+      "action": "accept",
+      "bidirectional": true,
+      "protocol": "tcp",
+      "ports": [
+        "80"
+      ],
+      "port_ranges": [
+        {
+          "start": 80,
+          "end": 320
+        }
+      ],
+      "id": "ch8i4ug6lnn4g9hqv7mg",
+      "sources": [
+        "ch8i4ug6lnn4g9hqv797"
+      ],
+      "sourceResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      },
+      "destinations": [
+        "ch8i4ug6lnn4g9h7v7m0"
+      ],
+      "destinationResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      }
+    }
+  ]
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "name": "ch8i4ug6lnn4g9hqv7mg",
+  "description": "This is a default policy that allows connections between all the resources",
+  "enabled": true,
+  "source_posture_checks": [
+    "chacdk86lnnboviihd70"
+  ],
+  "rules": [
+    {
+      "name": "Default",
+      "description": "This is a default rule that allows connections between all the resources",
+      "enabled": true,
+      "action": "accept",
+      "bidirectional": true,
+      "protocol": "tcp",
+      "ports": [
+        "80"
+      ],
+      "port_ranges": [
+        {
+          "start": 80,
+          "end": 320
+        }
+      ],
+      "id": "ch8i4ug6lnn4g9hqv7mg",
+      "sources": [
+        "ch8i4ug6lnn4g9hqv797"
+      ],
+      "sourceResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      },
+      "destinations": [
+        "ch8i4ug6lnn4g9h7v7m0"
+      ],
+      "destinationResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      }
+    }
+  ]
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/policies/{policyId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/policies/{policyId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "ch8i4ug6lnn4g9hqv7mg",
+  "description": "This is a default policy that allows connections between all the resources",
+  "enabled": true,
+  "source_posture_checks": [
+    "chacdk86lnnboviihd70"
+  ],
+  "rules": [
+    {
+      "name": "Default",
+      "description": "This is a default rule that allows connections between all the resources",
+      "enabled": true,
+      "action": "accept",
+      "bidirectional": true,
+      "protocol": "tcp",
+      "ports": [
+        "80"
+      ],
+      "port_ranges": [
+        {
+          "start": 80,
+          "end": 320
+        }
+      ],
+      "id": "ch8i4ug6lnn4g9hqv7mg",
+      "sources": [
+        "ch8i4ug6lnn4g9hqv797"
+      ],
+      "sourceResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      },
+      "destinations": [
+        "ch8i4ug6lnn4g9h7v7m0"
+      ],
+      "destinationResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      }
+    }
+  ]
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -923,7 +1981,131 @@ The unique identifier of a policy
 <CodeGroup title="Request" tag="DELETE" label="/api/policies/{policyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/policies/{policyId} \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/policies/{policyId}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/policies/{policyId}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/policies/{policyId}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/policies/{policyId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/policies/{policyId}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/policies/{policyId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 

--- a/src/pages/ipa/resources/policies.mdx
+++ b/src/pages/ipa/resources/policies.mdx
@@ -18,60 +18,60 @@ curl -X GET https://api.netbird.io/api/policies \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/policies" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "name": "string",
-    "description": "string",
-    "enabled": "boolean",
-    "id": "string",
+    "name": "ch8i4ug6lnn4g9hqv7mg",
+    "description": "This is a default policy that allows connections between all the resources",
+    "enabled": true,
+    "id": "ch8i4ug6lnn4g9hqv7mg",
     "source_posture_checks": [
-      "string"
+      "chacdk86lnnboviihd70"
     ],
     "rules": [
       {
-        "name": "string",
-        "description": "string",
-        "enabled": "boolean",
-        "action": "string",
-        "bidirectional": "boolean",
-        "protocol": "string",
+        "name": "Default",
+        "description": "This is a default rule that allows connections between all the resources",
+        "enabled": true,
+        "action": "accept",
+        "bidirectional": true,
+        "protocol": "tcp",
         "ports": [
-          "string"
+          "80"
         ],
         "port_ranges": [
           {
-            "start": "integer",
-            "end": "integer"
+            "start": 80,
+            "end": 320
           }
         ],
-        "id": "string",
+        "id": "ch8i4ug6lnn4g9hqv7mg",
         "sources": [
           {
-            "id": "string",
-            "name": "string",
-            "peers_count": "integer",
-            "resources_count": "integer",
-            "issued": "string"
+            "id": "ch8i4ug6lnn4g9hqv7m0",
+            "name": "devs",
+            "peers_count": 2,
+            "resources_count": 5,
+            "issued": "api"
           }
         ],
         "sourceResource": {
-          "id": "string",
-          "type": "string"
+          "id": "chacdk86lnnboviihd7g",
+          "type": "host"
         },
         "destinations": [
           {
-            "id": "string",
-            "name": "string",
-            "peers_count": "integer",
-            "resources_count": "integer",
-            "issued": "string"
+            "id": "ch8i4ug6lnn4g9hqv7m0",
+            "name": "devs",
+            "peers_count": 2,
+            "resources_count": 5,
+            "issued": "api"
           }
         ],
         "destinationResource": {
-          "id": "string",
-          "type": "string"
+          "id": "chacdk86lnnboviihd7g",
+          "type": "host"
         }
       }
     ]
@@ -159,16 +159,105 @@ Creates a policy
 
 
 <Properties>
-<Property name="body" type="object" >
+<Property name="name" type="string" required={true} >
+Policy name identifier
+</Property>
+<Property name="description" type="string" >
+Policy friendly description
+</Property>
+<Property name="enabled" type="boolean" required={true} >
+Policy status
+</Property>
+<Property name="source_posture_checks" type="string[]" >
+Posture checks ID's applied to policy source groups
+</Property>
+<Property name="rules" type="object[]" required={true} >
 
 <details class="custom-details" open >
 
-<summary>Object list</summary>
+<summary>Policy rule object for policy UI editor</summary>
 <Properties>
+<Property name="name" type="string" required={true} >
+Policy rule name identifier
+</Property>
+<Property name="description" type="string" >
+Policy rule friendly description
+</Property>
+<Property name="enabled" type="boolean" required={true} >
+Policy rule status
+</Property>
+<Property name="action" type="string" required={true} >
+Policy rule accept or drops packets
+</Property>
+<Property name="bidirectional" type="boolean" required={true} >
+Define if the rule is applicable in both directions, sources, and destinations.
+</Property>
+<Property name="protocol" type="string" required={true} >
+Policy rule type of the traffic
+</Property>
+<Property name="ports" type="string[]" >
+Policy rule affected ports
+</Property>
+<Property name="port_ranges" type="object[]" >
 
+<details class="custom-details" open >
+
+<summary>Policy rule affected ports ranges list</summary>
 <Properties>
+<Property name="start" type="integer" required={true} >
+The starting port of the range
+</Property>
+<Property name="end" type="integer" required={true} >
+The ending port of the range
+</Property>
 
 </Properties>
+
+</details>
+</Property>
+<Property name="id" type="string" >
+Policy rule ID
+</Property>
+<Property name="sources" type="string[]" >
+Policy rule source group IDs
+</Property>
+<Property name="sourceResource" type="object" >
+
+<details class="custom-details" open >
+
+<summary>More Information</summary>
+<Properties>
+<Property name="id" type="string" required={true} >
+ID of the resource
+</Property>
+<Property name="type" type="string" required={true} >
+Network resource type based of the address
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="destinations" type="string[]" >
+Policy rule destination group IDs
+</Property>
+<Property name="destinationResource" type="object" >
+
+<details class="custom-details" open >
+
+<summary>More Information</summary>
+<Properties>
+<Property name="id" type="string" required={true} >
+ID of the resource
+</Property>
+<Property name="type" type="string" required={true} >
+Network resource type based of the address
+</Property>
+
+</Properties>
+
+</details>
+</Property>
 
 </Properties>
 
@@ -183,10 +272,56 @@ Creates a policy
 <CodeGroup title="Request" tag="POST" label="/api/policies" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/policies \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "name": "ch8i4ug6lnn4g9hqv7mg",
+  "description": "This is a default policy that allows connections between all the resources",
+  "enabled": true,
+  "source_posture_checks": [
+    "chacdk86lnnboviihd70"
+  ],
+  "rules": [
+    {
+      "name": "Default",
+      "description": "This is a default rule that allows connections between all the resources",
+      "enabled": true,
+      "action": "accept",
+      "bidirectional": true,
+      "protocol": "tcp",
+      "ports": [
+        "80"
+      ],
+      "port_ranges": [
+        {
+          "start": 80,
+          "end": 320
+        }
+      ],
+      "id": "ch8i4ug6lnn4g9hqv7mg",
+      "sources": [
+        "ch8i4ug6lnn4g9hqv797"
+      ],
+      "sourceResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      },
+      "destinations": [
+        "ch8i4ug6lnn4g9h7v7m0"
+      ],
+      "destinationResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      }
+    }
+  ]
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "name": "ch8i4ug6lnn4g9hqv7mg",
   "description": "This is a default policy that allows connections between all the resources",
   "enabled": true,
@@ -237,65 +372,6 @@ curl -X POST https://api.netbird.io/api/policies \
       "destinationResource": {
         "id": "chacdk86lnnboviihd7g",
         "type": "host"
-      }
-    }
-  ]
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="POST" label="/api/policies" >
-```json {{ title: 'Example' }}
-{
-  "name": "string",
-  "description": "string",
-  "enabled": "boolean",
-  "id": "string",
-  "source_posture_checks": [
-    "string"
-  ],
-  "rules": [
-    {
-      "name": "string",
-      "description": "string",
-      "enabled": "boolean",
-      "action": "string",
-      "bidirectional": "boolean",
-      "protocol": "string",
-      "ports": [
-        "string"
-      ],
-      "port_ranges": [
-        {
-          "start": "integer",
-          "end": "integer"
-        }
-      ],
-      "id": "string",
-      "sources": [
-        {
-          "id": "string",
-          "name": "string",
-          "peers_count": "integer",
-          "resources_count": "integer",
-          "issued": "string"
-        }
-      ],
-      "sourceResource": {
-        "id": "string",
-        "type": "string"
-      },
-      "destinations": [
-        {
-          "id": "string",
-          "name": "string",
-          "peers_count": "integer",
-          "resources_count": "integer",
-          "issued": "string"
-        }
-      ],
-      "destinationResource": {
-        "id": "string",
-        "type": "string"
       }
     }
   ]
@@ -396,59 +472,59 @@ curl -X GET https://api.netbird.io/api/policies/{policyId} \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/policies/{policyId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "name": "string",
-  "description": "string",
-  "enabled": "boolean",
-  "id": "string",
+  "name": "ch8i4ug6lnn4g9hqv7mg",
+  "description": "This is a default policy that allows connections between all the resources",
+  "enabled": true,
+  "id": "ch8i4ug6lnn4g9hqv7mg",
   "source_posture_checks": [
-    "string"
+    "chacdk86lnnboviihd70"
   ],
   "rules": [
     {
-      "name": "string",
-      "description": "string",
-      "enabled": "boolean",
-      "action": "string",
-      "bidirectional": "boolean",
-      "protocol": "string",
+      "name": "Default",
+      "description": "This is a default rule that allows connections between all the resources",
+      "enabled": true,
+      "action": "accept",
+      "bidirectional": true,
+      "protocol": "tcp",
       "ports": [
-        "string"
+        "80"
       ],
       "port_ranges": [
         {
-          "start": "integer",
-          "end": "integer"
+          "start": 80,
+          "end": 320
         }
       ],
-      "id": "string",
+      "id": "ch8i4ug6lnn4g9hqv7mg",
       "sources": [
         {
-          "id": "string",
-          "name": "string",
-          "peers_count": "integer",
-          "resources_count": "integer",
-          "issued": "string"
+          "id": "ch8i4ug6lnn4g9hqv7m0",
+          "name": "devs",
+          "peers_count": 2,
+          "resources_count": 5,
+          "issued": "api"
         }
       ],
       "sourceResource": {
-        "id": "string",
-        "type": "string"
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
       },
       "destinations": [
         {
-          "id": "string",
-          "name": "string",
-          "peers_count": "integer",
-          "resources_count": "integer",
-          "issued": "string"
+          "id": "ch8i4ug6lnn4g9hqv7m0",
+          "name": "devs",
+          "peers_count": 2,
+          "resources_count": 5,
+          "issued": "api"
         }
       ],
       "destinationResource": {
-        "id": "string",
-        "type": "string"
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
       }
     }
   ]
@@ -544,16 +620,105 @@ The unique identifier of a policy
 
 
 <Properties>
-<Property name="body" type="object" >
+<Property name="name" type="string" required={true} >
+Policy name identifier
+</Property>
+<Property name="description" type="string" >
+Policy friendly description
+</Property>
+<Property name="enabled" type="boolean" required={true} >
+Policy status
+</Property>
+<Property name="source_posture_checks" type="string[]" >
+Posture checks ID's applied to policy source groups
+</Property>
+<Property name="rules" type="object[]" required={true} >
 
 <details class="custom-details" open >
 
-<summary>Object list</summary>
+<summary>Policy rule object for policy UI editor</summary>
 <Properties>
+<Property name="name" type="string" required={true} >
+Policy rule name identifier
+</Property>
+<Property name="description" type="string" >
+Policy rule friendly description
+</Property>
+<Property name="enabled" type="boolean" required={true} >
+Policy rule status
+</Property>
+<Property name="action" type="string" required={true} >
+Policy rule accept or drops packets
+</Property>
+<Property name="bidirectional" type="boolean" required={true} >
+Define if the rule is applicable in both directions, sources, and destinations.
+</Property>
+<Property name="protocol" type="string" required={true} >
+Policy rule type of the traffic
+</Property>
+<Property name="ports" type="string[]" >
+Policy rule affected ports
+</Property>
+<Property name="port_ranges" type="object[]" >
 
+<details class="custom-details" open >
+
+<summary>Policy rule affected ports ranges list</summary>
 <Properties>
+<Property name="start" type="integer" required={true} >
+The starting port of the range
+</Property>
+<Property name="end" type="integer" required={true} >
+The ending port of the range
+</Property>
 
 </Properties>
+
+</details>
+</Property>
+<Property name="id" type="string" >
+Policy rule ID
+</Property>
+<Property name="sources" type="string[]" >
+Policy rule source group IDs
+</Property>
+<Property name="sourceResource" type="object" >
+
+<details class="custom-details" open >
+
+<summary>More Information</summary>
+<Properties>
+<Property name="id" type="string" required={true} >
+ID of the resource
+</Property>
+<Property name="type" type="string" required={true} >
+Network resource type based of the address
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="destinations" type="string[]" >
+Policy rule destination group IDs
+</Property>
+<Property name="destinationResource" type="object" >
+
+<details class="custom-details" open >
+
+<summary>More Information</summary>
+<Properties>
+<Property name="id" type="string" required={true} >
+ID of the resource
+</Property>
+<Property name="type" type="string" required={true} >
+Network resource type based of the address
+</Property>
+
+</Properties>
+
+</details>
+</Property>
 
 </Properties>
 
@@ -568,10 +733,56 @@ The unique identifier of a policy
 <CodeGroup title="Request" tag="PUT" label="/api/policies/{policyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/policies/{policyId} \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "name": "ch8i4ug6lnn4g9hqv7mg",
+  "description": "This is a default policy that allows connections between all the resources",
+  "enabled": true,
+  "source_posture_checks": [
+    "chacdk86lnnboviihd70"
+  ],
+  "rules": [
+    {
+      "name": "Default",
+      "description": "This is a default rule that allows connections between all the resources",
+      "enabled": true,
+      "action": "accept",
+      "bidirectional": true,
+      "protocol": "tcp",
+      "ports": [
+        "80"
+      ],
+      "port_ranges": [
+        {
+          "start": 80,
+          "end": 320
+        }
+      ],
+      "id": "ch8i4ug6lnn4g9hqv7mg",
+      "sources": [
+        "ch8i4ug6lnn4g9hqv797"
+      ],
+      "sourceResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      },
+      "destinations": [
+        "ch8i4ug6lnn4g9h7v7m0"
+      ],
+      "destinationResource": {
+        "id": "chacdk86lnnboviihd7g",
+        "type": "host"
+      }
+    }
+  ]
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "name": "ch8i4ug6lnn4g9hqv7mg",
   "description": "This is a default policy that allows connections between all the resources",
   "enabled": true,
@@ -622,65 +833,6 @@ curl -X PUT https://api.netbird.io/api/policies/{policyId} \
       "destinationResource": {
         "id": "chacdk86lnnboviihd7g",
         "type": "host"
-      }
-    }
-  ]
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="PUT" label="/api/policies/{policyId}" >
-```json {{ title: 'Example' }}
-{
-  "name": "string",
-  "description": "string",
-  "enabled": "boolean",
-  "id": "string",
-  "source_posture_checks": [
-    "string"
-  ],
-  "rules": [
-    {
-      "name": "string",
-      "description": "string",
-      "enabled": "boolean",
-      "action": "string",
-      "bidirectional": "boolean",
-      "protocol": "string",
-      "ports": [
-        "string"
-      ],
-      "port_ranges": [
-        {
-          "start": "integer",
-          "end": "integer"
-        }
-      ],
-      "id": "string",
-      "sources": [
-        {
-          "id": "string",
-          "name": "string",
-          "peers_count": "integer",
-          "resources_count": "integer",
-          "issued": "string"
-        }
-      ],
-      "sourceResource": {
-        "id": "string",
-        "type": "string"
-      },
-      "destinations": [
-        {
-          "id": "string",
-          "name": "string",
-          "peers_count": "integer",
-          "resources_count": "integer",
-          "issued": "string"
-        }
-      ],
-      "destinationResource": {
-        "id": "string",
-        "type": "string"
       }
     }
   ]

--- a/src/pages/ipa/resources/policies.mdx
+++ b/src/pages/ipa/resources/policies.mdx
@@ -1,223 +1,84 @@
 export const title = 'Policies'
 
 
+## List all Policies {{ tag: 'GET', label: '/api/policies' }}
 
-## List all Policies  {{ tag: 'GET' , label: '/api/policies' }}
 
 <Row>
-  <Col>
-    Returns a list of all policies
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/policies">
+<Col>
+Returns a list of all policies
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/policies" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/policies \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/policies',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/policies"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/policies"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/policies")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/policies")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/policies',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/policies" >
 ```json {{ title: 'Example' }}
 [
   {
-    "name": "ch8i4ug6lnn4g9hqv7mg",
-    "description": "This is a default policy that allows connections between all the resources",
-    "enabled": true,
-    "id": "ch8i4ug6lnn4g9hqv7mg",
+    "name": "string",
+    "description": "string",
+    "enabled": "boolean",
+    "id": "string",
     "source_posture_checks": [
-      "chacdk86lnnboviihd70"
+      "string"
     ],
     "rules": [
       {
-        "name": "Default",
-        "description": "This is a default rule that allows connections between all the resources",
-        "enabled": true,
-        "action": "accept",
-        "bidirectional": true,
-        "protocol": "tcp",
+        "name": "string",
+        "description": "string",
+        "enabled": "boolean",
+        "action": "string",
+        "bidirectional": "boolean",
+        "protocol": "string",
         "ports": [
-          "80"
+          "string"
         ],
         "port_ranges": [
           {
-            "start": 80,
-            "end": 320
+            "start": "integer",
+            "end": "integer"
           }
         ],
-        "id": "ch8i4ug6lnn4g9hqv7mg",
+        "id": "string",
         "sources": [
           {
-            "id": "ch8i4ug6lnn4g9hqv7m0",
-            "name": "devs",
-            "peers_count": 2,
-            "resources_count": 5,
-            "issued": "api"
+            "id": "string",
+            "name": "string",
+            "peers_count": "integer",
+            "resources_count": "integer",
+            "issued": "string"
           }
         ],
         "sourceResource": {
-          "id": "chacdk86lnnboviihd7g",
-          "type": "host"
+          "id": "string",
+          "type": "string"
         },
         "destinations": [
           {
-            "id": "ch8i4ug6lnn4g9hqv7m0",
-            "name": "devs",
-            "peers_count": 2,
-            "resources_count": 5,
-            "issued": "api"
+            "id": "string",
+            "name": "string",
+            "peers_count": "integer",
+            "resources_count": "integer",
+            "issued": "string"
           }
         ],
         "destinationResource": {
-          "id": "chacdk86lnnboviihd7g",
-          "type": "host"
+          "id": "string",
+          "type": "string"
         }
       }
     ]
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -277,178 +138,49 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Create a Policy  {{ tag: 'POST' , label: '/api/policies' }}
+
+## Create a Policy {{ tag: 'POST', label: '/api/policies' }}
+
 
 <Row>
-  <Col>
-    Creates a policy
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true}>
-        
-            Policy name identifier
-        
-        </Property>
-    <Property name="description" type="string" required={false}>
-        
-            Policy friendly description
-        
-        </Property>
-    <Property name="enabled" type="boolean" required={true}>
-        
-            Policy status
-        
-        </Property>
-    <Property name="source_posture_checks" type="string[]" required={false}>
-        
-            Posture checks ID's applied to policy source groups
-        
-        </Property>
-    <Property name="rules" type="object[]" required={true}>
-        
-            <details class="custom-details" open>
-                <summary>Policy rule object for policy UI editor</summary>
-                <Properties>
-                
-                    <Properties><Property name="name" type="string" required={true}>
-        
-            Policy rule name identifier
-        
-        </Property>
-    <Property name="description" type="string" required={false}>
-        
-            Policy rule friendly description
-        
-        </Property>
-    <Property name="enabled" type="boolean" required={true}>
-        
-            Policy rule status
-        
-        </Property>
-    <Property name="action" type="string" required={true} enumList={["accept","drop"]}>
-        
-            Policy rule accept or drops packets
-        
-        </Property>
-    <Property name="bidirectional" type="boolean" required={true}>
-        
-            Define if the rule is applicable in both directions, sources, and destinations.
-        
-        </Property>
-    <Property name="protocol" type="string" required={true} enumList={["all","tcp","udp","icmp"]}>
-        
-            Policy rule type of the traffic
-        
-        </Property>
-    <Property name="ports" type="string[]" required={false}>
-        
-            Policy rule affected ports
-        
-        </Property>
-    <Property name="port_ranges" type="object[]" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Policy rule affected ports ranges list</summary>
-                <Properties>
-                
-                    <Properties><Property name="start" type="integer" required={true}>
-        
-            The starting port of the range
-        
-        </Property>
-    <Property name="end" type="integer" required={true}>
-        
-            The ending port of the range
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="id" type="string" required={false}>
-        
-            Policy rule ID
-        
-        </Property>
-    <Property name="sources" type="string[]" required={false}>
-        
-            Policy rule source group IDs
-        
-        </Property>
-    <Property name="sourceResource" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>More Information</summary>
-                <Properties>
-                
-                    <Properties><Property name="id" type="string" required={true}>
-        
-            ID of the resource
-        
-        </Property>
-    <Property name="type" type="string" required={true} enumList={["host","subnet","domain"]}>
-        
-            Network resource type based of the address
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="destinations" type="string[]" required={false}>
-        
-            Policy rule destination group IDs
-        
-        </Property>
-    <Property name="destinationResource" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>More Information</summary>
-                <Properties>
-                
-                    <Properties><Property name="id" type="string" required={true}>
-        
-            ID of the resource
-        
-        </Property>
-    <Property name="type" type="string" required={true} enumList={["host","subnet","domain"]}>
-        
-            Network resource type based of the address
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Creates a policy
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/api/policies">
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="body" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Object list</summary>
+<Properties>
+
+<Properties>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="POST" label="/api/policies" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/policies \
 -H 'Accept: application/json' \
@@ -458,6 +190,7 @@ curl -X POST https://api.netbird.io/api/policies \
   "name": "ch8i4ug6lnn4g9hqv7mg",
   "description": "This is a default policy that allows connections between all the resources",
   "enabled": true,
+  "id": "ch8i4ug6lnn4g9hqv7mg",
   "source_posture_checks": [
     "chacdk86lnnboviihd70"
   ],
@@ -480,14 +213,26 @@ curl -X POST https://api.netbird.io/api/policies \
       ],
       "id": "ch8i4ug6lnn4g9hqv7mg",
       "sources": [
-        "ch8i4ug6lnn4g9hqv797"
+        {
+          "id": "ch8i4ug6lnn4g9hqv7m0",
+          "name": "devs",
+          "peers_count": 2,
+          "resources_count": 5,
+          "issued": "api"
+        }
       ],
       "sourceResource": {
         "id": "chacdk86lnnboviihd7g",
         "type": "host"
       },
       "destinations": [
-        "ch8i4ug6lnn4g9h7v7m0"
+        {
+          "id": "ch8i4ug6lnn4g9hqv7m0",
+          "name": "devs",
+          "peers_count": 2,
+          "resources_count": 5,
+          "issued": "api"
+        }
       ],
       "destinationResource": {
         "id": "chacdk86lnnboviihd7g",
@@ -497,463 +242,66 @@ curl -X POST https://api.netbird.io/api/policies \
   ]
 }'
 ```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "ch8i4ug6lnn4g9hqv7mg",
-  "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
-  "source_posture_checks": [
-    "chacdk86lnnboviihd70"
-  ],
-  "rules": [
-    {
-      "name": "Default",
-      "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
-      "action": "accept",
-      "bidirectional": true,
-      "protocol": "tcp",
-      "ports": [
-        "80"
-      ],
-      "port_ranges": [
-        {
-          "start": 80,
-          "end": 320
-        }
-      ],
-      "id": "ch8i4ug6lnn4g9hqv7mg",
-      "sources": [
-        "ch8i4ug6lnn4g9hqv797"
-      ],
-      "sourceResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      },
-      "destinations": [
-        "ch8i4ug6lnn4g9h7v7m0"
-      ],
-      "destinationResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      }
-    }
-  ]
-});
-let config = {
-  method: 'post',
-  maxBodyLength: Infinity,
-  url: '/api/policies',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/policies"
-payload = json.dumps({
-  "name": "ch8i4ug6lnn4g9hqv7mg",
-  "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
-  "source_posture_checks": [
-    "chacdk86lnnboviihd70"
-  ],
-  "rules": [
-    {
-      "name": "Default",
-      "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
-      "action": "accept",
-      "bidirectional": true,
-      "protocol": "tcp",
-      "ports": [
-        "80"
-      ],
-      "port_ranges": [
-        {
-          "start": 80,
-          "end": 320
-        }
-      ],
-      "id": "ch8i4ug6lnn4g9hqv7mg",
-      "sources": [
-        "ch8i4ug6lnn4g9hqv797"
-      ],
-      "sourceResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      },
-      "destinations": [
-        "ch8i4ug6lnn4g9h7v7m0"
-      ],
-      "destinationResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      }
-    }
-  ]
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("POST", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/policies"
-  method := "POST"
-  
-  payload := strings.NewReader(`{
-  "name": "ch8i4ug6lnn4g9hqv7mg",
-  "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
-  "source_posture_checks": [
-    "chacdk86lnnboviihd70"
-  ],
-  "rules": [
-    {
-      "name": "Default",
-      "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
-      "action": "accept",
-      "bidirectional": true,
-      "protocol": "tcp",
-      "ports": [
-        "80"
-      ],
-      "port_ranges": [
-        {
-          "start": 80,
-          "end": 320
-        }
-      ],
-      "id": "ch8i4ug6lnn4g9hqv7mg",
-      "sources": [
-        "ch8i4ug6lnn4g9hqv797"
-      ],
-      "sourceResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      },
-      "destinations": [
-        "ch8i4ug6lnn4g9h7v7m0"
-      ],
-      "destinationResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      }
-    }
-  ]
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/policies")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Post.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "ch8i4ug6lnn4g9hqv7mg",
-  "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
-  "source_posture_checks": [
-    "chacdk86lnnboviihd70"
-  ],
-  "rules": [
-    {
-      "name": "Default",
-      "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
-      "action": "accept",
-      "bidirectional": true,
-      "protocol": "tcp",
-      "ports": [
-        "80"
-      ],
-      "port_ranges": [
-        {
-          "start": 80,
-          "end": 320
-        }
-      ],
-      "id": "ch8i4ug6lnn4g9hqv7mg",
-      "sources": [
-        "ch8i4ug6lnn4g9hqv797"
-      ],
-      "sourceResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      },
-      "destinations": [
-        "ch8i4ug6lnn4g9h7v7m0"
-      ],
-      "destinationResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      }
-    }
-  ]
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "ch8i4ug6lnn4g9hqv7mg",
-  "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
-  "source_posture_checks": [
-    "chacdk86lnnboviihd70"
-  ],
-  "rules": [
-    {
-      "name": "Default",
-      "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
-      "action": "accept",
-      "bidirectional": true,
-      "protocol": "tcp",
-      "ports": [
-        "80"
-      ],
-      "port_ranges": [
-        {
-          "start": 80,
-          "end": 320
-        }
-      ],
-      "id": "ch8i4ug6lnn4g9hqv7mg",
-      "sources": [
-        "ch8i4ug6lnn4g9hqv797"
-      ],
-      "sourceResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      },
-      "destinations": [
-        "ch8i4ug6lnn4g9h7v7m0"
-      ],
-      "destinationResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      }
-    }
-  ]
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/policies")
-  .method("POST", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/policies',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'POST',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "ch8i4ug6lnn4g9hqv7mg",
-  "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
-  "source_posture_checks": [
-    "chacdk86lnnboviihd70"
-  ],
-  "rules": [
-    {
-      "name": "Default",
-      "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
-      "action": "accept",
-      "bidirectional": true,
-      "protocol": "tcp",
-      "ports": [
-        "80"
-      ],
-      "port_ranges": [
-        {
-          "start": 80,
-          "end": 320
-        }
-      ],
-      "id": "ch8i4ug6lnn4g9hqv7mg",
-      "sources": [
-        "ch8i4ug6lnn4g9hqv797"
-      ],
-      "sourceResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      },
-      "destinations": [
-        "ch8i4ug6lnn4g9h7v7m0"
-      ],
-      "destinationResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      }
-    }
-  ]
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="POST" label="/api/policies" >
 ```json {{ title: 'Example' }}
 {
-  "name": "ch8i4ug6lnn4g9hqv7mg",
-  "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
-  "id": "ch8i4ug6lnn4g9hqv7mg",
+  "name": "string",
+  "description": "string",
+  "enabled": "boolean",
+  "id": "string",
   "source_posture_checks": [
-    "chacdk86lnnboviihd70"
+    "string"
   ],
   "rules": [
     {
-      "name": "Default",
-      "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
-      "action": "accept",
-      "bidirectional": true,
-      "protocol": "tcp",
+      "name": "string",
+      "description": "string",
+      "enabled": "boolean",
+      "action": "string",
+      "bidirectional": "boolean",
+      "protocol": "string",
       "ports": [
-        "80"
+        "string"
       ],
       "port_ranges": [
         {
-          "start": 80,
-          "end": 320
+          "start": "integer",
+          "end": "integer"
         }
       ],
-      "id": "ch8i4ug6lnn4g9hqv7mg",
+      "id": "string",
       "sources": [
         {
-          "id": "ch8i4ug6lnn4g9hqv7m0",
-          "name": "devs",
-          "peers_count": 2,
-          "resources_count": 5,
-          "issued": "api"
+          "id": "string",
+          "name": "string",
+          "peers_count": "integer",
+          "resources_count": "integer",
+          "issued": "string"
         }
       ],
       "sourceResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
+        "id": "string",
+        "type": "string"
       },
       "destinations": [
         {
-          "id": "ch8i4ug6lnn4g9hqv7m0",
-          "name": "devs",
-          "peers_count": 2,
-          "resources_count": 5,
-          "issued": "api"
+          "id": "string",
+          "name": "string",
+          "peers_count": "integer",
+          "resources_count": "integer",
+          "issued": "string"
         }
       ],
       "destinationResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
+        "id": "string",
+        "type": "string"
       }
     }
   ]
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "name": "string",
@@ -1011,237 +359,102 @@ echo $response;
   ]
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Retrieve a Policy  {{ tag: 'GET' , label: '/api/policies/{policyId}' }}
+
+## Retrieve a Policy {{ tag: 'GET', label: '/api/policies/{policyId}' }}
+
 
 <Row>
-  <Col>
-    Get information about a Policies
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="policyId" type="string" required={true}> 
-            The unique identifier of a policy
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/policies/{policyId}">
+<Col>
+Get information about a Policies
+
+### Path Parameters
+
+
+<Properties>
+<Property name="policyId" type="string" required={true} >
+The unique identifier of a policy
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/policies/{policyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/policies/{policyId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/policies/{policyId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/policies/{policyId}"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/policies/{policyId}"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/policies/{policyId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/policies/{policyId}")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/policies/{policyId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/policies/{policyId}" >
 ```json {{ title: 'Example' }}
 {
-  "name": "ch8i4ug6lnn4g9hqv7mg",
-  "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
-  "id": "ch8i4ug6lnn4g9hqv7mg",
+  "name": "string",
+  "description": "string",
+  "enabled": "boolean",
+  "id": "string",
   "source_posture_checks": [
-    "chacdk86lnnboviihd70"
+    "string"
   ],
   "rules": [
     {
-      "name": "Default",
-      "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
-      "action": "accept",
-      "bidirectional": true,
-      "protocol": "tcp",
+      "name": "string",
+      "description": "string",
+      "enabled": "boolean",
+      "action": "string",
+      "bidirectional": "boolean",
+      "protocol": "string",
       "ports": [
-        "80"
+        "string"
       ],
       "port_ranges": [
         {
-          "start": 80,
-          "end": 320
+          "start": "integer",
+          "end": "integer"
         }
       ],
-      "id": "ch8i4ug6lnn4g9hqv7mg",
+      "id": "string",
       "sources": [
         {
-          "id": "ch8i4ug6lnn4g9hqv7m0",
-          "name": "devs",
-          "peers_count": 2,
-          "resources_count": 5,
-          "issued": "api"
+          "id": "string",
+          "name": "string",
+          "peers_count": "integer",
+          "resources_count": "integer",
+          "issued": "string"
         }
       ],
       "sourceResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
+        "id": "string",
+        "type": "string"
       },
       "destinations": [
         {
-          "id": "ch8i4ug6lnn4g9hqv7m0",
-          "name": "devs",
-          "peers_count": 2,
-          "resources_count": 5,
-          "issued": "api"
+          "id": "string",
+          "name": "string",
+          "peers_count": "integer",
+          "resources_count": "integer",
+          "issued": "string"
         }
       ],
       "destinationResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
+        "id": "string",
+        "type": "string"
       }
     }
   ]
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "name": "string",
@@ -1299,186 +512,60 @@ echo $response;
   ]
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Update a Policy  {{ tag: 'PUT' , label: '/api/policies/{policyId}' }}
+
+## Update a Policy {{ tag: 'PUT', label: '/api/policies/{policyId}' }}
+
 
 <Row>
-  <Col>
-    Update/Replace a Policy
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="policyId" type="string" required={true}> 
-            The unique identifier of a policy
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true}>
-        
-            Policy name identifier
-        
-        </Property>
-    <Property name="description" type="string" required={false}>
-        
-            Policy friendly description
-        
-        </Property>
-    <Property name="enabled" type="boolean" required={true}>
-        
-            Policy status
-        
-        </Property>
-    <Property name="source_posture_checks" type="string[]" required={false}>
-        
-            Posture checks ID's applied to policy source groups
-        
-        </Property>
-    <Property name="rules" type="object[]" required={true}>
-        
-            <details class="custom-details" open>
-                <summary>Policy rule object for policy UI editor</summary>
-                <Properties>
-                
-                    <Properties><Property name="name" type="string" required={true}>
-        
-            Policy rule name identifier
-        
-        </Property>
-    <Property name="description" type="string" required={false}>
-        
-            Policy rule friendly description
-        
-        </Property>
-    <Property name="enabled" type="boolean" required={true}>
-        
-            Policy rule status
-        
-        </Property>
-    <Property name="action" type="string" required={true} enumList={["accept","drop"]}>
-        
-            Policy rule accept or drops packets
-        
-        </Property>
-    <Property name="bidirectional" type="boolean" required={true}>
-        
-            Define if the rule is applicable in both directions, sources, and destinations.
-        
-        </Property>
-    <Property name="protocol" type="string" required={true} enumList={["all","tcp","udp","icmp"]}>
-        
-            Policy rule type of the traffic
-        
-        </Property>
-    <Property name="ports" type="string[]" required={false}>
-        
-            Policy rule affected ports
-        
-        </Property>
-    <Property name="port_ranges" type="object[]" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Policy rule affected ports ranges list</summary>
-                <Properties>
-                
-                    <Properties><Property name="start" type="integer" required={true}>
-        
-            The starting port of the range
-        
-        </Property>
-    <Property name="end" type="integer" required={true}>
-        
-            The ending port of the range
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="id" type="string" required={false}>
-        
-            Policy rule ID
-        
-        </Property>
-    <Property name="sources" type="string[]" required={false}>
-        
-            Policy rule source group IDs
-        
-        </Property>
-    <Property name="sourceResource" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>More Information</summary>
-                <Properties>
-                
-                    <Properties><Property name="id" type="string" required={true}>
-        
-            ID of the resource
-        
-        </Property>
-    <Property name="type" type="string" required={true} enumList={["host","subnet","domain"]}>
-        
-            Network resource type based of the address
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="destinations" type="string[]" required={false}>
-        
-            Policy rule destination group IDs
-        
-        </Property>
-    <Property name="destinationResource" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>More Information</summary>
-                <Properties>
-                
-                    <Properties><Property name="id" type="string" required={true}>
-        
-            ID of the resource
-        
-        </Property>
-    <Property name="type" type="string" required={true} enumList={["host","subnet","domain"]}>
-        
-            Network resource type based of the address
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Update/Replace a Policy
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="PUT" label="/api/policies/{policyId}">
+### Path Parameters
+
+
+<Properties>
+<Property name="policyId" type="string" required={true} >
+The unique identifier of a policy
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="body" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Object list</summary>
+<Properties>
+
+<Properties>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="PUT" label="/api/policies/{policyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/policies/{policyId} \
 -H 'Accept: application/json' \
@@ -1488,450 +575,6 @@ curl -X PUT https://api.netbird.io/api/policies/{policyId} \
   "name": "ch8i4ug6lnn4g9hqv7mg",
   "description": "This is a default policy that allows connections between all the resources",
   "enabled": true,
-  "source_posture_checks": [
-    "chacdk86lnnboviihd70"
-  ],
-  "rules": [
-    {
-      "name": "Default",
-      "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
-      "action": "accept",
-      "bidirectional": true,
-      "protocol": "tcp",
-      "ports": [
-        "80"
-      ],
-      "port_ranges": [
-        {
-          "start": 80,
-          "end": 320
-        }
-      ],
-      "id": "ch8i4ug6lnn4g9hqv7mg",
-      "sources": [
-        "ch8i4ug6lnn4g9hqv797"
-      ],
-      "sourceResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      },
-      "destinations": [
-        "ch8i4ug6lnn4g9h7v7m0"
-      ],
-      "destinationResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      }
-    }
-  ]
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "ch8i4ug6lnn4g9hqv7mg",
-  "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
-  "source_posture_checks": [
-    "chacdk86lnnboviihd70"
-  ],
-  "rules": [
-    {
-      "name": "Default",
-      "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
-      "action": "accept",
-      "bidirectional": true,
-      "protocol": "tcp",
-      "ports": [
-        "80"
-      ],
-      "port_ranges": [
-        {
-          "start": 80,
-          "end": 320
-        }
-      ],
-      "id": "ch8i4ug6lnn4g9hqv7mg",
-      "sources": [
-        "ch8i4ug6lnn4g9hqv797"
-      ],
-      "sourceResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      },
-      "destinations": [
-        "ch8i4ug6lnn4g9h7v7m0"
-      ],
-      "destinationResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      }
-    }
-  ]
-});
-let config = {
-  method: 'put',
-  maxBodyLength: Infinity,
-  url: '/api/policies/{policyId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/policies/{policyId}"
-payload = json.dumps({
-  "name": "ch8i4ug6lnn4g9hqv7mg",
-  "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
-  "source_posture_checks": [
-    "chacdk86lnnboviihd70"
-  ],
-  "rules": [
-    {
-      "name": "Default",
-      "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
-      "action": "accept",
-      "bidirectional": true,
-      "protocol": "tcp",
-      "ports": [
-        "80"
-      ],
-      "port_ranges": [
-        {
-          "start": 80,
-          "end": 320
-        }
-      ],
-      "id": "ch8i4ug6lnn4g9hqv7mg",
-      "sources": [
-        "ch8i4ug6lnn4g9hqv797"
-      ],
-      "sourceResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      },
-      "destinations": [
-        "ch8i4ug6lnn4g9h7v7m0"
-      ],
-      "destinationResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      }
-    }
-  ]
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("PUT", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/policies/{policyId}"
-  method := "PUT"
-  
-  payload := strings.NewReader(`{
-  "name": "ch8i4ug6lnn4g9hqv7mg",
-  "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
-  "source_posture_checks": [
-    "chacdk86lnnboviihd70"
-  ],
-  "rules": [
-    {
-      "name": "Default",
-      "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
-      "action": "accept",
-      "bidirectional": true,
-      "protocol": "tcp",
-      "ports": [
-        "80"
-      ],
-      "port_ranges": [
-        {
-          "start": 80,
-          "end": 320
-        }
-      ],
-      "id": "ch8i4ug6lnn4g9hqv7mg",
-      "sources": [
-        "ch8i4ug6lnn4g9hqv797"
-      ],
-      "sourceResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      },
-      "destinations": [
-        "ch8i4ug6lnn4g9h7v7m0"
-      ],
-      "destinationResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      }
-    }
-  ]
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/policies/{policyId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Put.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "ch8i4ug6lnn4g9hqv7mg",
-  "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
-  "source_posture_checks": [
-    "chacdk86lnnboviihd70"
-  ],
-  "rules": [
-    {
-      "name": "Default",
-      "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
-      "action": "accept",
-      "bidirectional": true,
-      "protocol": "tcp",
-      "ports": [
-        "80"
-      ],
-      "port_ranges": [
-        {
-          "start": 80,
-          "end": 320
-        }
-      ],
-      "id": "ch8i4ug6lnn4g9hqv7mg",
-      "sources": [
-        "ch8i4ug6lnn4g9hqv797"
-      ],
-      "sourceResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      },
-      "destinations": [
-        "ch8i4ug6lnn4g9h7v7m0"
-      ],
-      "destinationResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      }
-    }
-  ]
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "ch8i4ug6lnn4g9hqv7mg",
-  "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
-  "source_posture_checks": [
-    "chacdk86lnnboviihd70"
-  ],
-  "rules": [
-    {
-      "name": "Default",
-      "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
-      "action": "accept",
-      "bidirectional": true,
-      "protocol": "tcp",
-      "ports": [
-        "80"
-      ],
-      "port_ranges": [
-        {
-          "start": 80,
-          "end": 320
-        }
-      ],
-      "id": "ch8i4ug6lnn4g9hqv7mg",
-      "sources": [
-        "ch8i4ug6lnn4g9hqv797"
-      ],
-      "sourceResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      },
-      "destinations": [
-        "ch8i4ug6lnn4g9h7v7m0"
-      ],
-      "destinationResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      }
-    }
-  ]
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/policies/{policyId}")
-  .method("PUT", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/policies/{policyId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'PUT',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "ch8i4ug6lnn4g9hqv7mg",
-  "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
-  "source_posture_checks": [
-    "chacdk86lnnboviihd70"
-  ],
-  "rules": [
-    {
-      "name": "Default",
-      "description": "This is a default rule that allows connections between all the resources",
-      "enabled": true,
-      "action": "accept",
-      "bidirectional": true,
-      "protocol": "tcp",
-      "ports": [
-        "80"
-      ],
-      "port_ranges": [
-        {
-          "start": 80,
-          "end": 320
-        }
-      ],
-      "id": "ch8i4ug6lnn4g9hqv7mg",
-      "sources": [
-        "ch8i4ug6lnn4g9hqv797"
-      ],
-      "sourceResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      },
-      "destinations": [
-        "ch8i4ug6lnn4g9h7v7m0"
-      ],
-      "destinationResource": {
-        "id": "chacdk86lnnboviihd7g",
-        "type": "host"
-      }
-    }
-  ]
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
-  "name": "ch8i4ug6lnn4g9hqv7mg",
-  "description": "This is a default policy that allows connections between all the resources",
-  "enabled": true,
   "id": "ch8i4ug6lnn4g9hqv7mg",
   "source_posture_checks": [
     "chacdk86lnnboviihd70"
@@ -1982,8 +625,68 @@ echo $response;
       }
     }
   ]
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="PUT" label="/api/policies/{policyId}" >
+```json {{ title: 'Example' }}
+{
+  "name": "string",
+  "description": "string",
+  "enabled": "boolean",
+  "id": "string",
+  "source_posture_checks": [
+    "string"
+  ],
+  "rules": [
+    {
+      "name": "string",
+      "description": "string",
+      "enabled": "boolean",
+      "action": "string",
+      "bidirectional": "boolean",
+      "protocol": "string",
+      "ports": [
+        "string"
+      ],
+      "port_ranges": [
+        {
+          "start": "integer",
+          "end": "integer"
+        }
+      ],
+      "id": "string",
+      "sources": [
+        {
+          "id": "string",
+          "name": "string",
+          "peers_count": "integer",
+          "resources_count": "integer",
+          "issued": "string"
+        }
+      ],
+      "sourceResource": {
+        "id": "string",
+        "type": "string"
+      },
+      "destinations": [
+        {
+          "id": "string",
+          "name": "string",
+          "peers_count": "integer",
+          "resources_count": "integer",
+          "issued": "string"
+        }
+      ],
+      "destinationResource": {
+        "id": "string",
+        "type": "string"
+      }
+    }
+  ]
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "name": "string",
@@ -2041,174 +744,44 @@ echo $response;
   ]
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Delete a Policy  {{ tag: 'DELETE' , label: '/api/policies/{policyId}' }}
+
+## Delete a Policy {{ tag: 'DELETE', label: '/api/policies/{policyId}' }}
+
 
 <Row>
-  <Col>
-    Delete a policy
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="policyId" type="string" required={true}> 
-            The unique identifier of a policy
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="DELETE" label="/api/policies/{policyId}">
+<Col>
+Delete a policy
+
+### Path Parameters
+
+
+<Properties>
+<Property name="policyId" type="string" required={true} >
+The unique identifier of a policy
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/policies/{policyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/policies/{policyId} \
--H 'Authorization: Token <TOKEN>' 
+-H 'Authorization: Token <TOKEN>' \
 ```
+</CodeGroup>
 
-```js
-const axios = require('axios');
+</Col>
 
-let config = {
-  method: 'delete',
-  maxBodyLength: Infinity,
-  url: '/api/policies/{policyId}',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/policies/{policyId}"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("DELETE", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/policies/{policyId}"
-  method := "DELETE"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/policies/{policyId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Delete.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/policies/{policyId}")
-  .method("DELETE")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/policies/{policyId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'DELETE',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
 </Row>
-
 ---

--- a/src/pages/ipa/resources/posture-checks.mdx
+++ b/src/pages/ipa/resources/posture-checks.mdx
@@ -15,6 +15,141 @@ curl -X GET https://api.netbird.io/api/posture-checks \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/posture-checks',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/posture-checks"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/posture-checks"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/posture-checks")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/posture-checks")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/posture-checks',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
 </CodeGroup>
 <CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
@@ -350,9 +485,9 @@ Path to the process executable file in a Windows operating system
 <CodeGroup title="Request" tag="POST" label="/api/posture-checks" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/posture-checks \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "Default",
   "description": "This checks if the peer is running required NetBird's version",
@@ -405,6 +540,460 @@ curl -X POST https://api.netbird.io/api/posture-checks \
     }
   }
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "Default",
+  "description": "This checks if the peer is running required NetBird's version",
+  "checks": {
+    "nb_version_check": {
+      "min_version": "14.3"
+    },
+    "os_version_check": {
+      "android": {
+        "min_version": "13"
+      },
+      "ios": {
+        "min_version": "17.3.1"
+      },
+      "darwin": {
+        "min_version": "14.2.1"
+      },
+      "linux": {
+        "min_kernel_version": "5.3.3"
+      },
+      "windows": {
+        "min_kernel_version": "10.0.1234"
+      }
+    },
+    "geo_location_check": {
+      "locations": [
+        {
+          "country_code": "DE",
+          "city_name": "Berlin"
+        }
+      ],
+      "action": "allow"
+    },
+    "peer_network_range_check": {
+      "ranges": [
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "2001:db8:1234:1a00::/56"
+      ],
+      "action": "allow"
+    },
+    "process_check": {
+      "processes": [
+        {
+          "linux_path": "/usr/local/bin/netbird",
+          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
+          "windows_path": "C: rogramDataetBird\netbird.exe"
+        }
+      ]
+    }
+  }
+});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/posture-checks',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/posture-checks"
+payload = json.dumps({
+  "name": "Default",
+  "description": "This checks if the peer is running required NetBird's version",
+  "checks": {
+    "nb_version_check": {
+      "min_version": "14.3"
+    },
+    "os_version_check": {
+      "android": {
+        "min_version": "13"
+      },
+      "ios": {
+        "min_version": "17.3.1"
+      },
+      "darwin": {
+        "min_version": "14.2.1"
+      },
+      "linux": {
+        "min_kernel_version": "5.3.3"
+      },
+      "windows": {
+        "min_kernel_version": "10.0.1234"
+      }
+    },
+    "geo_location_check": {
+      "locations": [
+        {
+          "country_code": "DE",
+          "city_name": "Berlin"
+        }
+      ],
+      "action": "allow"
+    },
+    "peer_network_range_check": {
+      "ranges": [
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "2001:db8:1234:1a00::/56"
+      ],
+      "action": "allow"
+    },
+    "process_check": {
+      "processes": [
+        {
+          "linux_path": "/usr/local/bin/netbird",
+          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
+          "windows_path": "C: rogramDataetBird\netbird.exe"
+        }
+      ]
+    }
+  }
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/posture-checks"
+  method := "POST"
+  
+  payload := strings.NewReader(`{
+  "name": "Default",
+  "description": "This checks if the peer is running required NetBird's version",
+  "checks": {
+    "nb_version_check": {
+      "min_version": "14.3"
+    },
+    "os_version_check": {
+      "android": {
+        "min_version": "13"
+      },
+      "ios": {
+        "min_version": "17.3.1"
+      },
+      "darwin": {
+        "min_version": "14.2.1"
+      },
+      "linux": {
+        "min_kernel_version": "5.3.3"
+      },
+      "windows": {
+        "min_kernel_version": "10.0.1234"
+      }
+    },
+    "geo_location_check": {
+      "locations": [
+        {
+          "country_code": "DE",
+          "city_name": "Berlin"
+        }
+      ],
+      "action": "allow"
+    },
+    "peer_network_range_check": {
+      "ranges": [
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "2001:db8:1234:1a00::/56"
+      ],
+      "action": "allow"
+    },
+    "process_check": {
+      "processes": [
+        {
+          "linux_path": "/usr/local/bin/netbird",
+          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
+          "windows_path": "C: rogramDataetBird\netbird.exe"
+        }
+      ]
+    }
+  }
+}`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/posture-checks")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "Default",
+  "description": "This checks if the peer is running required NetBird's version",
+  "checks": {
+    "nb_version_check": {
+      "min_version": "14.3"
+    },
+    "os_version_check": {
+      "android": {
+        "min_version": "13"
+      },
+      "ios": {
+        "min_version": "17.3.1"
+      },
+      "darwin": {
+        "min_version": "14.2.1"
+      },
+      "linux": {
+        "min_kernel_version": "5.3.3"
+      },
+      "windows": {
+        "min_kernel_version": "10.0.1234"
+      }
+    },
+    "geo_location_check": {
+      "locations": [
+        {
+          "country_code": "DE",
+          "city_name": "Berlin"
+        }
+      ],
+      "action": "allow"
+    },
+    "peer_network_range_check": {
+      "ranges": [
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "2001:db8:1234:1a00::/56"
+      ],
+      "action": "allow"
+    },
+    "process_check": {
+      "processes": [
+        {
+          "linux_path": "/usr/local/bin/netbird",
+          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
+          "windows_path": "C: rogramDataetBird\netbird.exe"
+        }
+      ]
+    }
+  }
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{
+  \"name\": \"Default\",
+  \"description\": \"This checks if the peer is running required NetBird's version\",
+  \"checks\": {
+    \"nb_version_check\": {
+      \"min_version\": \"14.3\"
+    },
+    \"os_version_check\": {
+      \"android\": {
+        \"min_version\": \"13\"
+      },
+      \"ios\": {
+        \"min_version\": \"17.3.1\"
+      },
+      \"darwin\": {
+        \"min_version\": \"14.2.1\"
+      },
+      \"linux\": {
+        \"min_kernel_version\": \"5.3.3\"
+      },
+      \"windows\": {
+        \"min_kernel_version\": \"10.0.1234\"
+      }
+    },
+    \"geo_location_check\": {
+      \"locations\": [
+        {
+          \"country_code\": \"DE\",
+          \"city_name\": \"Berlin\"
+        }
+      ],
+      \"action\": \"allow\"
+    },
+    \"peer_network_range_check\": {
+      \"ranges\": [
+        \"192.168.1.0/24\",
+        \"10.0.0.0/8\",
+        \"2001:db8:1234:1a00::/56\"
+      ],
+      \"action\": \"allow\"
+    },
+    \"process_check\": {
+      \"processes\": [
+        {
+          \"linux_path\": \"/usr/local/bin/netbird\",
+          \"mac_path\": \"/Applications/NetBird.app/Contents/MacOS/netbird\",
+          \"windows_path\": \"C: rogramDataetBird\netbird.exe\"
+        }
+      ]
+    }
+  }
+}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/posture-checks")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/posture-checks',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "Default",
+  "description": "This checks if the peer is running required NetBird's version",
+  "checks": {
+    "nb_version_check": {
+      "min_version": "14.3"
+    },
+    "os_version_check": {
+      "android": {
+        "min_version": "13"
+      },
+      "ios": {
+        "min_version": "17.3.1"
+      },
+      "darwin": {
+        "min_version": "14.2.1"
+      },
+      "linux": {
+        "min_kernel_version": "5.3.3"
+      },
+      "windows": {
+        "min_kernel_version": "10.0.1234"
+      }
+    },
+    "geo_location_check": {
+      "locations": [
+        {
+          "country_code": "DE",
+          "city_name": "Berlin"
+        }
+      ],
+      "action": "allow"
+    },
+    "peer_network_range_check": {
+      "ranges": [
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "2001:db8:1234:1a00::/56"
+      ],
+      "action": "allow"
+    },
+    "process_check": {
+      "processes": [
+        {
+          "linux_path": "/usr/local/bin/netbird",
+          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
+          "windows_path": "C: rogramDataetBird\netbird.exe"
+        }
+      ]
+    }
+  }
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -551,6 +1140,141 @@ The unique identifier of a posture check
 curl -X GET https://api.netbird.io/api/posture-checks/{postureCheckId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/posture-checks/{postureCheckId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/posture-checks/{postureCheckId}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/posture-checks/{postureCheckId}"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/posture-checks/{postureCheckId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/posture-checks/{postureCheckId}")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/posture-checks/{postureCheckId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -894,9 +1618,9 @@ Path to the process executable file in a Windows operating system
 <CodeGroup title="Request" tag="PUT" label="/api/posture-checks/{postureCheckId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/posture-checks/{postureCheckId} \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "Default",
   "description": "This checks if the peer is running required NetBird's version",
@@ -949,6 +1673,460 @@ curl -X PUT https://api.netbird.io/api/posture-checks/{postureCheckId} \
     }
   }
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "Default",
+  "description": "This checks if the peer is running required NetBird's version",
+  "checks": {
+    "nb_version_check": {
+      "min_version": "14.3"
+    },
+    "os_version_check": {
+      "android": {
+        "min_version": "13"
+      },
+      "ios": {
+        "min_version": "17.3.1"
+      },
+      "darwin": {
+        "min_version": "14.2.1"
+      },
+      "linux": {
+        "min_kernel_version": "5.3.3"
+      },
+      "windows": {
+        "min_kernel_version": "10.0.1234"
+      }
+    },
+    "geo_location_check": {
+      "locations": [
+        {
+          "country_code": "DE",
+          "city_name": "Berlin"
+        }
+      ],
+      "action": "allow"
+    },
+    "peer_network_range_check": {
+      "ranges": [
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "2001:db8:1234:1a00::/56"
+      ],
+      "action": "allow"
+    },
+    "process_check": {
+      "processes": [
+        {
+          "linux_path": "/usr/local/bin/netbird",
+          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
+          "windows_path": "C: rogramDataetBird\netbird.exe"
+        }
+      ]
+    }
+  }
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/posture-checks/{postureCheckId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/posture-checks/{postureCheckId}"
+payload = json.dumps({
+  "name": "Default",
+  "description": "This checks if the peer is running required NetBird's version",
+  "checks": {
+    "nb_version_check": {
+      "min_version": "14.3"
+    },
+    "os_version_check": {
+      "android": {
+        "min_version": "13"
+      },
+      "ios": {
+        "min_version": "17.3.1"
+      },
+      "darwin": {
+        "min_version": "14.2.1"
+      },
+      "linux": {
+        "min_kernel_version": "5.3.3"
+      },
+      "windows": {
+        "min_kernel_version": "10.0.1234"
+      }
+    },
+    "geo_location_check": {
+      "locations": [
+        {
+          "country_code": "DE",
+          "city_name": "Berlin"
+        }
+      ],
+      "action": "allow"
+    },
+    "peer_network_range_check": {
+      "ranges": [
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "2001:db8:1234:1a00::/56"
+      ],
+      "action": "allow"
+    },
+    "process_check": {
+      "processes": [
+        {
+          "linux_path": "/usr/local/bin/netbird",
+          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
+          "windows_path": "C: rogramDataetBird\netbird.exe"
+        }
+      ]
+    }
+  }
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/posture-checks/{postureCheckId}"
+  method := "PUT"
+  
+  payload := strings.NewReader({
+  "name": "Default",
+  "description": "This checks if the peer is running required NetBird's version",
+  "checks": {
+    "nb_version_check": {
+      "min_version": "14.3"
+    },
+    "os_version_check": {
+      "android": {
+        "min_version": "13"
+      },
+      "ios": {
+        "min_version": "17.3.1"
+      },
+      "darwin": {
+        "min_version": "14.2.1"
+      },
+      "linux": {
+        "min_kernel_version": "5.3.3"
+      },
+      "windows": {
+        "min_kernel_version": "10.0.1234"
+      }
+    },
+    "geo_location_check": {
+      "locations": [
+        {
+          "country_code": "DE",
+          "city_name": "Berlin"
+        }
+      ],
+      "action": "allow"
+    },
+    "peer_network_range_check": {
+      "ranges": [
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "2001:db8:1234:1a00::/56"
+      ],
+      "action": "allow"
+    },
+    "process_check": {
+      "processes": [
+        {
+          "linux_path": "/usr/local/bin/netbird",
+          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
+          "windows_path": "C: rogramDataetBird\netbird.exe"
+        }
+      ]
+    }
+  }
+})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/posture-checks/{postureCheckId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "Default",
+  "description": "This checks if the peer is running required NetBird's version",
+  "checks": {
+    "nb_version_check": {
+      "min_version": "14.3"
+    },
+    "os_version_check": {
+      "android": {
+        "min_version": "13"
+      },
+      "ios": {
+        "min_version": "17.3.1"
+      },
+      "darwin": {
+        "min_version": "14.2.1"
+      },
+      "linux": {
+        "min_kernel_version": "5.3.3"
+      },
+      "windows": {
+        "min_kernel_version": "10.0.1234"
+      }
+    },
+    "geo_location_check": {
+      "locations": [
+        {
+          "country_code": "DE",
+          "city_name": "Berlin"
+        }
+      ],
+      "action": "allow"
+    },
+    "peer_network_range_check": {
+      "ranges": [
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "2001:db8:1234:1a00::/56"
+      ],
+      "action": "allow"
+    },
+    "process_check": {
+      "processes": [
+        {
+          "linux_path": "/usr/local/bin/netbird",
+          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
+          "windows_path": "C: rogramDataetBird\netbird.exe"
+        }
+      ]
+    }
+  }
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "name": "Default",
+  "description": "This checks if the peer is running required NetBird's version",
+  "checks": {
+    "nb_version_check": {
+      "min_version": "14.3"
+    },
+    "os_version_check": {
+      "android": {
+        "min_version": "13"
+      },
+      "ios": {
+        "min_version": "17.3.1"
+      },
+      "darwin": {
+        "min_version": "14.2.1"
+      },
+      "linux": {
+        "min_kernel_version": "5.3.3"
+      },
+      "windows": {
+        "min_kernel_version": "10.0.1234"
+      }
+    },
+    "geo_location_check": {
+      "locations": [
+        {
+          "country_code": "DE",
+          "city_name": "Berlin"
+        }
+      ],
+      "action": "allow"
+    },
+    "peer_network_range_check": {
+      "ranges": [
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "2001:db8:1234:1a00::/56"
+      ],
+      "action": "allow"
+    },
+    "process_check": {
+      "processes": [
+        {
+          "linux_path": "/usr/local/bin/netbird",
+          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
+          "windows_path": "C: rogramDataetBird\netbird.exe"
+        }
+      ]
+    }
+  }
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/posture-checks/{postureCheckId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/posture-checks/{postureCheckId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "Default",
+  "description": "This checks if the peer is running required NetBird's version",
+  "checks": {
+    "nb_version_check": {
+      "min_version": "14.3"
+    },
+    "os_version_check": {
+      "android": {
+        "min_version": "13"
+      },
+      "ios": {
+        "min_version": "17.3.1"
+      },
+      "darwin": {
+        "min_version": "14.2.1"
+      },
+      "linux": {
+        "min_kernel_version": "5.3.3"
+      },
+      "windows": {
+        "min_kernel_version": "10.0.1234"
+      }
+    },
+    "geo_location_check": {
+      "locations": [
+        {
+          "country_code": "DE",
+          "city_name": "Berlin"
+        }
+      ],
+      "action": "allow"
+    },
+    "peer_network_range_check": {
+      "ranges": [
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "2001:db8:1234:1a00::/56"
+      ],
+      "action": "allow"
+    },
+    "process_check": {
+      "processes": [
+        {
+          "linux_path": "/usr/local/bin/netbird",
+          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
+          "windows_path": "C: rogramDataetBird\netbird.exe"
+        }
+      ]
+    }
+  }
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -1093,7 +2271,131 @@ The unique identifier of a posture check
 <CodeGroup title="Request" tag="DELETE" label="/api/posture-checks/{postureCheckId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/posture-checks/{postureCheckId} \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/posture-checks/{postureCheckId}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/posture-checks/{postureCheckId}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/posture-checks/{postureCheckId}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/posture-checks/{postureCheckId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/posture-checks/{postureCheckId}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/posture-checks/{postureCheckId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 

--- a/src/pages/ipa/resources/posture-checks.mdx
+++ b/src/pages/ipa/resources/posture-checks.mdx
@@ -18,55 +18,57 @@ curl -X GET https://api.netbird.io/api/posture-checks \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/posture-checks" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
-    "name": "string",
-    "description": "string",
+    "id": "ch8i4ug6lnn4g9hqv7mg",
+    "name": "Default",
+    "description": "This checks if the peer is running required NetBird's version",
     "checks": {
       "nb_version_check": {
-        "min_version": "string"
+        "min_version": "14.3"
       },
       "os_version_check": {
         "android": {
-          "min_version": "string"
-        },
-        "darwin": {
-          "min_version": "string"
+          "min_version": "13"
         },
         "ios": {
-          "min_version": "string"
+          "min_version": "17.3.1"
+        },
+        "darwin": {
+          "min_version": "14.2.1"
         },
         "linux": {
-          "min_kernel_version": "string"
+          "min_kernel_version": "5.3.3"
         },
         "windows": {
-          "min_kernel_version": "string"
+          "min_kernel_version": "10.0.1234"
         }
       },
       "geo_location_check": {
         "locations": [
           {
-            "country_code": "string",
-            "city_name": "string"
+            "country_code": "DE",
+            "city_name": "Berlin"
           }
         ],
-        "action": "string"
+        "action": "allow"
       },
       "peer_network_range_check": {
         "ranges": [
-          "string"
+          "192.168.1.0/24",
+          "10.0.0.0/8",
+          "2001:db8:1234:1a00::/56"
         ],
-        "action": "string"
+        "action": "allow"
       },
       "process_check": {
         "processes": [
           {
-            "linux_path": "string",
-            "mac_path": "string",
-            "windows_path": "string"
+            "linux_path": "/usr/local/bin/netbird",
+            "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
+            "windows_path": "C: rogramDataetBird\netbird.exe"
           }
         ]
       }
@@ -161,27 +163,182 @@ Posture check friendly description
 
 <details class="custom-details" open >
 
-<summary>Object list</summary>
-<Properties>
-
+<summary>List of objects that perform the actual checks</summary>
 <Properties>
 <Property name="nb_version_check" type="object" >
 
-</Property>
-<Property name="os_version_check" type="object" >
+<details class="custom-details" open >
 
-</Property>
-<Property name="geo_location_check" type="object" >
-
-</Property>
-<Property name="peer_network_range_check" type="object" >
-
-</Property>
-<Property name="process_check" type="object" >
-
+<summary>Posture check for the version of operating system</summary>
+<Properties>
+<Property name="min_version" type="string" required={true} >
+Minimum acceptable version
 </Property>
 
 </Properties>
+
+</details>
+</Property>
+<Property name="os_version_check" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check for the version of operating system</summary>
+<Properties>
+<Property name="android" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check for the version of operating system</summary>
+<Properties>
+<Property name="min_version" type="string" required={true} >
+Minimum acceptable version
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="darwin" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check for the version of operating system</summary>
+<Properties>
+<Property name="min_version" type="string" required={true} >
+Minimum acceptable version
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="ios" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check for the version of operating system</summary>
+<Properties>
+<Property name="min_version" type="string" required={true} >
+Minimum acceptable version
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="linux" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check with the kernel version</summary>
+<Properties>
+<Property name="min_kernel_version" type="string" required={true} >
+Minimum acceptable version
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="windows" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check with the kernel version</summary>
+<Properties>
+<Property name="min_kernel_version" type="string" required={true} >
+Minimum acceptable version
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="geo_location_check" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check for geo location</summary>
+<Properties>
+<Property name="locations" type="object[]" required={true} >
+
+<details class="custom-details" open >
+
+<summary>List of geo locations to which the policy applies</summary>
+<Properties>
+<Property name="country_code" type="string" required={true} >
+2-letter ISO 3166-1 alpha-2 code that represents the country
+</Property>
+<Property name="city_name" type="string" >
+Commonly used English name of the city
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="action" type="string" required={true} >
+Action to take upon policy match
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="peer_network_range_check" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check for allow or deny access based on peer local network addresses</summary>
+<Properties>
+<Property name="ranges" type="string[]" required={true} >
+List of peer network ranges in CIDR notation
+</Property>
+<Property name="action" type="string" required={true} >
+Action to take upon policy match
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="process_check" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture Check for binaries exist and are running in the peer’s system</summary>
+<Properties>
+<Property name="processes" type="object[]" required={true} >
+
+<details class="custom-details" open >
+
+<summary>More Information</summary>
+<Properties>
+<Property name="linux_path" type="string" >
+Path to the process executable file in a Linux operating system
+</Property>
+<Property name="mac_path" type="string" >
+Path to the process executable file in a Mac operating system
+</Property>
+<Property name="windows_path" type="string" >
+Path to the process executable file in a Windows operating system
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+
+</Properties>
+
+</details>
+</Property>
 
 </Properties>
 
@@ -196,11 +353,10 @@ Posture check friendly description
 <CodeGroup title="Request" tag="POST" label="/api/posture-checks" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/posture-checks \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "id": "ch8i4ug6lnn4g9hqv7mg",
   "name": "Default",
   "description": "This checks if the peer is running required NetBird's version",
   "checks": {
@@ -254,54 +410,56 @@ curl -X POST https://api.netbird.io/api/posture-checks \
 }'
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="POST" label="/api/posture-checks" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "name": "string",
-  "description": "string",
+  "id": "ch8i4ug6lnn4g9hqv7mg",
+  "name": "Default",
+  "description": "This checks if the peer is running required NetBird's version",
   "checks": {
     "nb_version_check": {
-      "min_version": "string"
+      "min_version": "14.3"
     },
     "os_version_check": {
       "android": {
-        "min_version": "string"
-      },
-      "darwin": {
-        "min_version": "string"
+        "min_version": "13"
       },
       "ios": {
-        "min_version": "string"
+        "min_version": "17.3.1"
+      },
+      "darwin": {
+        "min_version": "14.2.1"
       },
       "linux": {
-        "min_kernel_version": "string"
+        "min_kernel_version": "5.3.3"
       },
       "windows": {
-        "min_kernel_version": "string"
+        "min_kernel_version": "10.0.1234"
       }
     },
     "geo_location_check": {
       "locations": [
         {
-          "country_code": "string",
-          "city_name": "string"
+          "country_code": "DE",
+          "city_name": "Berlin"
         }
       ],
-      "action": "string"
+      "action": "allow"
     },
     "peer_network_range_check": {
       "ranges": [
-        "string"
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "2001:db8:1234:1a00::/56"
       ],
-      "action": "string"
+      "action": "allow"
     },
     "process_check": {
       "processes": [
         {
-          "linux_path": "string",
-          "mac_path": "string",
-          "windows_path": "string"
+          "linux_path": "/usr/local/bin/netbird",
+          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
+          "windows_path": "C: rogramDataetBird\netbird.exe"
         }
       ]
     }
@@ -399,54 +557,56 @@ curl -X GET https://api.netbird.io/api/posture-checks/{postureCheckId} \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/posture-checks/{postureCheckId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "name": "string",
-  "description": "string",
+  "id": "ch8i4ug6lnn4g9hqv7mg",
+  "name": "Default",
+  "description": "This checks if the peer is running required NetBird's version",
   "checks": {
     "nb_version_check": {
-      "min_version": "string"
+      "min_version": "14.3"
     },
     "os_version_check": {
       "android": {
-        "min_version": "string"
-      },
-      "darwin": {
-        "min_version": "string"
+        "min_version": "13"
       },
       "ios": {
-        "min_version": "string"
+        "min_version": "17.3.1"
+      },
+      "darwin": {
+        "min_version": "14.2.1"
       },
       "linux": {
-        "min_kernel_version": "string"
+        "min_kernel_version": "5.3.3"
       },
       "windows": {
-        "min_kernel_version": "string"
+        "min_kernel_version": "10.0.1234"
       }
     },
     "geo_location_check": {
       "locations": [
         {
-          "country_code": "string",
-          "city_name": "string"
+          "country_code": "DE",
+          "city_name": "Berlin"
         }
       ],
-      "action": "string"
+      "action": "allow"
     },
     "peer_network_range_check": {
       "ranges": [
-        "string"
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "2001:db8:1234:1a00::/56"
       ],
-      "action": "string"
+      "action": "allow"
     },
     "process_check": {
       "processes": [
         {
-          "linux_path": "string",
-          "mac_path": "string",
-          "windows_path": "string"
+          "linux_path": "/usr/local/bin/netbird",
+          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
+          "windows_path": "C: rogramDataetBird\netbird.exe"
         }
       ]
     }
@@ -549,27 +709,182 @@ Posture check friendly description
 
 <details class="custom-details" open >
 
-<summary>Object list</summary>
-<Properties>
-
+<summary>List of objects that perform the actual checks</summary>
 <Properties>
 <Property name="nb_version_check" type="object" >
 
-</Property>
-<Property name="os_version_check" type="object" >
+<details class="custom-details" open >
 
-</Property>
-<Property name="geo_location_check" type="object" >
-
-</Property>
-<Property name="peer_network_range_check" type="object" >
-
-</Property>
-<Property name="process_check" type="object" >
-
+<summary>Posture check for the version of operating system</summary>
+<Properties>
+<Property name="min_version" type="string" required={true} >
+Minimum acceptable version
 </Property>
 
 </Properties>
+
+</details>
+</Property>
+<Property name="os_version_check" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check for the version of operating system</summary>
+<Properties>
+<Property name="android" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check for the version of operating system</summary>
+<Properties>
+<Property name="min_version" type="string" required={true} >
+Minimum acceptable version
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="darwin" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check for the version of operating system</summary>
+<Properties>
+<Property name="min_version" type="string" required={true} >
+Minimum acceptable version
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="ios" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check for the version of operating system</summary>
+<Properties>
+<Property name="min_version" type="string" required={true} >
+Minimum acceptable version
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="linux" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check with the kernel version</summary>
+<Properties>
+<Property name="min_kernel_version" type="string" required={true} >
+Minimum acceptable version
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="windows" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check with the kernel version</summary>
+<Properties>
+<Property name="min_kernel_version" type="string" required={true} >
+Minimum acceptable version
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="geo_location_check" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check for geo location</summary>
+<Properties>
+<Property name="locations" type="object[]" required={true} >
+
+<details class="custom-details" open >
+
+<summary>List of geo locations to which the policy applies</summary>
+<Properties>
+<Property name="country_code" type="string" required={true} >
+2-letter ISO 3166-1 alpha-2 code that represents the country
+</Property>
+<Property name="city_name" type="string" >
+Commonly used English name of the city
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="action" type="string" required={true} >
+Action to take upon policy match
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="peer_network_range_check" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture check for allow or deny access based on peer local network addresses</summary>
+<Properties>
+<Property name="ranges" type="string[]" required={true} >
+List of peer network ranges in CIDR notation
+</Property>
+<Property name="action" type="string" required={true} >
+Action to take upon policy match
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+<Property name="process_check" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Posture Check for binaries exist and are running in the peer’s system</summary>
+<Properties>
+<Property name="processes" type="object[]" required={true} >
+
+<details class="custom-details" open >
+
+<summary>More Information</summary>
+<Properties>
+<Property name="linux_path" type="string" >
+Path to the process executable file in a Linux operating system
+</Property>
+<Property name="mac_path" type="string" >
+Path to the process executable file in a Mac operating system
+</Property>
+<Property name="windows_path" type="string" >
+Path to the process executable file in a Windows operating system
+</Property>
+
+</Properties>
+
+</details>
+</Property>
+
+</Properties>
+
+</details>
+</Property>
 
 </Properties>
 
@@ -584,11 +899,10 @@ Posture check friendly description
 <CodeGroup title="Request" tag="PUT" label="/api/posture-checks/{postureCheckId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/posture-checks/{postureCheckId} \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "id": "ch8i4ug6lnn4g9hqv7mg",
   "name": "Default",
   "description": "This checks if the peer is running required NetBird's version",
   "checks": {
@@ -642,54 +956,56 @@ curl -X PUT https://api.netbird.io/api/posture-checks/{postureCheckId} \
 }'
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="PUT" label="/api/posture-checks/{postureCheckId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "name": "string",
-  "description": "string",
+  "id": "ch8i4ug6lnn4g9hqv7mg",
+  "name": "Default",
+  "description": "This checks if the peer is running required NetBird's version",
   "checks": {
     "nb_version_check": {
-      "min_version": "string"
+      "min_version": "14.3"
     },
     "os_version_check": {
       "android": {
-        "min_version": "string"
-      },
-      "darwin": {
-        "min_version": "string"
+        "min_version": "13"
       },
       "ios": {
-        "min_version": "string"
+        "min_version": "17.3.1"
+      },
+      "darwin": {
+        "min_version": "14.2.1"
       },
       "linux": {
-        "min_kernel_version": "string"
+        "min_kernel_version": "5.3.3"
       },
       "windows": {
-        "min_kernel_version": "string"
+        "min_kernel_version": "10.0.1234"
       }
     },
     "geo_location_check": {
       "locations": [
         {
-          "country_code": "string",
-          "city_name": "string"
+          "country_code": "DE",
+          "city_name": "Berlin"
         }
       ],
-      "action": "string"
+      "action": "allow"
     },
     "peer_network_range_check": {
       "ranges": [
-        "string"
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "2001:db8:1234:1a00::/56"
       ],
-      "action": "string"
+      "action": "allow"
     },
     "process_check": {
       "processes": [
         {
-          "linux_path": "string",
-          "mac_path": "string",
-          "windows_path": "string"
+          "linux_path": "/usr/local/bin/netbird",
+          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
+          "windows_path": "C: rogramDataetBird\netbird.exe"
         }
       ]
     }

--- a/src/pages/ipa/resources/posture-checks.mdx
+++ b/src/pages/ipa/resources/posture-checks.mdx
@@ -5,12 +5,10 @@ export const title = 'Posture Checks'
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all posture checks
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/posture-checks" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/posture-checks \
@@ -137,6 +135,7 @@ curl -X GET https://api.netbird.io/api/posture-checks \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -145,8 +144,7 @@ curl -X GET https://api.netbird.io/api/posture-checks \
 
 
 <Row>
-
-<Col>
+ <Col>
 Creates a posture check
 
 ### Request-Body Parameters
@@ -160,14 +158,12 @@ Posture check name identifier
 Posture check friendly description
 </Property>
 <Property name="checks" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>List of objects that perform the actual checks</summary>
 <Properties>
 <Property name="nb_version_check" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check for the version of operating system</summary>
 <Properties>
@@ -178,16 +174,15 @@ Minimum acceptable version
 </Properties>
 
 </details>
+
 </Property>
 <Property name="os_version_check" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check for the version of operating system</summary>
 <Properties>
 <Property name="android" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check for the version of operating system</summary>
 <Properties>
@@ -198,10 +193,10 @@ Minimum acceptable version
 </Properties>
 
 </details>
+
 </Property>
 <Property name="darwin" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check for the version of operating system</summary>
 <Properties>
@@ -212,10 +207,10 @@ Minimum acceptable version
 </Properties>
 
 </details>
+
 </Property>
 <Property name="ios" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check for the version of operating system</summary>
 <Properties>
@@ -226,10 +221,10 @@ Minimum acceptable version
 </Properties>
 
 </details>
+
 </Property>
 <Property name="linux" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check with the kernel version</summary>
 <Properties>
@@ -240,10 +235,10 @@ Minimum acceptable version
 </Properties>
 
 </details>
+
 </Property>
 <Property name="windows" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check with the kernel version</summary>
 <Properties>
@@ -254,21 +249,21 @@ Minimum acceptable version
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </details>
+
 </Property>
 <Property name="geo_location_check" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check for geo location</summary>
 <Properties>
 <Property name="locations" type="object[]" required={true} >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>List of geo locations to which the policy applies</summary>
 <Properties>
@@ -282,6 +277,7 @@ Commonly used English name of the city
 </Properties>
 
 </details>
+
 </Property>
 <Property name="action" type="string" required={true} >
 Action to take upon policy match
@@ -290,10 +286,10 @@ Action to take upon policy match
 </Properties>
 
 </details>
+
 </Property>
 <Property name="peer_network_range_check" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check for allow or deny access based on peer local network addresses</summary>
 <Properties>
@@ -307,16 +303,15 @@ Action to take upon policy match
 </Properties>
 
 </details>
+
 </Property>
 <Property name="process_check" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture Check for binaries exist and are running in the peer’s system</summary>
 <Properties>
 <Property name="processes" type="object[]" required={true} >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>More Information</summary>
 <Properties>
@@ -333,23 +328,25 @@ Path to the process executable file in a Windows operating system
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="POST" label="/api/posture-checks" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/posture-checks \
@@ -525,6 +522,7 @@ curl -X POST https://api.netbird.io/api/posture-checks \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -533,8 +531,7 @@ curl -X POST https://api.netbird.io/api/posture-checks \
 
 
 <Row>
-
-<Col>
+ <Col>
 Get information about a posture check
 
 ### Path Parameters
@@ -548,8 +545,7 @@ The unique identifier of a posture check
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/posture-checks/{postureCheckId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/posture-checks/{postureCheckId} \
@@ -672,6 +668,7 @@ curl -X GET https://api.netbird.io/api/posture-checks/{postureCheckId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -680,8 +677,7 @@ curl -X GET https://api.netbird.io/api/posture-checks/{postureCheckId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Update/Replace a posture check
 
 ### Path Parameters
@@ -706,14 +702,12 @@ Posture check name identifier
 Posture check friendly description
 </Property>
 <Property name="checks" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>List of objects that perform the actual checks</summary>
 <Properties>
 <Property name="nb_version_check" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check for the version of operating system</summary>
 <Properties>
@@ -724,16 +718,15 @@ Minimum acceptable version
 </Properties>
 
 </details>
+
 </Property>
 <Property name="os_version_check" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check for the version of operating system</summary>
 <Properties>
 <Property name="android" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check for the version of operating system</summary>
 <Properties>
@@ -744,10 +737,10 @@ Minimum acceptable version
 </Properties>
 
 </details>
+
 </Property>
 <Property name="darwin" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check for the version of operating system</summary>
 <Properties>
@@ -758,10 +751,10 @@ Minimum acceptable version
 </Properties>
 
 </details>
+
 </Property>
 <Property name="ios" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check for the version of operating system</summary>
 <Properties>
@@ -772,10 +765,10 @@ Minimum acceptable version
 </Properties>
 
 </details>
+
 </Property>
 <Property name="linux" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check with the kernel version</summary>
 <Properties>
@@ -786,10 +779,10 @@ Minimum acceptable version
 </Properties>
 
 </details>
+
 </Property>
 <Property name="windows" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check with the kernel version</summary>
 <Properties>
@@ -800,21 +793,21 @@ Minimum acceptable version
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </details>
+
 </Property>
 <Property name="geo_location_check" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check for geo location</summary>
 <Properties>
 <Property name="locations" type="object[]" required={true} >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>List of geo locations to which the policy applies</summary>
 <Properties>
@@ -828,6 +821,7 @@ Commonly used English name of the city
 </Properties>
 
 </details>
+
 </Property>
 <Property name="action" type="string" required={true} >
 Action to take upon policy match
@@ -836,10 +830,10 @@ Action to take upon policy match
 </Properties>
 
 </details>
+
 </Property>
 <Property name="peer_network_range_check" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture check for allow or deny access based on peer local network addresses</summary>
 <Properties>
@@ -853,16 +847,15 @@ Action to take upon policy match
 </Properties>
 
 </details>
+
 </Property>
 <Property name="process_check" type="object" >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>Posture Check for binaries exist and are running in the peer’s system</summary>
 <Properties>
 <Property name="processes" type="object[]" required={true} >
-
-<details class="custom-details" open >
+ <details class="custom-details" open>
 
 <summary>More Information</summary>
 <Properties>
@@ -879,23 +872,25 @@ Path to the process executable file in a Windows operating system
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </details>
+
 </Property>
 
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="PUT" label="/api/posture-checks/{postureCheckId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/posture-checks/{postureCheckId} \
@@ -1071,6 +1066,7 @@ curl -X PUT https://api.netbird.io/api/posture-checks/{postureCheckId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -1079,8 +1075,7 @@ curl -X PUT https://api.netbird.io/api/posture-checks/{postureCheckId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Delete a posture check
 
 ### Path Parameters
@@ -1094,8 +1089,7 @@ The unique identifier of a posture check
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/posture-checks/{postureCheckId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/posture-checks/{postureCheckId} \
@@ -1106,4 +1100,5 @@ curl -X DELETE https://api.netbird.io/api/posture-checks/{postureCheckId} \
 </Col>
 
 </Row>
+
 ---

--- a/src/pages/ipa/resources/posture-checks.mdx
+++ b/src/pages/ipa/resources/posture-checks.mdx
@@ -1,222 +1,25 @@
 export const title = 'Posture Checks'
 
 
+## List all Posture Checks {{ tag: 'GET', label: '/api/posture-checks' }}
 
-## List all Posture Checks  {{ tag: 'GET' , label: '/api/posture-checks' }}
 
 <Row>
-  <Col>
-    Returns a list of all posture checks
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/posture-checks">
+<Col>
+Returns a list of all posture checks
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/posture-checks" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/posture-checks \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/posture-checks',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/posture-checks"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/posture-checks"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/posture-checks")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/posture-checks")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/posture-checks',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/posture-checks" >
 ```json {{ title: 'Example' }}
-[
-  {
-    "id": "ch8i4ug6lnn4g9hqv7mg",
-    "name": "Default",
-    "description": "This checks if the peer is running required NetBird's version",
-    "checks": {
-      "nb_version_check": {
-        "min_version": "14.3"
-      },
-      "os_version_check": {
-        "android": {
-          "min_version": "13"
-        },
-        "ios": {
-          "min_version": "17.3.1"
-        },
-        "darwin": {
-          "min_version": "14.2.1"
-        },
-        "linux": {
-          "min_kernel_version": "5.3.3"
-        },
-        "windows": {
-          "min_kernel_version": "10.0.1234"
-        }
-      },
-      "geo_location_check": {
-        "locations": [
-          {
-            "country_code": "DE",
-            "city_name": "Berlin"
-          }
-        ],
-        "action": "allow"
-      },
-      "peer_network_range_check": {
-        "ranges": [
-          "192.168.1.0/24",
-          "10.0.0.0/8",
-          "2001:db8:1234:1a00::/56"
-        ],
-        "action": "allow"
-      },
-      "process_check": {
-        "processes": [
-          {
-            "linux_path": "/usr/local/bin/netbird",
-            "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-            "windows_path": "C: rogramDataetBird\netbird.exe"
-          }
-        ]
-      }
-    }
-  }
-]
-```
-```json {{ title: 'Schema' }}
 [
   {
     "id": "string",
@@ -228,19 +31,19 @@ echo $response;
       },
       "os_version_check": {
         "android": {
-          "min_version": "13"
-        },
-        "ios": {
-          "min_version": "17.3.1"
+          "min_version": "string"
         },
         "darwin": {
-          "min_version": "14.2.1"
+          "min_version": "string"
+        },
+        "ios": {
+          "min_version": "string"
         },
         "linux": {
-          "min_kernel_version": "5.3.3"
+          "min_kernel_version": "string"
         },
         "windows": {
-          "min_kernel_version": "10.0.1234"
+          "min_kernel_version": "string"
         }
       },
       "geo_location_check": {
@@ -271,272 +74,133 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
 
+```json {{ title: 'Schema' }}
+[
+  {
+    "id": "string",
+    "name": "string",
+    "description": "string",
+    "checks": {
+      "nb_version_check": {
+        "min_version": "string"
+      },
+      "os_version_check": {
+        "android": {
+          "min_version": "string"
+        },
+        "darwin": {
+          "min_version": "string"
+        },
+        "ios": {
+          "min_version": "string"
+        },
+        "linux": {
+          "min_kernel_version": "string"
+        },
+        "windows": {
+          "min_kernel_version": "string"
+        }
+      },
+      "geo_location_check": {
+        "locations": [
+          {
+            "country_code": "string",
+            "city_name": "string"
+          }
+        ],
+        "action": "string"
+      },
+      "peer_network_range_check": {
+        "ranges": [
+          "string"
+        ],
+        "action": "string"
+      },
+      "process_check": {
+        "processes": [
+          {
+            "linux_path": "string",
+            "mac_path": "string",
+            "windows_path": "string"
+          }
+        ]
+      }
+    }
+  }
+]
+```
+</CodeGroup>
+
+</Col>
+
+</Row>
 ---
 
 
-## Create a Posture Check  {{ tag: 'POST' , label: '/api/posture-checks' }}
+
+## Create a Posture Check {{ tag: 'POST', label: '/api/posture-checks' }}
+
 
 <Row>
-  <Col>
-    Creates a posture check
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true}>
-        
-            Posture check name identifier
-        
-        </Property>
-    <Property name="description" type="string" required={true}>
-        
-            Posture check friendly description
-        
-        </Property>
-    <Property name="checks" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>List of objects that perform the actual checks</summary>
-                <Properties>
-                
-                    <Properties><Property name="nb_version_check" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check for the version of operating system</summary>
-                <Properties>
-                
-                    <Properties><Property name="min_version" type="string" required={true}>
-        
-            Minimum acceptable version
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="os_version_check" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check for the version of operating system</summary>
-                <Properties>
-                
-                    <Properties><Property name="android" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check for the version of operating system</summary>
-                <Properties>
-                
-                    <Properties><Property name="min_version" type="string" required={true}>
-        
-            Minimum acceptable version
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="darwin" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check for the version of operating system</summary>
-                <Properties>
-                
-                    <Properties><Property name="min_version" type="string" required={true}>
-        
-            Minimum acceptable version
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="ios" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check for the version of operating system</summary>
-                <Properties>
-                
-                    <Properties><Property name="min_version" type="string" required={true}>
-        
-            Minimum acceptable version
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="linux" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check with the kernel version</summary>
-                <Properties>
-                
-                    <Properties><Property name="min_kernel_version" type="string" required={true}>
-        
-            Minimum acceptable version
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="windows" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check with the kernel version</summary>
-                <Properties>
-                
-                    <Properties><Property name="min_kernel_version" type="string" required={true}>
-        
-            Minimum acceptable version
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="geo_location_check" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check for geo location</summary>
-                <Properties>
-                
-                    <Properties><Property name="locations" type="object[]" required={true}>
-        
-            <details class="custom-details" open>
-                <summary>List of geo locations to which the policy applies</summary>
-                <Properties>
-                
-                    <Properties><Property name="country_code" type="string" required={true}>
-        
-            2-letter ISO 3166-1 alpha-2 code that represents the country
-        
-        </Property>
-    <Property name="city_name" type="string" required={false}>
-        
-            Commonly used English name of the city
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="action" type="string" required={true} enumList={["allow","deny"]}>
-        
-            Action to take upon policy match
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="peer_network_range_check" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check for allow or deny access based on peer local network addresses</summary>
-                <Properties>
-                
-                    <Properties><Property name="ranges" type="string[]" required={true}>
-        
-            List of peer network ranges in CIDR notation
-        
-        </Property>
-    <Property name="action" type="string" required={true} enumList={["allow","deny"]}>
-        
-            Action to take upon policy match
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="process_check" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture Check for binaries exist and are running in the peer’s system</summary>
-                <Properties>
-                
-                    <Properties><Property name="processes" type="object[]" required={true}>
-        
-            <details class="custom-details" open>
-                <summary>More Information</summary>
-                <Properties>
-                
-                    <Properties><Property name="linux_path" type="string" required={false}>
-        
-            Path to the process executable file in a Linux operating system
-        
-        </Property>
-    <Property name="mac_path" type="string" required={false}>
-        
-            Path to the process executable file in a Mac operating system
-        
-        </Property>
-    <Property name="windows_path" type="string" required={false}>
-        
-            Path to the process executable file in a Windows operating system
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Creates a posture check
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/api/posture-checks">
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="name" type="string" required={true} >
+Posture check name identifier
+</Property>
+<Property name="description" type="string" required={true} >
+Posture check friendly description
+</Property>
+<Property name="checks" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Object list</summary>
+<Properties>
+
+<Properties>
+<Property name="nb_version_check" type="object" >
+
+</Property>
+<Property name="os_version_check" type="object" >
+
+</Property>
+<Property name="geo_location_check" type="object" >
+
+</Property>
+<Property name="peer_network_range_check" type="object" >
+
+</Property>
+<Property name="process_check" type="object" >
+
+</Property>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="POST" label="/api/posture-checks" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/posture-checks \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "id": "ch8i4ug6lnn4g9hqv7mg",
   "name": "Default",
   "description": "This checks if the peer is running required NetBird's version",
   "checks": {
@@ -589,522 +253,9 @@ curl -X POST https://api.netbird.io/api/posture-checks \
   }
 }'
 ```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "Default",
-  "description": "This checks if the peer is running required NetBird's version",
-  "checks": {
-    "nb_version_check": {
-      "min_version": "14.3"
-    },
-    "os_version_check": {
-      "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
-      },
-      "darwin": {
-        "min_version": "14.2.1"
-      },
-      "linux": {
-        "min_kernel_version": "5.3.3"
-      },
-      "windows": {
-        "min_kernel_version": "10.0.1234"
-      }
-    },
-    "geo_location_check": {
-      "locations": [
-        {
-          "country_code": "DE",
-          "city_name": "Berlin"
-        }
-      ],
-      "action": "allow"
-    },
-    "peer_network_range_check": {
-      "ranges": [
-        "192.168.1.0/24",
-        "10.0.0.0/8",
-        "2001:db8:1234:1a00::/56"
-      ],
-      "action": "allow"
-    },
-    "process_check": {
-      "processes": [
-        {
-          "linux_path": "/usr/local/bin/netbird",
-          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-          "windows_path": "C: rogramDataetBird\netbird.exe"
-        }
-      ]
-    }
-  }
-});
-let config = {
-  method: 'post',
-  maxBodyLength: Infinity,
-  url: '/api/posture-checks',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/posture-checks"
-payload = json.dumps({
-  "name": "Default",
-  "description": "This checks if the peer is running required NetBird's version",
-  "checks": {
-    "nb_version_check": {
-      "min_version": "14.3"
-    },
-    "os_version_check": {
-      "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
-      },
-      "darwin": {
-        "min_version": "14.2.1"
-      },
-      "linux": {
-        "min_kernel_version": "5.3.3"
-      },
-      "windows": {
-        "min_kernel_version": "10.0.1234"
-      }
-    },
-    "geo_location_check": {
-      "locations": [
-        {
-          "country_code": "DE",
-          "city_name": "Berlin"
-        }
-      ],
-      "action": "allow"
-    },
-    "peer_network_range_check": {
-      "ranges": [
-        "192.168.1.0/24",
-        "10.0.0.0/8",
-        "2001:db8:1234:1a00::/56"
-      ],
-      "action": "allow"
-    },
-    "process_check": {
-      "processes": [
-        {
-          "linux_path": "/usr/local/bin/netbird",
-          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-          "windows_path": "C: rogramDataetBird\netbird.exe"
-        }
-      ]
-    }
-  }
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("POST", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/posture-checks"
-  method := "POST"
-  
-  payload := strings.NewReader(`{
-  "name": "Default",
-  "description": "This checks if the peer is running required NetBird's version",
-  "checks": {
-    "nb_version_check": {
-      "min_version": "14.3"
-    },
-    "os_version_check": {
-      "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
-      },
-      "darwin": {
-        "min_version": "14.2.1"
-      },
-      "linux": {
-        "min_kernel_version": "5.3.3"
-      },
-      "windows": {
-        "min_kernel_version": "10.0.1234"
-      }
-    },
-    "geo_location_check": {
-      "locations": [
-        {
-          "country_code": "DE",
-          "city_name": "Berlin"
-        }
-      ],
-      "action": "allow"
-    },
-    "peer_network_range_check": {
-      "ranges": [
-        "192.168.1.0/24",
-        "10.0.0.0/8",
-        "2001:db8:1234:1a00::/56"
-      ],
-      "action": "allow"
-    },
-    "process_check": {
-      "processes": [
-        {
-          "linux_path": "/usr/local/bin/netbird",
-          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-          "windows_path": "C: rogramDataetBird\netbird.exe"
-        }
-      ]
-    }
-  }
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/posture-checks")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Post.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "Default",
-  "description": "This checks if the peer is running required NetBird's version",
-  "checks": {
-    "nb_version_check": {
-      "min_version": "14.3"
-    },
-    "os_version_check": {
-      "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
-      },
-      "darwin": {
-        "min_version": "14.2.1"
-      },
-      "linux": {
-        "min_kernel_version": "5.3.3"
-      },
-      "windows": {
-        "min_kernel_version": "10.0.1234"
-      }
-    },
-    "geo_location_check": {
-      "locations": [
-        {
-          "country_code": "DE",
-          "city_name": "Berlin"
-        }
-      ],
-      "action": "allow"
-    },
-    "peer_network_range_check": {
-      "ranges": [
-        "192.168.1.0/24",
-        "10.0.0.0/8",
-        "2001:db8:1234:1a00::/56"
-      ],
-      "action": "allow"
-    },
-    "process_check": {
-      "processes": [
-        {
-          "linux_path": "/usr/local/bin/netbird",
-          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-          "windows_path": "C: rogramDataetBird\netbird.exe"
-        }
-      ]
-    }
-  }
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "Default",
-  "description": "This checks if the peer is running required NetBird's version",
-  "checks": {
-    "nb_version_check": {
-      "min_version": "14.3"
-    },
-    "os_version_check": {
-      "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
-      },
-      "darwin": {
-        "min_version": "14.2.1"
-      },
-      "linux": {
-        "min_kernel_version": "5.3.3"
-      },
-      "windows": {
-        "min_kernel_version": "10.0.1234"
-      }
-    },
-    "geo_location_check": {
-      "locations": [
-        {
-          "country_code": "DE",
-          "city_name": "Berlin"
-        }
-      ],
-      "action": "allow"
-    },
-    "peer_network_range_check": {
-      "ranges": [
-        "192.168.1.0/24",
-        "10.0.0.0/8",
-        "2001:db8:1234:1a00::/56"
-      ],
-      "action": "allow"
-    },
-    "process_check": {
-      "processes": [
-        {
-          "linux_path": "/usr/local/bin/netbird",
-          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-          "windows_path": "C: rogramDataetBird\netbird.exe"
-        }
-      ]
-    }
-  }
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/posture-checks")
-  .method("POST", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/posture-checks',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'POST',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "Default",
-  "description": "This checks if the peer is running required NetBird's version",
-  "checks": {
-    "nb_version_check": {
-      "min_version": "14.3"
-    },
-    "os_version_check": {
-      "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
-      },
-      "darwin": {
-        "min_version": "14.2.1"
-      },
-      "linux": {
-        "min_kernel_version": "5.3.3"
-      },
-      "windows": {
-        "min_kernel_version": "10.0.1234"
-      }
-    },
-    "geo_location_check": {
-      "locations": [
-        {
-          "country_code": "DE",
-          "city_name": "Berlin"
-        }
-      ],
-      "action": "allow"
-    },
-    "peer_network_range_check": {
-      "ranges": [
-        "192.168.1.0/24",
-        "10.0.0.0/8",
-        "2001:db8:1234:1a00::/56"
-      ],
-      "action": "allow"
-    },
-    "process_check": {
-      "processes": [
-        {
-          "linux_path": "/usr/local/bin/netbird",
-          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-          "windows_path": "C: rogramDataetBird\netbird.exe"
-        }
-      ]
-    }
-  }
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="POST" label="/api/posture-checks" >
 ```json {{ title: 'Example' }}
-{
-  "id": "ch8i4ug6lnn4g9hqv7mg",
-  "name": "Default",
-  "description": "This checks if the peer is running required NetBird's version",
-  "checks": {
-    "nb_version_check": {
-      "min_version": "14.3"
-    },
-    "os_version_check": {
-      "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
-      },
-      "darwin": {
-        "min_version": "14.2.1"
-      },
-      "linux": {
-        "min_kernel_version": "5.3.3"
-      },
-      "windows": {
-        "min_kernel_version": "10.0.1234"
-      }
-    },
-    "geo_location_check": {
-      "locations": [
-        {
-          "country_code": "DE",
-          "city_name": "Berlin"
-        }
-      ],
-      "action": "allow"
-    },
-    "peer_network_range_check": {
-      "ranges": [
-        "192.168.1.0/24",
-        "10.0.0.0/8",
-        "2001:db8:1234:1a00::/56"
-      ],
-      "action": "allow"
-    },
-    "process_check": {
-      "processes": [
-        {
-          "linux_path": "/usr/local/bin/netbird",
-          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-          "windows_path": "C: rogramDataetBird\netbird.exe"
-        }
-      ]
-    }
-  }
-}
-```
-```json {{ title: 'Schema' }}
 {
   "id": "string",
   "name": "string",
@@ -1115,19 +266,19 @@ echo $response;
     },
     "os_version_check": {
       "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
+        "min_version": "string"
       },
       "darwin": {
-        "min_version": "14.2.1"
+        "min_version": "string"
+      },
+      "ios": {
+        "min_version": "string"
       },
       "linux": {
-        "min_kernel_version": "5.3.3"
+        "min_kernel_version": "string"
       },
       "windows": {
-        "min_kernel_version": "10.0.1234"
+        "min_kernel_version": "string"
       }
     },
     "geo_location_check": {
@@ -1157,236 +308,99 @@ echo $response;
   }
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
 
+```json {{ title: 'Schema' }}
+{
+  "id": "string",
+  "name": "string",
+  "description": "string",
+  "checks": {
+    "nb_version_check": {
+      "min_version": "string"
+    },
+    "os_version_check": {
+      "android": {
+        "min_version": "string"
+      },
+      "darwin": {
+        "min_version": "string"
+      },
+      "ios": {
+        "min_version": "string"
+      },
+      "linux": {
+        "min_kernel_version": "string"
+      },
+      "windows": {
+        "min_kernel_version": "string"
+      }
+    },
+    "geo_location_check": {
+      "locations": [
+        {
+          "country_code": "string",
+          "city_name": "string"
+        }
+      ],
+      "action": "string"
+    },
+    "peer_network_range_check": {
+      "ranges": [
+        "string"
+      ],
+      "action": "string"
+    },
+    "process_check": {
+      "processes": [
+        {
+          "linux_path": "string",
+          "mac_path": "string",
+          "windows_path": "string"
+        }
+      ]
+    }
+  }
+}
+```
+</CodeGroup>
+
+</Col>
+
+</Row>
 ---
 
 
-## Retrieve a Posture Check  {{ tag: 'GET' , label: '/api/posture-checks/{postureCheckId}' }}
+
+## Retrieve a Posture Check {{ tag: 'GET', label: '/api/posture-checks/{postureCheckId}' }}
+
 
 <Row>
-  <Col>
-    Get information about a posture check
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="postureCheckId" type="string" required={true}> 
-            The unique identifier of a posture check
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/posture-checks/{postureCheckId}">
+<Col>
+Get information about a posture check
+
+### Path Parameters
+
+
+<Properties>
+<Property name="postureCheckId" type="string" required={true} >
+The unique identifier of a posture check
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/posture-checks/{postureCheckId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/posture-checks/{postureCheckId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/posture-checks/{postureCheckId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/posture-checks/{postureCheckId}"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/posture-checks/{postureCheckId}"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/posture-checks/{postureCheckId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/posture-checks/{postureCheckId}")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/posture-checks/{postureCheckId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/posture-checks/{postureCheckId}" >
 ```json {{ title: 'Example' }}
-{
-  "id": "ch8i4ug6lnn4g9hqv7mg",
-  "name": "Default",
-  "description": "This checks if the peer is running required NetBird's version",
-  "checks": {
-    "nb_version_check": {
-      "min_version": "14.3"
-    },
-    "os_version_check": {
-      "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
-      },
-      "darwin": {
-        "min_version": "14.2.1"
-      },
-      "linux": {
-        "min_kernel_version": "5.3.3"
-      },
-      "windows": {
-        "min_kernel_version": "10.0.1234"
-      }
-    },
-    "geo_location_check": {
-      "locations": [
-        {
-          "country_code": "DE",
-          "city_name": "Berlin"
-        }
-      ],
-      "action": "allow"
-    },
-    "peer_network_range_check": {
-      "ranges": [
-        "192.168.1.0/24",
-        "10.0.0.0/8",
-        "2001:db8:1234:1a00::/56"
-      ],
-      "action": "allow"
-    },
-    "process_check": {
-      "processes": [
-        {
-          "linux_path": "/usr/local/bin/netbird",
-          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-          "windows_path": "C: rogramDataetBird\netbird.exe"
-        }
-      ]
-    }
-  }
-}
-```
-```json {{ title: 'Schema' }}
 {
   "id": "string",
   "name": "string",
@@ -1397,19 +411,19 @@ echo $response;
     },
     "os_version_check": {
       "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
+        "min_version": "string"
       },
       "darwin": {
-        "min_version": "14.2.1"
+        "min_version": "string"
+      },
+      "ios": {
+        "min_version": "string"
       },
       "linux": {
-        "min_kernel_version": "5.3.3"
+        "min_kernel_version": "string"
       },
       "windows": {
-        "min_kernel_version": "10.0.1234"
+        "min_kernel_version": "string"
       }
     },
     "geo_location_check": {
@@ -1439,280 +453,142 @@ echo $response;
   }
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
 
+```json {{ title: 'Schema' }}
+{
+  "id": "string",
+  "name": "string",
+  "description": "string",
+  "checks": {
+    "nb_version_check": {
+      "min_version": "string"
+    },
+    "os_version_check": {
+      "android": {
+        "min_version": "string"
+      },
+      "darwin": {
+        "min_version": "string"
+      },
+      "ios": {
+        "min_version": "string"
+      },
+      "linux": {
+        "min_kernel_version": "string"
+      },
+      "windows": {
+        "min_kernel_version": "string"
+      }
+    },
+    "geo_location_check": {
+      "locations": [
+        {
+          "country_code": "string",
+          "city_name": "string"
+        }
+      ],
+      "action": "string"
+    },
+    "peer_network_range_check": {
+      "ranges": [
+        "string"
+      ],
+      "action": "string"
+    },
+    "process_check": {
+      "processes": [
+        {
+          "linux_path": "string",
+          "mac_path": "string",
+          "windows_path": "string"
+        }
+      ]
+    }
+  }
+}
+```
+</CodeGroup>
+
+</Col>
+
+</Row>
 ---
 
 
-## Update a Posture Check  {{ tag: 'PUT' , label: '/api/posture-checks/{postureCheckId}' }}
+
+## Update a Posture Check {{ tag: 'PUT', label: '/api/posture-checks/{postureCheckId}' }}
+
 
 <Row>
-  <Col>
-    Update/Replace a posture check
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="postureCheckId" type="string" required={true}> 
-            The unique identifier of a posture check
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true}>
-        
-            Posture check name identifier
-        
-        </Property>
-    <Property name="description" type="string" required={true}>
-        
-            Posture check friendly description
-        
-        </Property>
-    <Property name="checks" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>List of objects that perform the actual checks</summary>
-                <Properties>
-                
-                    <Properties><Property name="nb_version_check" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check for the version of operating system</summary>
-                <Properties>
-                
-                    <Properties><Property name="min_version" type="string" required={true}>
-        
-            Minimum acceptable version
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="os_version_check" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check for the version of operating system</summary>
-                <Properties>
-                
-                    <Properties><Property name="android" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check for the version of operating system</summary>
-                <Properties>
-                
-                    <Properties><Property name="min_version" type="string" required={true}>
-        
-            Minimum acceptable version
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="darwin" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check for the version of operating system</summary>
-                <Properties>
-                
-                    <Properties><Property name="min_version" type="string" required={true}>
-        
-            Minimum acceptable version
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="ios" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check for the version of operating system</summary>
-                <Properties>
-                
-                    <Properties><Property name="min_version" type="string" required={true}>
-        
-            Minimum acceptable version
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="linux" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check with the kernel version</summary>
-                <Properties>
-                
-                    <Properties><Property name="min_kernel_version" type="string" required={true}>
-        
-            Minimum acceptable version
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="windows" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check with the kernel version</summary>
-                <Properties>
-                
-                    <Properties><Property name="min_kernel_version" type="string" required={true}>
-        
-            Minimum acceptable version
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="geo_location_check" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check for geo location</summary>
-                <Properties>
-                
-                    <Properties><Property name="locations" type="object[]" required={true}>
-        
-            <details class="custom-details" open>
-                <summary>List of geo locations to which the policy applies</summary>
-                <Properties>
-                
-                    <Properties><Property name="country_code" type="string" required={true}>
-        
-            2-letter ISO 3166-1 alpha-2 code that represents the country
-        
-        </Property>
-    <Property name="city_name" type="string" required={false}>
-        
-            Commonly used English name of the city
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="action" type="string" required={true} enumList={["allow","deny"]}>
-        
-            Action to take upon policy match
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="peer_network_range_check" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture check for allow or deny access based on peer local network addresses</summary>
-                <Properties>
-                
-                    <Properties><Property name="ranges" type="string[]" required={true}>
-        
-            List of peer network ranges in CIDR notation
-        
-        </Property>
-    <Property name="action" type="string" required={true} enumList={["allow","deny"]}>
-        
-            Action to take upon policy match
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    <Property name="process_check" type="object" required={false}>
-        
-            <details class="custom-details" open>
-                <summary>Posture Check for binaries exist and are running in the peer’s system</summary>
-                <Properties>
-                
-                    <Properties><Property name="processes" type="object[]" required={true}>
-        
-            <details class="custom-details" open>
-                <summary>More Information</summary>
-                <Properties>
-                
-                    <Properties><Property name="linux_path" type="string" required={false}>
-        
-            Path to the process executable file in a Linux operating system
-        
-        </Property>
-    <Property name="mac_path" type="string" required={false}>
-        
-            Path to the process executable file in a Mac operating system
-        
-        </Property>
-    <Property name="windows_path" type="string" required={false}>
-        
-            Path to the process executable file in a Windows operating system
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
-                
-                </Properties>
-            </details>
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Update/Replace a posture check
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="PUT" label="/api/posture-checks/{postureCheckId}">
+### Path Parameters
+
+
+<Properties>
+<Property name="postureCheckId" type="string" required={true} >
+The unique identifier of a posture check
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="name" type="string" required={true} >
+Posture check name identifier
+</Property>
+<Property name="description" type="string" required={true} >
+Posture check friendly description
+</Property>
+<Property name="checks" type="object" >
+
+<details class="custom-details" open >
+
+<summary>Object list</summary>
+<Properties>
+
+<Properties>
+<Property name="nb_version_check" type="object" >
+
+</Property>
+<Property name="os_version_check" type="object" >
+
+</Property>
+<Property name="geo_location_check" type="object" >
+
+</Property>
+<Property name="peer_network_range_check" type="object" >
+
+</Property>
+<Property name="process_check" type="object" >
+
+</Property>
+
+</Properties>
+
+</Properties>
+
+</details>
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="PUT" label="/api/posture-checks/{postureCheckId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/posture-checks/{postureCheckId} \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "id": "ch8i4ug6lnn4g9hqv7mg",
   "name": "Default",
   "description": "This checks if the peer is running required NetBird's version",
   "checks": {
@@ -1765,522 +641,9 @@ curl -X PUT https://api.netbird.io/api/posture-checks/{postureCheckId} \
   }
 }'
 ```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "Default",
-  "description": "This checks if the peer is running required NetBird's version",
-  "checks": {
-    "nb_version_check": {
-      "min_version": "14.3"
-    },
-    "os_version_check": {
-      "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
-      },
-      "darwin": {
-        "min_version": "14.2.1"
-      },
-      "linux": {
-        "min_kernel_version": "5.3.3"
-      },
-      "windows": {
-        "min_kernel_version": "10.0.1234"
-      }
-    },
-    "geo_location_check": {
-      "locations": [
-        {
-          "country_code": "DE",
-          "city_name": "Berlin"
-        }
-      ],
-      "action": "allow"
-    },
-    "peer_network_range_check": {
-      "ranges": [
-        "192.168.1.0/24",
-        "10.0.0.0/8",
-        "2001:db8:1234:1a00::/56"
-      ],
-      "action": "allow"
-    },
-    "process_check": {
-      "processes": [
-        {
-          "linux_path": "/usr/local/bin/netbird",
-          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-          "windows_path": "C: rogramDataetBird\netbird.exe"
-        }
-      ]
-    }
-  }
-});
-let config = {
-  method: 'put',
-  maxBodyLength: Infinity,
-  url: '/api/posture-checks/{postureCheckId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/posture-checks/{postureCheckId}"
-payload = json.dumps({
-  "name": "Default",
-  "description": "This checks if the peer is running required NetBird's version",
-  "checks": {
-    "nb_version_check": {
-      "min_version": "14.3"
-    },
-    "os_version_check": {
-      "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
-      },
-      "darwin": {
-        "min_version": "14.2.1"
-      },
-      "linux": {
-        "min_kernel_version": "5.3.3"
-      },
-      "windows": {
-        "min_kernel_version": "10.0.1234"
-      }
-    },
-    "geo_location_check": {
-      "locations": [
-        {
-          "country_code": "DE",
-          "city_name": "Berlin"
-        }
-      ],
-      "action": "allow"
-    },
-    "peer_network_range_check": {
-      "ranges": [
-        "192.168.1.0/24",
-        "10.0.0.0/8",
-        "2001:db8:1234:1a00::/56"
-      ],
-      "action": "allow"
-    },
-    "process_check": {
-      "processes": [
-        {
-          "linux_path": "/usr/local/bin/netbird",
-          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-          "windows_path": "C: rogramDataetBird\netbird.exe"
-        }
-      ]
-    }
-  }
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("PUT", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/posture-checks/{postureCheckId}"
-  method := "PUT"
-  
-  payload := strings.NewReader(`{
-  "name": "Default",
-  "description": "This checks if the peer is running required NetBird's version",
-  "checks": {
-    "nb_version_check": {
-      "min_version": "14.3"
-    },
-    "os_version_check": {
-      "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
-      },
-      "darwin": {
-        "min_version": "14.2.1"
-      },
-      "linux": {
-        "min_kernel_version": "5.3.3"
-      },
-      "windows": {
-        "min_kernel_version": "10.0.1234"
-      }
-    },
-    "geo_location_check": {
-      "locations": [
-        {
-          "country_code": "DE",
-          "city_name": "Berlin"
-        }
-      ],
-      "action": "allow"
-    },
-    "peer_network_range_check": {
-      "ranges": [
-        "192.168.1.0/24",
-        "10.0.0.0/8",
-        "2001:db8:1234:1a00::/56"
-      ],
-      "action": "allow"
-    },
-    "process_check": {
-      "processes": [
-        {
-          "linux_path": "/usr/local/bin/netbird",
-          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-          "windows_path": "C: rogramDataetBird\netbird.exe"
-        }
-      ]
-    }
-  }
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/posture-checks/{postureCheckId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Put.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "Default",
-  "description": "This checks if the peer is running required NetBird's version",
-  "checks": {
-    "nb_version_check": {
-      "min_version": "14.3"
-    },
-    "os_version_check": {
-      "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
-      },
-      "darwin": {
-        "min_version": "14.2.1"
-      },
-      "linux": {
-        "min_kernel_version": "5.3.3"
-      },
-      "windows": {
-        "min_kernel_version": "10.0.1234"
-      }
-    },
-    "geo_location_check": {
-      "locations": [
-        {
-          "country_code": "DE",
-          "city_name": "Berlin"
-        }
-      ],
-      "action": "allow"
-    },
-    "peer_network_range_check": {
-      "ranges": [
-        "192.168.1.0/24",
-        "10.0.0.0/8",
-        "2001:db8:1234:1a00::/56"
-      ],
-      "action": "allow"
-    },
-    "process_check": {
-      "processes": [
-        {
-          "linux_path": "/usr/local/bin/netbird",
-          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-          "windows_path": "C: rogramDataetBird\netbird.exe"
-        }
-      ]
-    }
-  }
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "Default",
-  "description": "This checks if the peer is running required NetBird's version",
-  "checks": {
-    "nb_version_check": {
-      "min_version": "14.3"
-    },
-    "os_version_check": {
-      "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
-      },
-      "darwin": {
-        "min_version": "14.2.1"
-      },
-      "linux": {
-        "min_kernel_version": "5.3.3"
-      },
-      "windows": {
-        "min_kernel_version": "10.0.1234"
-      }
-    },
-    "geo_location_check": {
-      "locations": [
-        {
-          "country_code": "DE",
-          "city_name": "Berlin"
-        }
-      ],
-      "action": "allow"
-    },
-    "peer_network_range_check": {
-      "ranges": [
-        "192.168.1.0/24",
-        "10.0.0.0/8",
-        "2001:db8:1234:1a00::/56"
-      ],
-      "action": "allow"
-    },
-    "process_check": {
-      "processes": [
-        {
-          "linux_path": "/usr/local/bin/netbird",
-          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-          "windows_path": "C: rogramDataetBird\netbird.exe"
-        }
-      ]
-    }
-  }
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/posture-checks/{postureCheckId}")
-  .method("PUT", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/posture-checks/{postureCheckId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'PUT',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "Default",
-  "description": "This checks if the peer is running required NetBird's version",
-  "checks": {
-    "nb_version_check": {
-      "min_version": "14.3"
-    },
-    "os_version_check": {
-      "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
-      },
-      "darwin": {
-        "min_version": "14.2.1"
-      },
-      "linux": {
-        "min_kernel_version": "5.3.3"
-      },
-      "windows": {
-        "min_kernel_version": "10.0.1234"
-      }
-    },
-    "geo_location_check": {
-      "locations": [
-        {
-          "country_code": "DE",
-          "city_name": "Berlin"
-        }
-      ],
-      "action": "allow"
-    },
-    "peer_network_range_check": {
-      "ranges": [
-        "192.168.1.0/24",
-        "10.0.0.0/8",
-        "2001:db8:1234:1a00::/56"
-      ],
-      "action": "allow"
-    },
-    "process_check": {
-      "processes": [
-        {
-          "linux_path": "/usr/local/bin/netbird",
-          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-          "windows_path": "C: rogramDataetBird\netbird.exe"
-        }
-      ]
-    }
-  }
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="PUT" label="/api/posture-checks/{postureCheckId}" >
 ```json {{ title: 'Example' }}
-{
-  "id": "ch8i4ug6lnn4g9hqv7mg",
-  "name": "Default",
-  "description": "This checks if the peer is running required NetBird's version",
-  "checks": {
-    "nb_version_check": {
-      "min_version": "14.3"
-    },
-    "os_version_check": {
-      "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
-      },
-      "darwin": {
-        "min_version": "14.2.1"
-      },
-      "linux": {
-        "min_kernel_version": "5.3.3"
-      },
-      "windows": {
-        "min_kernel_version": "10.0.1234"
-      }
-    },
-    "geo_location_check": {
-      "locations": [
-        {
-          "country_code": "DE",
-          "city_name": "Berlin"
-        }
-      ],
-      "action": "allow"
-    },
-    "peer_network_range_check": {
-      "ranges": [
-        "192.168.1.0/24",
-        "10.0.0.0/8",
-        "2001:db8:1234:1a00::/56"
-      ],
-      "action": "allow"
-    },
-    "process_check": {
-      "processes": [
-        {
-          "linux_path": "/usr/local/bin/netbird",
-          "mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
-          "windows_path": "C: rogramDataetBird\netbird.exe"
-        }
-      ]
-    }
-  }
-}
-```
-```json {{ title: 'Schema' }}
 {
   "id": "string",
   "name": "string",
@@ -2291,19 +654,19 @@ echo $response;
     },
     "os_version_check": {
       "android": {
-        "min_version": "13"
-      },
-      "ios": {
-        "min_version": "17.3.1"
+        "min_version": "string"
       },
       "darwin": {
-        "min_version": "14.2.1"
+        "min_version": "string"
+      },
+      "ios": {
+        "min_version": "string"
       },
       "linux": {
-        "min_kernel_version": "5.3.3"
+        "min_kernel_version": "string"
       },
       "windows": {
-        "min_kernel_version": "10.0.1234"
+        "min_kernel_version": "string"
       }
     },
     "geo_location_check": {
@@ -2333,174 +696,98 @@ echo $response;
   }
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
 
+```json {{ title: 'Schema' }}
+{
+  "id": "string",
+  "name": "string",
+  "description": "string",
+  "checks": {
+    "nb_version_check": {
+      "min_version": "string"
+    },
+    "os_version_check": {
+      "android": {
+        "min_version": "string"
+      },
+      "darwin": {
+        "min_version": "string"
+      },
+      "ios": {
+        "min_version": "string"
+      },
+      "linux": {
+        "min_kernel_version": "string"
+      },
+      "windows": {
+        "min_kernel_version": "string"
+      }
+    },
+    "geo_location_check": {
+      "locations": [
+        {
+          "country_code": "string",
+          "city_name": "string"
+        }
+      ],
+      "action": "string"
+    },
+    "peer_network_range_check": {
+      "ranges": [
+        "string"
+      ],
+      "action": "string"
+    },
+    "process_check": {
+      "processes": [
+        {
+          "linux_path": "string",
+          "mac_path": "string",
+          "windows_path": "string"
+        }
+      ]
+    }
+  }
+}
+```
+</CodeGroup>
+
+</Col>
+
+</Row>
 ---
 
 
-## Delete a Posture Check  {{ tag: 'DELETE' , label: '/api/posture-checks/{postureCheckId}' }}
+
+## Delete a Posture Check {{ tag: 'DELETE', label: '/api/posture-checks/{postureCheckId}' }}
+
 
 <Row>
-  <Col>
-    Delete a posture check
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="postureCheckId" type="string" required={true}> 
-            The unique identifier of a posture check
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="DELETE" label="/api/posture-checks/{postureCheckId}">
+<Col>
+Delete a posture check
+
+### Path Parameters
+
+
+<Properties>
+<Property name="postureCheckId" type="string" required={true} >
+The unique identifier of a posture check
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/posture-checks/{postureCheckId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/posture-checks/{postureCheckId} \
--H 'Authorization: Token <TOKEN>' 
+-H 'Authorization: Token <TOKEN>' \
 ```
+</CodeGroup>
 
-```js
-const axios = require('axios');
+</Col>
 
-let config = {
-  method: 'delete',
-  maxBodyLength: Infinity,
-  url: '/api/posture-checks/{postureCheckId}',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/posture-checks/{postureCheckId}"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("DELETE", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/posture-checks/{postureCheckId}"
-  method := "DELETE"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/posture-checks/{postureCheckId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Delete.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/posture-checks/{postureCheckId}")
-  .method("DELETE")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/posture-checks/{postureCheckId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'DELETE',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
 </Row>
-
 ---

--- a/src/pages/ipa/resources/routes.mdx
+++ b/src/pages/ipa/resources/routes.mdx
@@ -5,12 +5,10 @@ export const title = 'Routes'
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all routes
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/routes" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/routes \
@@ -83,6 +81,7 @@ curl -X GET https://api.netbird.io/api/routes \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -91,8 +90,7 @@ curl -X GET https://api.netbird.io/api/routes \
 
 
 <Row>
-
-<Col>
+ <Col>
 Creates a Route
 
 ### Request-Body Parameters
@@ -142,8 +140,7 @@ Indicate if this exit node route (0.0.0.0/0) should skip auto-application for cl
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="POST" label="/api/routes" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/routes \
@@ -236,6 +233,7 @@ curl -X POST https://api.netbird.io/api/routes \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -244,8 +242,7 @@ curl -X POST https://api.netbird.io/api/routes \
 
 
 <Row>
-
-<Col>
+ <Col>
 Get information about a Routes
 
 ### Path Parameters
@@ -259,8 +256,7 @@ The unique identifier of a route
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/routes/{routeId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/routes/{routeId} \
@@ -329,6 +325,7 @@ curl -X GET https://api.netbird.io/api/routes/{routeId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -337,8 +334,7 @@ curl -X GET https://api.netbird.io/api/routes/{routeId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Update/Replace a Route
 
 ### Path Parameters
@@ -399,8 +395,7 @@ Indicate if this exit node route (0.0.0.0/0) should skip auto-application for cl
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="PUT" label="/api/routes/{routeId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/routes/{routeId} \
@@ -493,6 +488,7 @@ curl -X PUT https://api.netbird.io/api/routes/{routeId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -501,8 +497,7 @@ curl -X PUT https://api.netbird.io/api/routes/{routeId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Delete a route
 
 ### Path Parameters
@@ -516,8 +511,7 @@ The unique identifier of a route
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/routes/{routeId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/routes/{routeId} \
@@ -528,4 +522,5 @@ curl -X DELETE https://api.netbird.io/api/routes/{routeId} \
 </Col>
 
 </Row>
+
 ---

--- a/src/pages/ipa/resources/routes.mdx
+++ b/src/pages/ipa/resources/routes.mdx
@@ -1,192 +1,53 @@
 export const title = 'Routes'
 
 
+## List all Routes {{ tag: 'GET', label: '/api/routes' }}
 
-## List all Routes  {{ tag: 'GET' , label: '/api/routes' }}
 
 <Row>
-  <Col>
-    Returns a list of all routes
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/routes">
+<Col>
+Returns a list of all routes
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/routes" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/routes \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/routes',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/routes"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/routes"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/routes")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/routes")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/routes',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/routes" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "chacdk86lnnboviihd7g",
-    "network_type": "IPv4",
-    "description": "My first route",
-    "network_id": "Route 1",
-    "enabled": true,
-    "peer": "chacbco6lnnbn6cg5s91",
+    "id": "string",
+    "network_type": "string",
+    "description": "string",
+    "network_id": "string",
+    "enabled": "boolean",
+    "peer": "string",
     "peer_groups": [
-      "chacbco6lnnbn6cg5s91"
+      "string"
     ],
-    "network": "10.64.0.0/24",
+    "network": "string",
     "domains": [
-      "example.com"
+      "string"
     ],
-    "metric": 9999,
-    "masquerade": true,
+    "metric": "integer",
+    "masquerade": "boolean",
     "groups": [
-      "chacdk86lnnboviihd70"
+      "string"
     ],
-    "keep_route": true,
+    "keep_route": "boolean",
     "access_control_groups": [
-      "chacbco6lnnbn6cg5s91"
+      "string"
     ]
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -215,96 +76,78 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Create a Route  {{ tag: 'POST' , label: '/api/routes' }}
+
+## Create a Route {{ tag: 'POST', label: '/api/routes' }}
+
 
 <Row>
-  <Col>
-    Creates a Route
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="description" type="string" required={true}>
-        
-            Route description
-        
-        </Property>
-    <Property name="network_id" type="string" required={true} minLen={1} maxLen={40}>
-        
-            Route network identifier, to group HA routes
-        
-        </Property>
-    <Property name="enabled" type="boolean" required={true}>
-        
-            Route status
-        
-        </Property>
-    <Property name="peer" type="string" required={false}>
-        
-            Peer Identifier associated with route. This property can not be set together with `peer_groups`
-        
-        </Property>
-    <Property name="peer_groups" type="string[]" required={false}>
-        
-            Peers Group Identifier associated with route. This property can not be set together with `peer`
-        
-        </Property>
-    <Property name="network" type="string" required={false}>
-        
-            Network range in CIDR format, Conflicts with domains
-        
-        </Property>
-    <Property name="domains" type="string[]" required={false}>
-        
-            Domain list to be dynamically resolved. Max of 32 domains can be added per route configuration. Conflicts with network
-        
-        </Property>
-    <Property name="metric" type="integer" required={true} min={1} max={9999}>
-        
-            Route metric number. Lowest number has higher priority
-        
-        </Property>
-    <Property name="masquerade" type="boolean" required={true}>
-        
-            Indicate if peer should masquerade traffic to this route's prefix
-        
-        </Property>
-    <Property name="groups" type="string[]" required={true}>
-        
-            Group IDs containing routing peers
-        
-        </Property>
-    <Property name="keep_route" type="boolean" required={true}>
-        
-            Indicate if the route should be kept after a domain doesn't resolve that IP anymore
-        
-        </Property>
-    <Property name="access_control_groups" type="string[]" required={false}>
-        
-            Access control group identifier associated with route.
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Creates a Route
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/api/routes">
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="description" type="string" required={true} >
+Route description
+</Property>
+<Property name="network_id" type="string" required={true} minLen={1} maxLen={40} >
+Route network identifier, to group HA routes
+</Property>
+<Property name="enabled" type="boolean" required={true} >
+Route status
+</Property>
+<Property name="peer" type="string" >
+Peer Identifier associated with route. This property can not be set together with `peer_groups`
+</Property>
+<Property name="peer_groups" type="string[]" >
+Peers Group Identifier associated with route. This property can not be set together with `peer`
+</Property>
+<Property name="network" type="string" >
+Network range in CIDR format, Conflicts with domains
+</Property>
+<Property name="domains" type="string[]" >
+Domain list to be dynamically resolved. Max of 32 domains can be added per route configuration. Conflicts with network
+</Property>
+<Property name="metric" type="integer" required={true} >
+Route metric number. Lowest number has higher priority
+</Property>
+<Property name="masquerade" type="boolean" required={true} >
+Indicate if peer should masquerade traffic to this route's prefix
+</Property>
+<Property name="groups" type="string[]" required={true} >
+Group IDs containing routing peers
+</Property>
+<Property name="keep_route" type="boolean" required={true} >
+Indicate if the route should be kept after a domain doesn't resolve that IP anymore
+</Property>
+<Property name="access_control_groups" type="string[]" >
+Access control group identifier associated with route.
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="POST" label="/api/routes" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/routes \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "id": "chacdk86lnnboviihd7g",
+  "network_type": "IPv4",
   "description": "My first route",
   "network_id": "Route 1",
   "enabled": true,
@@ -327,312 +170,35 @@ curl -X POST https://api.netbird.io/api/routes \
   ]
 }'
 ```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "description": "My first route",
-  "network_id": "Route 1",
-  "enabled": true,
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "network": "10.64.0.0/24",
-  "domains": [
-    "example.com"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ],
-  "keep_route": true,
-  "access_control_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ]
-});
-let config = {
-  method: 'post',
-  maxBodyLength: Infinity,
-  url: '/api/routes',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/routes"
-payload = json.dumps({
-  "description": "My first route",
-  "network_id": "Route 1",
-  "enabled": true,
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "network": "10.64.0.0/24",
-  "domains": [
-    "example.com"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ],
-  "keep_route": true,
-  "access_control_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ]
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("POST", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/routes"
-  method := "POST"
-  
-  payload := strings.NewReader(`{
-  "description": "My first route",
-  "network_id": "Route 1",
-  "enabled": true,
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "network": "10.64.0.0/24",
-  "domains": [
-    "example.com"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ],
-  "keep_route": true,
-  "access_control_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ]
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/routes")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Post.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "description": "My first route",
-  "network_id": "Route 1",
-  "enabled": true,
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "network": "10.64.0.0/24",
-  "domains": [
-    "example.com"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ],
-  "keep_route": true,
-  "access_control_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ]
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "description": "My first route",
-  "network_id": "Route 1",
-  "enabled": true,
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "network": "10.64.0.0/24",
-  "domains": [
-    "example.com"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ],
-  "keep_route": true,
-  "access_control_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ]
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/routes")
-  .method("POST", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/routes',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'POST',  
-  CURLOPT_POSTFIELDS => '{
-  "description": "My first route",
-  "network_id": "Route 1",
-  "enabled": true,
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "network": "10.64.0.0/24",
-  "domains": [
-    "example.com"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ],
-  "keep_route": true,
-  "access_control_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ]
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="POST" label="/api/routes" >
 ```json {{ title: 'Example' }}
 {
-  "id": "chacdk86lnnboviihd7g",
-  "network_type": "IPv4",
-  "description": "My first route",
-  "network_id": "Route 1",
-  "enabled": true,
-  "peer": "chacbco6lnnbn6cg5s91",
+  "id": "string",
+  "network_type": "string",
+  "description": "string",
+  "network_id": "string",
+  "enabled": "boolean",
+  "peer": "string",
   "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
+    "string"
   ],
-  "network": "10.64.0.0/24",
+  "network": "string",
   "domains": [
-    "example.com"
+    "string"
   ],
-  "metric": 9999,
-  "masquerade": true,
+  "metric": "integer",
+  "masquerade": "boolean",
   "groups": [
-    "chacdk86lnnboviihd70"
+    "string"
   ],
-  "keep_route": true,
+  "keep_route": "boolean",
   "access_control_groups": [
-    "chacbco6lnnbn6cg5s91"
+    "string"
   ]
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -659,206 +225,71 @@ echo $response;
   ]
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Retrieve a Route  {{ tag: 'GET' , label: '/api/routes/{routeId}' }}
+
+## Retrieve a Route {{ tag: 'GET', label: '/api/routes/{routeId}' }}
+
 
 <Row>
-  <Col>
-    Get information about a Routes
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="routeId" type="string" required={true}> 
-            The unique identifier of a route
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/routes/{routeId}">
+<Col>
+Get information about a Routes
+
+### Path Parameters
+
+
+<Properties>
+<Property name="routeId" type="string" required={true} >
+The unique identifier of a route
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/routes/{routeId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/routes/{routeId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/routes/{routeId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/routes/{routeId}"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/routes/{routeId}"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/routes/{routeId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/routes/{routeId}")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/routes/{routeId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/routes/{routeId}" >
 ```json {{ title: 'Example' }}
 {
-  "id": "chacdk86lnnboviihd7g",
-  "network_type": "IPv4",
-  "description": "My first route",
-  "network_id": "Route 1",
-  "enabled": true,
-  "peer": "chacbco6lnnbn6cg5s91",
+  "id": "string",
+  "network_type": "string",
+  "description": "string",
+  "network_id": "string",
+  "enabled": "boolean",
+  "peer": "string",
   "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
+    "string"
   ],
-  "network": "10.64.0.0/24",
+  "network": "string",
   "domains": [
-    "example.com"
+    "string"
   ],
-  "metric": 9999,
-  "masquerade": true,
+  "metric": "integer",
+  "masquerade": "boolean",
   "groups": [
-    "chacdk86lnnboviihd70"
+    "string"
   ],
-  "keep_route": true,
+  "keep_route": "boolean",
   "access_control_groups": [
-    "chacbco6lnnbn6cg5s91"
+    "string"
   ]
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -885,408 +316,87 @@ echo $response;
   ]
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Update a Route  {{ tag: 'PUT' , label: '/api/routes/{routeId}' }}
+
+## Update a Route {{ tag: 'PUT', label: '/api/routes/{routeId}' }}
+
 
 <Row>
-  <Col>
-    Update/Replace a Route
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="routeId" type="string" required={true}> 
-            The unique identifier of a route
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="description" type="string" required={true}>
-        
-            Route description
-        
-        </Property>
-    <Property name="network_id" type="string" required={true} minLen={1} maxLen={40}>
-        
-            Route network identifier, to group HA routes
-        
-        </Property>
-    <Property name="enabled" type="boolean" required={true}>
-        
-            Route status
-        
-        </Property>
-    <Property name="peer" type="string" required={false}>
-        
-            Peer Identifier associated with route. This property can not be set together with `peer_groups`
-        
-        </Property>
-    <Property name="peer_groups" type="string[]" required={false}>
-        
-            Peers Group Identifier associated with route. This property can not be set together with `peer`
-        
-        </Property>
-    <Property name="network" type="string" required={false}>
-        
-            Network range in CIDR format, Conflicts with domains
-        
-        </Property>
-    <Property name="domains" type="string[]" required={false}>
-        
-            Domain list to be dynamically resolved. Max of 32 domains can be added per route configuration. Conflicts with network
-        
-        </Property>
-    <Property name="metric" type="integer" required={true} min={1} max={9999}>
-        
-            Route metric number. Lowest number has higher priority
-        
-        </Property>
-    <Property name="masquerade" type="boolean" required={true}>
-        
-            Indicate if peer should masquerade traffic to this route's prefix
-        
-        </Property>
-    <Property name="groups" type="string[]" required={true}>
-        
-            Group IDs containing routing peers
-        
-        </Property>
-    <Property name="keep_route" type="boolean" required={true}>
-        
-            Indicate if the route should be kept after a domain doesn't resolve that IP anymore
-        
-        </Property>
-    <Property name="access_control_groups" type="string[]" required={false}>
-        
-            Access control group identifier associated with route.
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Update/Replace a Route
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="PUT" label="/api/routes/{routeId}">
+### Path Parameters
+
+
+<Properties>
+<Property name="routeId" type="string" required={true} >
+The unique identifier of a route
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="description" type="string" required={true} >
+Route description
+</Property>
+<Property name="network_id" type="string" required={true} minLen={1} maxLen={40} >
+Route network identifier, to group HA routes
+</Property>
+<Property name="enabled" type="boolean" required={true} >
+Route status
+</Property>
+<Property name="peer" type="string" >
+Peer Identifier associated with route. This property can not be set together with `peer_groups`
+</Property>
+<Property name="peer_groups" type="string[]" >
+Peers Group Identifier associated with route. This property can not be set together with `peer`
+</Property>
+<Property name="network" type="string" >
+Network range in CIDR format, Conflicts with domains
+</Property>
+<Property name="domains" type="string[]" >
+Domain list to be dynamically resolved. Max of 32 domains can be added per route configuration. Conflicts with network
+</Property>
+<Property name="metric" type="integer" required={true} >
+Route metric number. Lowest number has higher priority
+</Property>
+<Property name="masquerade" type="boolean" required={true} >
+Indicate if peer should masquerade traffic to this route's prefix
+</Property>
+<Property name="groups" type="string[]" required={true} >
+Group IDs containing routing peers
+</Property>
+<Property name="keep_route" type="boolean" required={true} >
+Indicate if the route should be kept after a domain doesn't resolve that IP anymore
+</Property>
+<Property name="access_control_groups" type="string[]" >
+Access control group identifier associated with route.
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="PUT" label="/api/routes/{routeId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/routes/{routeId} \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "description": "My first route",
-  "network_id": "Route 1",
-  "enabled": true,
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "network": "10.64.0.0/24",
-  "domains": [
-    "example.com"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ],
-  "keep_route": true,
-  "access_control_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ]
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "description": "My first route",
-  "network_id": "Route 1",
-  "enabled": true,
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "network": "10.64.0.0/24",
-  "domains": [
-    "example.com"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ],
-  "keep_route": true,
-  "access_control_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ]
-});
-let config = {
-  method: 'put',
-  maxBodyLength: Infinity,
-  url: '/api/routes/{routeId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/routes/{routeId}"
-payload = json.dumps({
-  "description": "My first route",
-  "network_id": "Route 1",
-  "enabled": true,
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "network": "10.64.0.0/24",
-  "domains": [
-    "example.com"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ],
-  "keep_route": true,
-  "access_control_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ]
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("PUT", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/routes/{routeId}"
-  method := "PUT"
-  
-  payload := strings.NewReader(`{
-  "description": "My first route",
-  "network_id": "Route 1",
-  "enabled": true,
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "network": "10.64.0.0/24",
-  "domains": [
-    "example.com"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ],
-  "keep_route": true,
-  "access_control_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ]
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/routes/{routeId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Put.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "description": "My first route",
-  "network_id": "Route 1",
-  "enabled": true,
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "network": "10.64.0.0/24",
-  "domains": [
-    "example.com"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ],
-  "keep_route": true,
-  "access_control_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ]
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "description": "My first route",
-  "network_id": "Route 1",
-  "enabled": true,
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "network": "10.64.0.0/24",
-  "domains": [
-    "example.com"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ],
-  "keep_route": true,
-  "access_control_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ]
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/routes/{routeId}")
-  .method("PUT", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/routes/{routeId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'PUT',  
-  CURLOPT_POSTFIELDS => '{
-  "description": "My first route",
-  "network_id": "Route 1",
-  "enabled": true,
-  "peer": "chacbco6lnnbn6cg5s91",
-  "peer_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ],
-  "network": "10.64.0.0/24",
-  "domains": [
-    "example.com"
-  ],
-  "metric": 9999,
-  "masquerade": true,
-  "groups": [
-    "chacdk86lnnboviihd70"
-  ],
-  "keep_route": true,
-  "access_control_groups": [
-    "chacbco6lnnbn6cg5s91"
-  ]
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": "chacdk86lnnboviihd7g",
   "network_type": "IPv4",
   "description": "My first route",
@@ -1309,8 +419,37 @@ echo $response;
   "access_control_groups": [
     "chacbco6lnnbn6cg5s91"
   ]
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="PUT" label="/api/routes/{routeId}" >
+```json {{ title: 'Example' }}
+{
+  "id": "string",
+  "network_type": "string",
+  "description": "string",
+  "network_id": "string",
+  "enabled": "boolean",
+  "peer": "string",
+  "peer_groups": [
+    "string"
+  ],
+  "network": "string",
+  "domains": [
+    "string"
+  ],
+  "metric": "integer",
+  "masquerade": "boolean",
+  "groups": [
+    "string"
+  ],
+  "keep_route": "boolean",
+  "access_control_groups": [
+    "string"
+  ]
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -1337,174 +476,44 @@ echo $response;
   ]
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Delete a Route  {{ tag: 'DELETE' , label: '/api/routes/{routeId}' }}
+
+## Delete a Route {{ tag: 'DELETE', label: '/api/routes/{routeId}' }}
+
 
 <Row>
-  <Col>
-    Delete a route
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="routeId" type="string" required={true}> 
-            The unique identifier of a route
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="DELETE" label="/api/routes/{routeId}">
+<Col>
+Delete a route
+
+### Path Parameters
+
+
+<Properties>
+<Property name="routeId" type="string" required={true} >
+The unique identifier of a route
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/routes/{routeId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/routes/{routeId} \
--H 'Authorization: Token <TOKEN>' 
+-H 'Authorization: Token <TOKEN>' \
 ```
+</CodeGroup>
 
-```js
-const axios = require('axios');
+</Col>
 
-let config = {
-  method: 'delete',
-  maxBodyLength: Infinity,
-  url: '/api/routes/{routeId}',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/routes/{routeId}"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("DELETE", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/routes/{routeId}"
-  method := "DELETE"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/routes/{routeId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Delete.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/routes/{routeId}")
-  .method("DELETE")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/routes/{routeId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'DELETE',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
 </Row>
-
 ---

--- a/src/pages/ipa/resources/routes.mdx
+++ b/src/pages/ipa/resources/routes.mdx
@@ -18,32 +18,33 @@ curl -X GET https://api.netbird.io/api/routes \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/routes" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
-    "network_type": "string",
-    "description": "string",
-    "network_id": "string",
-    "enabled": "boolean",
-    "peer": "string",
+    "id": "chacdk86lnnboviihd7g",
+    "network_type": "IPv4",
+    "description": "My first route",
+    "network_id": "Route 1",
+    "enabled": true,
+    "peer": "chacbco6lnnbn6cg5s91",
     "peer_groups": [
-      "string"
+      "chacbco6lnnbn6cg5s91"
     ],
-    "network": "string",
+    "network": "10.64.0.0/24",
     "domains": [
-      "string"
+      "example.com"
     ],
-    "metric": "integer",
-    "masquerade": "boolean",
+    "metric": 9999,
+    "masquerade": true,
     "groups": [
-      "string"
+      "chacdk86lnnboviihd70"
     ],
-    "keep_route": "boolean",
+    "keep_route": true,
     "access_control_groups": [
-      "string"
-    ]
+      "chacbco6lnnbn6cg5s91"
+    ],
+    "skip_auto_apply": false
   }
 ]
 ```
@@ -72,7 +73,8 @@ curl -X GET https://api.netbird.io/api/routes \
     "keep_route": "boolean",
     "access_control_groups": [
       "string"
-    ]
+    ],
+    "skip_auto_apply": "boolean"
   }
 ]
 ```
@@ -118,7 +120,7 @@ Network range in CIDR format, Conflicts with domains
 <Property name="domains" type="string[]" >
 Domain list to be dynamically resolved. Max of 32 domains can be added per route configuration. Conflicts with network
 </Property>
-<Property name="metric" type="integer" required={true} >
+<Property name="metric" type="integer" required={true} min={1} max={9999} >
 Route metric number. Lowest number has higher priority
 </Property>
 <Property name="masquerade" type="boolean" required={true} >
@@ -133,6 +135,9 @@ Indicate if the route should be kept after a domain doesn't resolve that IP anym
 <Property name="access_control_groups" type="string[]" >
 Access control group identifier associated with route.
 </Property>
+<Property name="skip_auto_apply" type="boolean" >
+Indicate if this exit node route (0.0.0.0/0) should skip auto-application for client routing
+</Property>
 
 </Properties>
 
@@ -142,10 +147,37 @@ Access control group identifier associated with route.
 <CodeGroup title="Request" tag="POST" label="/api/routes" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/routes \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "description": "My first route",
+  "network_id": "Route 1",
+  "enabled": true,
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "network": "10.64.0.0/24",
+  "domains": [
+    "example.com"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ],
+  "keep_route": true,
+  "access_control_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "skip_auto_apply": false
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "chacdk86lnnboviihd7g",
   "network_type": "IPv4",
   "description": "My first route",
@@ -167,35 +199,8 @@ curl -X POST https://api.netbird.io/api/routes \
   "keep_route": true,
   "access_control_groups": [
     "chacbco6lnnbn6cg5s91"
-  ]
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="POST" label="/api/routes" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "network_type": "string",
-  "description": "string",
-  "network_id": "string",
-  "enabled": "boolean",
-  "peer": "string",
-  "peer_groups": [
-    "string"
   ],
-  "network": "string",
-  "domains": [
-    "string"
-  ],
-  "metric": "integer",
-  "masquerade": "boolean",
-  "groups": [
-    "string"
-  ],
-  "keep_route": "boolean",
-  "access_control_groups": [
-    "string"
-  ]
+  "skip_auto_apply": false
 }
 ```
 
@@ -222,7 +227,8 @@ curl -X POST https://api.netbird.io/api/routes \
   "keep_route": "boolean",
   "access_control_groups": [
     "string"
-  ]
+  ],
+  "skip_auto_apply": "boolean"
 }
 ```
 </CodeGroup>
@@ -262,31 +268,32 @@ curl -X GET https://api.netbird.io/api/routes/{routeId} \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/routes/{routeId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "network_type": "string",
-  "description": "string",
-  "network_id": "string",
-  "enabled": "boolean",
-  "peer": "string",
+  "id": "chacdk86lnnboviihd7g",
+  "network_type": "IPv4",
+  "description": "My first route",
+  "network_id": "Route 1",
+  "enabled": true,
+  "peer": "chacbco6lnnbn6cg5s91",
   "peer_groups": [
-    "string"
+    "chacbco6lnnbn6cg5s91"
   ],
-  "network": "string",
+  "network": "10.64.0.0/24",
   "domains": [
-    "string"
+    "example.com"
   ],
-  "metric": "integer",
-  "masquerade": "boolean",
+  "metric": 9999,
+  "masquerade": true,
   "groups": [
-    "string"
+    "chacdk86lnnboviihd70"
   ],
-  "keep_route": "boolean",
+  "keep_route": true,
   "access_control_groups": [
-    "string"
-  ]
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "skip_auto_apply": false
 }
 ```
 
@@ -313,7 +320,8 @@ curl -X GET https://api.netbird.io/api/routes/{routeId} \
   "keep_route": "boolean",
   "access_control_groups": [
     "string"
-  ]
+  ],
+  "skip_auto_apply": "boolean"
 }
 ```
 </CodeGroup>
@@ -369,7 +377,7 @@ Network range in CIDR format, Conflicts with domains
 <Property name="domains" type="string[]" >
 Domain list to be dynamically resolved. Max of 32 domains can be added per route configuration. Conflicts with network
 </Property>
-<Property name="metric" type="integer" required={true} >
+<Property name="metric" type="integer" required={true} min={1} max={9999} >
 Route metric number. Lowest number has higher priority
 </Property>
 <Property name="masquerade" type="boolean" required={true} >
@@ -384,6 +392,9 @@ Indicate if the route should be kept after a domain doesn't resolve that IP anym
 <Property name="access_control_groups" type="string[]" >
 Access control group identifier associated with route.
 </Property>
+<Property name="skip_auto_apply" type="boolean" >
+Indicate if this exit node route (0.0.0.0/0) should skip auto-application for client routing
+</Property>
 
 </Properties>
 
@@ -393,10 +404,37 @@ Access control group identifier associated with route.
 <CodeGroup title="Request" tag="PUT" label="/api/routes/{routeId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/routes/{routeId} \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "description": "My first route",
+  "network_id": "Route 1",
+  "enabled": true,
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "network": "10.64.0.0/24",
+  "domains": [
+    "example.com"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ],
+  "keep_route": true,
+  "access_control_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "skip_auto_apply": false
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "chacdk86lnnboviihd7g",
   "network_type": "IPv4",
   "description": "My first route",
@@ -418,35 +456,8 @@ curl -X PUT https://api.netbird.io/api/routes/{routeId} \
   "keep_route": true,
   "access_control_groups": [
     "chacbco6lnnbn6cg5s91"
-  ]
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="PUT" label="/api/routes/{routeId}" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "network_type": "string",
-  "description": "string",
-  "network_id": "string",
-  "enabled": "boolean",
-  "peer": "string",
-  "peer_groups": [
-    "string"
   ],
-  "network": "string",
-  "domains": [
-    "string"
-  ],
-  "metric": "integer",
-  "masquerade": "boolean",
-  "groups": [
-    "string"
-  ],
-  "keep_route": "boolean",
-  "access_control_groups": [
-    "string"
-  ]
+  "skip_auto_apply": false
 }
 ```
 
@@ -473,7 +484,8 @@ curl -X PUT https://api.netbird.io/api/routes/{routeId} \
   "keep_route": "boolean",
   "access_control_groups": [
     "string"
-  ]
+  ],
+  "skip_auto_apply": "boolean"
 }
 ```
 </CodeGroup>

--- a/src/pages/ipa/resources/routes.mdx
+++ b/src/pages/ipa/resources/routes.mdx
@@ -15,6 +15,141 @@ curl -X GET https://api.netbird.io/api/routes \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/routes',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/routes"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/routes"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/routes")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/routes")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/routes',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
 </CodeGroup>
 <CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
@@ -144,9 +279,9 @@ Indicate if this exit node route (0.0.0.0/0) should skip auto-application for cl
 <CodeGroup title="Request" tag="POST" label="/api/routes" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/routes \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "description": "My first route",
   "network_id": "Route 1",
@@ -170,6 +305,286 @@ curl -X POST https://api.netbird.io/api/routes \
   ],
   "skip_auto_apply": false
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "description": "My first route",
+  "network_id": "Route 1",
+  "enabled": true,
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "network": "10.64.0.0/24",
+  "domains": [
+    "example.com"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ],
+  "keep_route": true,
+  "access_control_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "skip_auto_apply": false
+});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/routes',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/routes"
+payload = json.dumps({
+  "description": "My first route",
+  "network_id": "Route 1",
+  "enabled": true,
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "network": "10.64.0.0/24",
+  "domains": [
+    "example.com"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ],
+  "keep_route": true,
+  "access_control_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "skip_auto_apply": false
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/routes"
+  method := "POST"
+  
+  payload := strings.NewReader(`{
+  "description": "My first route",
+  "network_id": "Route 1",
+  "enabled": true,
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "network": "10.64.0.0/24",
+  "domains": [
+    "example.com"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ],
+  "keep_route": true,
+  "access_control_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "skip_auto_apply": false
+}`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/routes")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "description": "My first route",
+  "network_id": "Route 1",
+  "enabled": true,
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "network": "10.64.0.0/24",
+  "domains": [
+    "example.com"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ],
+  "keep_route": true,
+  "access_control_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "skip_auto_apply": false
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{
+  \"description\": \"My first route\",
+  \"network_id\": \"Route 1\",
+  \"enabled\": true,
+  \"peer\": \"chacbco6lnnbn6cg5s91\",
+  \"peer_groups\": [
+    \"chacbco6lnnbn6cg5s91\"
+  ],
+  \"network\": \"10.64.0.0/24\",
+  \"domains\": [
+    \"example.com\"
+  ],
+  \"metric\": 9999,
+  \"masquerade\": true,
+  \"groups\": [
+    \"chacdk86lnnboviihd70\"
+  ],
+  \"keep_route\": true,
+  \"access_control_groups\": [
+    \"chacbco6lnnbn6cg5s91\"
+  ],
+  \"skip_auto_apply\": false
+}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/routes")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/routes',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{
+  "description": "My first route",
+  "network_id": "Route 1",
+  "enabled": true,
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "network": "10.64.0.0/24",
+  "domains": [
+    "example.com"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ],
+  "keep_route": true,
+  "access_control_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "skip_auto_apply": false
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -262,6 +677,141 @@ The unique identifier of a route
 curl -X GET https://api.netbird.io/api/routes/{routeId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/routes/{routeId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/routes/{routeId}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/routes/{routeId}"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/routes/{routeId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/routes/{routeId}")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/routes/{routeId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -399,9 +949,9 @@ Indicate if this exit node route (0.0.0.0/0) should skip auto-application for cl
 <CodeGroup title="Request" tag="PUT" label="/api/routes/{routeId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/routes/{routeId} \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "description": "My first route",
   "network_id": "Route 1",
@@ -425,6 +975,286 @@ curl -X PUT https://api.netbird.io/api/routes/{routeId} \
   ],
   "skip_auto_apply": false
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "description": "My first route",
+  "network_id": "Route 1",
+  "enabled": true,
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "network": "10.64.0.0/24",
+  "domains": [
+    "example.com"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ],
+  "keep_route": true,
+  "access_control_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "skip_auto_apply": false
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/routes/{routeId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/routes/{routeId}"
+payload = json.dumps({
+  "description": "My first route",
+  "network_id": "Route 1",
+  "enabled": true,
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "network": "10.64.0.0/24",
+  "domains": [
+    "example.com"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ],
+  "keep_route": true,
+  "access_control_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "skip_auto_apply": false
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/routes/{routeId}"
+  method := "PUT"
+  
+  payload := strings.NewReader({
+  "description": "My first route",
+  "network_id": "Route 1",
+  "enabled": true,
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "network": "10.64.0.0/24",
+  "domains": [
+    "example.com"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ],
+  "keep_route": true,
+  "access_control_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "skip_auto_apply": false
+})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/routes/{routeId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "description": "My first route",
+  "network_id": "Route 1",
+  "enabled": true,
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "network": "10.64.0.0/24",
+  "domains": [
+    "example.com"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ],
+  "keep_route": true,
+  "access_control_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "skip_auto_apply": false
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "description": "My first route",
+  "network_id": "Route 1",
+  "enabled": true,
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "network": "10.64.0.0/24",
+  "domains": [
+    "example.com"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ],
+  "keep_route": true,
+  "access_control_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "skip_auto_apply": false
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/routes/{routeId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/routes/{routeId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "description": "My first route",
+  "network_id": "Route 1",
+  "enabled": true,
+  "peer": "chacbco6lnnbn6cg5s91",
+  "peer_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "network": "10.64.0.0/24",
+  "domains": [
+    "example.com"
+  ],
+  "metric": 9999,
+  "masquerade": true,
+  "groups": [
+    "chacdk86lnnboviihd70"
+  ],
+  "keep_route": true,
+  "access_control_groups": [
+    "chacbco6lnnbn6cg5s91"
+  ],
+  "skip_auto_apply": false
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -515,7 +1345,131 @@ The unique identifier of a route
 <CodeGroup title="Request" tag="DELETE" label="/api/routes/{routeId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/routes/{routeId} \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/routes/{routeId}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/routes/{routeId}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/routes/{routeId}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/routes/{routeId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/routes/{routeId}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/routes/{routeId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 

--- a/src/pages/ipa/resources/setup-keys.mdx
+++ b/src/pages/ipa/resources/setup-keys.mdx
@@ -18,27 +18,27 @@ curl -X GET https://api.netbird.io/api/setup-keys \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/setup-keys" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
-    "name": "string",
-    "expires": "string",
-    "type": "string",
-    "valid": "boolean",
-    "revoked": "boolean",
-    "used_times": "integer",
-    "last_used": "string",
-    "state": "string",
+    "id": 2531583362,
+    "name": "Default key",
+    "expires": "2023-06-01T14:47:22.291057Z",
+    "type": "reusable",
+    "valid": true,
+    "revoked": false,
+    "used_times": 2,
+    "last_used": "2023-05-05T09:00:35.477782Z",
+    "state": "valid",
     "auto_groups": [
-      "string"
+      "ch8i4ug6lnn4g9hqv7m0"
     ],
-    "updated_at": "string",
-    "usage_limit": "integer",
-    "ephemeral": "boolean",
-    "allow_extra_dns_labels": "boolean",
-    "key": "string"
+    "updated_at": "2023-05-05T09:00:35.477782Z",
+    "usage_limit": 0,
+    "ephemeral": true,
+    "allow_extra_dns_labels": true,
+    "key": "A6160****"
   }
 ]
 ```
@@ -93,7 +93,7 @@ Setup Key name
 <Property name="type" type="string" required={true} >
 Setup key type, one-off for single time usage and reusable
 </Property>
-<Property name="expires_in" type="integer" required={true} >
+<Property name="expires_in" type="integer" required={true} min={86400} max={31536000} >
 Expiration time in seconds
 </Property>
 <Property name="auto_groups" type="string[]" required={true} >
@@ -117,10 +117,25 @@ Allow extra DNS labels to be added to the peer
 <CodeGroup title="Request" tag="POST" label="/api/setup-keys" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/setup-keys \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "name": "Default key",
+  "type": "reusable",
+  "expires_in": 86400,
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "usage_limit": 0,
+  "ephemeral": true,
+  "allow_extra_dns_labels": true
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": 2531583362,
   "name": "Default key",
   "expires": "2023-06-01T14:47:22.291057Z",
@@ -138,29 +153,6 @@ curl -X POST https://api.netbird.io/api/setup-keys \
   "ephemeral": true,
   "allow_extra_dns_labels": true,
   "key": "A616097E-FCF0-48FA-9354-CA4A61142761"
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="POST" label="/api/setup-keys" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "name": "string",
-  "expires": "string",
-  "type": "string",
-  "valid": "boolean",
-  "revoked": "boolean",
-  "used_times": "integer",
-  "last_used": "string",
-  "state": "string",
-  "auto_groups": [
-    "string"
-  ],
-  "updated_at": "string",
-  "usage_limit": "integer",
-  "ephemeral": "boolean",
-  "allow_extra_dns_labels": "boolean",
-  "key": "string"
 }
 ```
 
@@ -222,26 +214,26 @@ curl -X GET https://api.netbird.io/api/setup-keys/{keyId} \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/setup-keys/{keyId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "name": "string",
-  "expires": "string",
-  "type": "string",
-  "valid": "boolean",
-  "revoked": "boolean",
-  "used_times": "integer",
-  "last_used": "string",
-  "state": "string",
+  "id": 2531583362,
+  "name": "Default key",
+  "expires": "2023-06-01T14:47:22.291057Z",
+  "type": "reusable",
+  "valid": true,
+  "revoked": false,
+  "used_times": 2,
+  "last_used": "2023-05-05T09:00:35.477782Z",
+  "state": "valid",
   "auto_groups": [
-    "string"
+    "ch8i4ug6lnn4g9hqv7m0"
   ],
-  "updated_at": "string",
-  "usage_limit": "integer",
-  "ephemeral": "boolean",
-  "allow_extra_dns_labels": "boolean",
-  "key": "string"
+  "updated_at": "2023-05-05T09:00:35.477782Z",
+  "usage_limit": 0,
+  "ephemeral": true,
+  "allow_extra_dns_labels": true,
+  "key": "A6160****"
 }
 ```
 
@@ -313,10 +305,20 @@ List of group IDs to auto-assign to peers registered with this key
 <CodeGroup title="Request" tag="PUT" label="/api/setup-keys/{keyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/setup-keys/{keyId} \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "revoked": false,
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ]
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": 2531583362,
   "name": "Default key",
   "expires": "2023-06-01T14:47:22.291057Z",
@@ -334,29 +336,6 @@ curl -X PUT https://api.netbird.io/api/setup-keys/{keyId} \
   "ephemeral": true,
   "allow_extra_dns_labels": true,
   "key": "A6160****"
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="PUT" label="/api/setup-keys/{keyId}" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "name": "string",
-  "expires": "string",
-  "type": "string",
-  "valid": "boolean",
-  "revoked": "boolean",
-  "used_times": "integer",
-  "last_used": "string",
-  "state": "string",
-  "auto_groups": [
-    "string"
-  ],
-  "updated_at": "string",
-  "usage_limit": "integer",
-  "ephemeral": "boolean",
-  "allow_extra_dns_labels": "boolean",
-  "key": "string"
 }
 ```
 

--- a/src/pages/ipa/resources/setup-keys.mdx
+++ b/src/pages/ipa/resources/setup-keys.mdx
@@ -5,12 +5,10 @@ export const title = 'Setup Keys'
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all Setup Keys
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/setup-keys" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/setup-keys \
@@ -71,6 +69,7 @@ curl -X GET https://api.netbird.io/api/setup-keys \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -79,8 +78,7 @@ curl -X GET https://api.netbird.io/api/setup-keys \
 
 
 <Row>
-
-<Col>
+ <Col>
 Creates a setup key
 
 ### Request-Body Parameters
@@ -112,8 +110,7 @@ Allow extra DNS labels to be added to the peer
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="POST" label="/api/setup-keys" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/setup-keys \
@@ -182,6 +179,7 @@ curl -X POST https://api.netbird.io/api/setup-keys \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -190,8 +188,7 @@ curl -X POST https://api.netbird.io/api/setup-keys \
 
 
 <Row>
-
-<Col>
+ <Col>
 Get information about a setup key
 
 ### Path Parameters
@@ -205,8 +202,7 @@ The unique identifier of a setup key
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/setup-keys/{keyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/setup-keys/{keyId} \
@@ -263,6 +259,7 @@ curl -X GET https://api.netbird.io/api/setup-keys/{keyId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -271,8 +268,7 @@ curl -X GET https://api.netbird.io/api/setup-keys/{keyId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Update information about a setup key
 
 ### Path Parameters
@@ -300,8 +296,7 @@ List of group IDs to auto-assign to peers registered with this key
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="PUT" label="/api/setup-keys/{keyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/setup-keys/{keyId} \
@@ -365,6 +360,7 @@ curl -X PUT https://api.netbird.io/api/setup-keys/{keyId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -373,8 +369,7 @@ curl -X PUT https://api.netbird.io/api/setup-keys/{keyId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Delete a Setup Key
 
 ### Path Parameters
@@ -388,8 +383,7 @@ The unique identifier of a setup key
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/setup-keys/{keyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/setup-keys/{keyId} \
@@ -400,4 +394,5 @@ curl -X DELETE https://api.netbird.io/api/setup-keys/{keyId} \
 </Col>
 
 </Row>
+
 ---

--- a/src/pages/ipa/resources/setup-keys.mdx
+++ b/src/pages/ipa/resources/setup-keys.mdx
@@ -15,6 +15,141 @@ curl -X GET https://api.netbird.io/api/setup-keys \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/setup-keys',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/setup-keys"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/setup-keys"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/setup-keys")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/setup-keys")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/setup-keys',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
 </CodeGroup>
 <CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
@@ -114,9 +249,9 @@ Allow extra DNS labels to be added to the peer
 <CodeGroup title="Request" tag="POST" label="/api/setup-keys" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/setup-keys \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "Default key",
   "type": "reusable",
@@ -128,6 +263,214 @@ curl -X POST https://api.netbird.io/api/setup-keys \
   "ephemeral": true,
   "allow_extra_dns_labels": true
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "Default key",
+  "type": "reusable",
+  "expires_in": 86400,
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "usage_limit": 0,
+  "ephemeral": true,
+  "allow_extra_dns_labels": true
+});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/setup-keys',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/setup-keys"
+payload = json.dumps({
+  "name": "Default key",
+  "type": "reusable",
+  "expires_in": 86400,
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "usage_limit": 0,
+  "ephemeral": true,
+  "allow_extra_dns_labels": true
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/setup-keys"
+  method := "POST"
+  
+  payload := strings.NewReader(`{
+  "name": "Default key",
+  "type": "reusable",
+  "expires_in": 86400,
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "usage_limit": 0,
+  "ephemeral": true,
+  "allow_extra_dns_labels": true
+}`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/setup-keys")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "Default key",
+  "type": "reusable",
+  "expires_in": 86400,
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "usage_limit": 0,
+  "ephemeral": true,
+  "allow_extra_dns_labels": true
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{
+  \"name\": \"Default key\",
+  \"type\": \"reusable\",
+  \"expires_in\": 86400,
+  \"auto_groups\": [
+    \"ch8i4ug6lnn4g9hqv7m0\"
+  ],
+  \"usage_limit\": 0,
+  \"ephemeral\": true,
+  \"allow_extra_dns_labels\": true
+}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/setup-keys")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/setup-keys',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "Default key",
+  "type": "reusable",
+  "expires_in": 86400,
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "usage_limit": 0,
+  "ephemeral": true,
+  "allow_extra_dns_labels": true
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -208,6 +551,141 @@ The unique identifier of a setup key
 curl -X GET https://api.netbird.io/api/setup-keys/{keyId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/setup-keys/{keyId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/setup-keys/{keyId}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/setup-keys/{keyId}"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/setup-keys/{keyId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/setup-keys/{keyId}")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/setup-keys/{keyId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -300,15 +778,193 @@ List of group IDs to auto-assign to peers registered with this key
 <CodeGroup title="Request" tag="PUT" label="/api/setup-keys/{keyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/setup-keys/{keyId} \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "revoked": false,
   "auto_groups": [
     "ch8i4ug6lnn4g9hqv7m0"
   ]
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "revoked": false,
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ]
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/setup-keys/{keyId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/setup-keys/{keyId}"
+payload = json.dumps({
+  "revoked": false,
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ]
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/setup-keys/{keyId}"
+  method := "PUT"
+  
+  payload := strings.NewReader({
+  "revoked": false,
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ]
+})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/setup-keys/{keyId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "revoked": false,
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ]
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "revoked": false,
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ]
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/setup-keys/{keyId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/setup-keys/{keyId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "revoked": false,
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ]
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -387,7 +1043,131 @@ The unique identifier of a setup key
 <CodeGroup title="Request" tag="DELETE" label="/api/setup-keys/{keyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/setup-keys/{keyId} \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/setup-keys/{keyId}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/setup-keys/{keyId}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/setup-keys/{keyId}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/setup-keys/{keyId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/setup-keys/{keyId}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/setup-keys/{keyId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 

--- a/src/pages/ipa/resources/setup-keys.mdx
+++ b/src/pages/ipa/resources/setup-keys.mdx
@@ -1,187 +1,48 @@
 export const title = 'Setup Keys'
 
 
+## List all Setup Keys {{ tag: 'GET', label: '/api/setup-keys' }}
 
-## List all Setup Keys  {{ tag: 'GET' , label: '/api/setup-keys' }}
 
 <Row>
-  <Col>
-    Returns a list of all Setup Keys
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/setup-keys">
+<Col>
+Returns a list of all Setup Keys
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/setup-keys" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/setup-keys \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/setup-keys',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/setup-keys"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/setup-keys"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/setup-keys")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/setup-keys")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/setup-keys',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/setup-keys" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": 2531583362,
-    "name": "Default key",
-    "expires": "2023-06-01T14:47:22.291057Z",
-    "type": "reusable",
-    "valid": true,
-    "revoked": false,
-    "used_times": 2,
-    "last_used": "2023-05-05T09:00:35.477782Z",
-    "state": "valid",
+    "id": "string",
+    "name": "string",
+    "expires": "string",
+    "type": "string",
+    "valid": "boolean",
+    "revoked": "boolean",
+    "used_times": "integer",
+    "last_used": "string",
+    "state": "string",
     "auto_groups": [
-      "ch8i4ug6lnn4g9hqv7m0"
+      "string"
     ],
-    "updated_at": "2023-05-05T09:00:35.477782Z",
-    "usage_limit": 0,
-    "ephemeral": true,
-    "allow_extra_dns_labels": true,
-    "key": "A6160****"
+    "updated_at": "string",
+    "usage_limit": "integer",
+    "ephemeral": "boolean",
+    "allow_extra_dns_labels": "boolean",
+    "key": "string"
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -205,298 +66,61 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Create a Setup Key  {{ tag: 'POST' , label: '/api/setup-keys' }}
+
+## Create a Setup Key {{ tag: 'POST', label: '/api/setup-keys' }}
+
 
 <Row>
-  <Col>
-    Creates a setup key
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true}>
-        
-            Setup Key name
-        
-        </Property>
-    <Property name="type" type="string" required={true}>
-        
-            Setup key type, one-off for single time usage and reusable
-        
-        </Property>
-    <Property name="expires_in" type="integer" required={true} min={86400} max={31536000}>
-        
-            Expiration time in seconds
-        
-        </Property>
-    <Property name="auto_groups" type="string[]" required={true}>
-        
-            List of group IDs to auto-assign to peers registered with this key
-        
-        </Property>
-    <Property name="usage_limit" type="integer" required={true}>
-        
-            A number of times this key can be used. The value of 0 indicates the unlimited usage.
-        
-        </Property>
-    <Property name="ephemeral" type="boolean" required={false}>
-        
-            Indicate that the peer will be ephemeral or not
-        
-        </Property>
-    <Property name="allow_extra_dns_labels" type="boolean" required={false}>
-        
-            Allow extra DNS labels to be added to the peer
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Creates a setup key
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/api/setup-keys">
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="name" type="string" required={true} >
+Setup Key name
+</Property>
+<Property name="type" type="string" required={true} >
+Setup key type, one-off for single time usage and reusable
+</Property>
+<Property name="expires_in" type="integer" required={true} >
+Expiration time in seconds
+</Property>
+<Property name="auto_groups" type="string[]" required={true} >
+List of group IDs to auto-assign to peers registered with this key
+</Property>
+<Property name="usage_limit" type="integer" required={true} >
+A number of times this key can be used. The value of 0 indicates the unlimited usage.
+</Property>
+<Property name="ephemeral" type="boolean" >
+Indicate that the peer will be ephemeral or not
+</Property>
+<Property name="allow_extra_dns_labels" type="boolean" >
+Allow extra DNS labels to be added to the peer
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="POST" label="/api/setup-keys" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/setup-keys \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "name": "Default key",
-  "type": "reusable",
-  "expires_in": 86400,
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "usage_limit": 0,
-  "ephemeral": true,
-  "allow_extra_dns_labels": true
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "Default key",
-  "type": "reusable",
-  "expires_in": 86400,
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "usage_limit": 0,
-  "ephemeral": true,
-  "allow_extra_dns_labels": true
-});
-let config = {
-  method: 'post',
-  maxBodyLength: Infinity,
-  url: '/api/setup-keys',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/setup-keys"
-payload = json.dumps({
-  "name": "Default key",
-  "type": "reusable",
-  "expires_in": 86400,
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "usage_limit": 0,
-  "ephemeral": true,
-  "allow_extra_dns_labels": true
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("POST", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/setup-keys"
-  method := "POST"
-  
-  payload := strings.NewReader(`{
-  "name": "Default key",
-  "type": "reusable",
-  "expires_in": 86400,
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "usage_limit": 0,
-  "ephemeral": true,
-  "allow_extra_dns_labels": true
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/setup-keys")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Post.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "Default key",
-  "type": "reusable",
-  "expires_in": 86400,
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "usage_limit": 0,
-  "ephemeral": true,
-  "allow_extra_dns_labels": true
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "Default key",
-  "type": "reusable",
-  "expires_in": 86400,
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "usage_limit": 0,
-  "ephemeral": true,
-  "allow_extra_dns_labels": true
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/setup-keys")
-  .method("POST", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/setup-keys',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'POST',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "Default key",
-  "type": "reusable",
-  "expires_in": 86400,
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "usage_limit": 0,
-  "ephemeral": true,
-  "allow_extra_dns_labels": true
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": 2531583362,
   "name": "Default key",
   "expires": "2023-06-01T14:47:22.291057Z",
@@ -514,8 +138,32 @@ echo $response;
   "ephemeral": true,
   "allow_extra_dns_labels": true,
   "key": "A616097E-FCF0-48FA-9354-CA4A61142761"
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="POST" label="/api/setup-keys" >
+```json {{ title: 'Example' }}
+{
+  "id": "string",
+  "name": "string",
+  "expires": "string",
+  "type": "string",
+  "valid": "boolean",
+  "revoked": "boolean",
+  "used_times": "integer",
+  "last_used": "string",
+  "state": "string",
+  "auto_groups": [
+    "string"
+  ],
+  "updated_at": "string",
+  "usage_limit": "integer",
+  "ephemeral": "boolean",
+  "allow_extra_dns_labels": "boolean",
+  "key": "string"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -537,201 +185,66 @@ echo $response;
   "key": "string"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Retrieve a Setup Key  {{ tag: 'GET' , label: '/api/setup-keys/{keyId}' }}
+
+## Retrieve a Setup Key {{ tag: 'GET', label: '/api/setup-keys/{keyId}' }}
+
 
 <Row>
-  <Col>
-    Get information about a setup key
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="keyId" type="string" required={true}> 
-            The unique identifier of a setup key
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/setup-keys/{keyId}">
+<Col>
+Get information about a setup key
+
+### Path Parameters
+
+
+<Properties>
+<Property name="keyId" type="string" required={true} >
+The unique identifier of a setup key
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/setup-keys/{keyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/setup-keys/{keyId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/setup-keys/{keyId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/setup-keys/{keyId}"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/setup-keys/{keyId}"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/setup-keys/{keyId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/setup-keys/{keyId}")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/setup-keys/{keyId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/setup-keys/{keyId}" >
 ```json {{ title: 'Example' }}
 {
-  "id": 2531583362,
-  "name": "Default key",
-  "expires": "2023-06-01T14:47:22.291057Z",
-  "type": "reusable",
-  "valid": true,
-  "revoked": false,
-  "used_times": 2,
-  "last_used": "2023-05-05T09:00:35.477782Z",
-  "state": "valid",
+  "id": "string",
+  "name": "string",
+  "expires": "string",
+  "type": "string",
+  "valid": "boolean",
+  "revoked": "boolean",
+  "used_times": "integer",
+  "last_used": "string",
+  "state": "string",
   "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
+    "string"
   ],
-  "updated_at": "2023-05-05T09:00:35.477782Z",
-  "usage_limit": 0,
-  "ephemeral": true,
-  "allow_extra_dns_labels": true,
-  "key": "A6160****"
+  "updated_at": "string",
+  "usage_limit": "integer",
+  "ephemeral": "boolean",
+  "allow_extra_dns_labels": "boolean",
+  "key": "string"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -753,246 +266,57 @@ echo $response;
   "key": "string"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Update a Setup Key  {{ tag: 'PUT' , label: '/api/setup-keys/{keyId}' }}
+
+## Update a Setup Key {{ tag: 'PUT', label: '/api/setup-keys/{keyId}' }}
+
 
 <Row>
-  <Col>
-    Update information about a setup key
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="keyId" type="string" required={true}> 
-            The unique identifier of a setup key
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="revoked" type="boolean" required={true}>
-        
-            Setup key revocation status
-        
-        </Property>
-    <Property name="auto_groups" type="string[]" required={true}>
-        
-            List of group IDs to auto-assign to peers registered with this key
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Update information about a setup key
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="PUT" label="/api/setup-keys/{keyId}">
+### Path Parameters
+
+
+<Properties>
+<Property name="keyId" type="string" required={true} >
+The unique identifier of a setup key
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="revoked" type="boolean" required={true} >
+Setup key revocation status
+</Property>
+<Property name="auto_groups" type="string[]" required={true} >
+List of group IDs to auto-assign to peers registered with this key
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="PUT" label="/api/setup-keys/{keyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/setup-keys/{keyId} \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "revoked": false,
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ]
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "revoked": false,
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ]
-});
-let config = {
-  method: 'put',
-  maxBodyLength: Infinity,
-  url: '/api/setup-keys/{keyId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/setup-keys/{keyId}"
-payload = json.dumps({
-  "revoked": false,
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ]
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("PUT", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/setup-keys/{keyId}"
-  method := "PUT"
-  
-  payload := strings.NewReader(`{
-  "revoked": false,
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ]
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/setup-keys/{keyId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Put.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "revoked": false,
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ]
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "revoked": false,
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ]
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/setup-keys/{keyId}")
-  .method("PUT", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/setup-keys/{keyId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'PUT',  
-  CURLOPT_POSTFIELDS => '{
-  "revoked": false,
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ]
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": 2531583362,
   "name": "Default key",
   "expires": "2023-06-01T14:47:22.291057Z",
@@ -1010,8 +334,32 @@ echo $response;
   "ephemeral": true,
   "allow_extra_dns_labels": true,
   "key": "A6160****"
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="PUT" label="/api/setup-keys/{keyId}" >
+```json {{ title: 'Example' }}
+{
+  "id": "string",
+  "name": "string",
+  "expires": "string",
+  "type": "string",
+  "valid": "boolean",
+  "revoked": "boolean",
+  "used_times": "integer",
+  "last_used": "string",
+  "state": "string",
+  "auto_groups": [
+    "string"
+  ],
+  "updated_at": "string",
+  "usage_limit": "integer",
+  "ephemeral": "boolean",
+  "allow_extra_dns_labels": "boolean",
+  "key": "string"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -1033,174 +381,44 @@ echo $response;
   "key": "string"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Delete a Setup Key  {{ tag: 'DELETE' , label: '/api/setup-keys/{keyId}' }}
+
+## Delete a Setup Key {{ tag: 'DELETE', label: '/api/setup-keys/{keyId}' }}
+
 
 <Row>
-  <Col>
-    Delete a Setup Key
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="keyId" type="string" required={true}> 
-            The unique identifier of a setup key
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="DELETE" label="/api/setup-keys/{keyId}">
+<Col>
+Delete a Setup Key
+
+### Path Parameters
+
+
+<Properties>
+<Property name="keyId" type="string" required={true} >
+The unique identifier of a setup key
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/setup-keys/{keyId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/setup-keys/{keyId} \
--H 'Authorization: Token <TOKEN>' 
+-H 'Authorization: Token <TOKEN>' \
 ```
+</CodeGroup>
 
-```js
-const axios = require('axios');
+</Col>
 
-let config = {
-  method: 'delete',
-  maxBodyLength: Infinity,
-  url: '/api/setup-keys/{keyId}',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/setup-keys/{keyId}"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("DELETE", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/setup-keys/{keyId}"
-  method := "DELETE"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/setup-keys/{keyId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Delete.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/setup-keys/{keyId}")
-  .method("DELETE")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/setup-keys/{keyId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'DELETE',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
 </Row>
-
 ---

--- a/src/pages/ipa/resources/tokens.mdx
+++ b/src/pages/ipa/resources/tokens.mdx
@@ -1,184 +1,48 @@
 export const title = 'Tokens'
 
 
+## List all Tokens {{ tag: 'GET', label: '/api/users/{userId}/tokens' }}
 
-## List all Tokens  {{ tag: 'GET' , label: '/api/users/{userId}/tokens' }}
 
 <Row>
-  <Col>
-    Returns a list of all tokens for a user
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="userId" type="string" required={true}> 
-            The unique identifier of a user
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/users/{userId}/tokens">
+<Col>
+Returns a list of all tokens for a user
+
+### Path Parameters
+
+
+<Properties>
+<Property name="userId" type="string" required={true} >
+The unique identifier of a user
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/users/{userId}/tokens" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/users/{userId}/tokens \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/users/{userId}/tokens',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/users/{userId}/tokens"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/users/{userId}/tokens"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/users/{userId}/tokens")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/users/{userId}/tokens")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}/tokens',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/users/{userId}/tokens" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "ch8i54g6lnn4g9hqv7n0",
-    "name": "My first token",
-    "expiration_date": "2023-05-05T14:38:28.977616Z",
-    "created_by": "google-oauth2|277474792786460067937",
-    "created_at": "2023-05-02T14:48:20.465209Z",
-    "last_used": "2023-05-04T12:45:25.9723616Z"
+    "id": "string",
+    "name": "string",
+    "expiration_date": "string",
+    "created_by": "string",
+    "created_at": "string",
+    "last_used": "string"
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -191,233 +55,58 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Create a Token  {{ tag: 'POST' , label: '/api/users/{userId}/tokens' }}
+
+## Create a Token {{ tag: 'POST', label: '/api/users/{userId}/tokens' }}
+
 
 <Row>
-  <Col>
-    Create a new token for a user
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="userId" type="string" required={true}> 
-            The unique identifier of a user
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="name" type="string" required={true}>
-        
-            Name of the token
-        
-        </Property>
-    <Property name="expires_in" type="integer" required={true} min={1} max={365}>
-        
-            Expiration in days
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Create a new token for a user
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/api/users/{userId}/tokens">
+### Path Parameters
+
+
+<Properties>
+<Property name="userId" type="string" required={true} >
+The unique identifier of a user
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="name" type="string" required={true} >
+Name of the token
+</Property>
+<Property name="expires_in" type="integer" required={true} >
+Expiration in days
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="POST" label="/api/users/{userId}/tokens" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/users/{userId}/tokens \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "name": "My first token",
-  "expires_in": 30
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "name": "My first token",
-  "expires_in": 30
-});
-let config = {
-  method: 'post',
-  maxBodyLength: Infinity,
-  url: '/api/users/{userId}/tokens',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/users/{userId}/tokens"
-payload = json.dumps({
-  "name": "My first token",
-  "expires_in": 30
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("POST", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/users/{userId}/tokens"
-  method := "POST"
-  
-  payload := strings.NewReader(`{
-  "name": "My first token",
-  "expires_in": 30
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/users/{userId}/tokens")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Post.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "name": "My first token",
-  "expires_in": 30
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "name": "My first token",
-  "expires_in": 30
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/users/{userId}/tokens")
-  .method("POST", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}/tokens',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'POST',  
-  CURLOPT_POSTFIELDS => '{
-  "name": "My first token",
-  "expires_in": 30
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
-  "plain_token": {},
+  "plain_token": "2023-05-02T14:48:20.465209Z",
   "personal_access_token": {
     "id": "ch8i54g6lnn4g9hqv7n0",
     "name": "My first token",
@@ -426,8 +115,24 @@ echo $response;
     "created_at": "2023-05-02T14:48:20.465209Z",
     "last_used": "2023-05-04T12:45:25.9723616Z"
   }
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="POST" label="/api/users/{userId}/tokens" >
+```json {{ title: 'Example' }}
+{
+  "plain_token": "string",
+  "personal_access_token": {
+    "id": "string",
+    "name": "string",
+    "expiration_date": "string",
+    "created_by": "string",
+    "created_at": "string",
+    "last_used": "string"
+  }
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "plain_token": "string",
@@ -441,194 +146,58 @@ echo $response;
   }
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Retrieve a Token  {{ tag: 'GET' , label: '/api/users/{userId}/tokens/{tokenId}' }}
+
+## Retrieve a Token {{ tag: 'GET', label: '/api/users/{userId}/tokens/{tokenId}' }}
+
 
 <Row>
-  <Col>
-    Returns a specific token for a user
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="userId" type="string" required={true}> 
-            The unique identifier of a user
-          </Property>   
-        
-          <Property name="tokenId" type="string" required={true}> 
-            The unique identifier of a token
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/users/{userId}/tokens/{tokenId}">
+<Col>
+Returns a specific token for a user
+
+### Path Parameters
+
+
+<Properties>
+<Property name="userId" type="string" required={true} >
+The unique identifier of a user
+</Property>
+<Property name="tokenId" type="string" required={true} >
+The unique identifier of a token
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/users/{userId}/tokens/{tokenId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/users/{userId}/tokens/{tokenId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/users/{userId}/tokens/{tokenId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/users/{userId}/tokens/{tokenId}"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/users/{userId}/tokens/{tokenId}"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/users/{userId}/tokens/{tokenId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/users/{userId}/tokens/{tokenId}")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}/tokens/{tokenId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/users/{userId}/tokens/{tokenId}" >
 ```json {{ title: 'Example' }}
 {
-  "id": "ch8i54g6lnn4g9hqv7n0",
-  "name": "My first token",
-  "expiration_date": "2023-05-05T14:38:28.977616Z",
-  "created_by": "google-oauth2|277474792786460067937",
-  "created_at": "2023-05-02T14:48:20.465209Z",
-  "last_used": "2023-05-04T12:45:25.9723616Z"
+  "id": "string",
+  "name": "string",
+  "expiration_date": "string",
+  "created_by": "string",
+  "created_at": "string",
+  "last_used": "string"
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -639,178 +208,47 @@ echo $response;
   "last_used": "string"
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Delete a Token  {{ tag: 'DELETE' , label: '/api/users/{userId}/tokens/{tokenId}' }}
+
+## Delete a Token {{ tag: 'DELETE', label: '/api/users/{userId}/tokens/{tokenId}' }}
+
 
 <Row>
-  <Col>
-    Delete a token for a user
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="userId" type="string" required={true}> 
-            The unique identifier of a user
-          </Property>   
-        
-          <Property name="tokenId" type="string" required={true}> 
-            The unique identifier of a token
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="DELETE" label="/api/users/{userId}/tokens/{tokenId}">
+<Col>
+Delete a token for a user
+
+### Path Parameters
+
+
+<Properties>
+<Property name="userId" type="string" required={true} >
+The unique identifier of a user
+</Property>
+<Property name="tokenId" type="string" required={true} >
+The unique identifier of a token
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/users/{userId}/tokens/{tokenId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/users/{userId}/tokens/{tokenId} \
--H 'Authorization: Token <TOKEN>' 
+-H 'Authorization: Token <TOKEN>' \
 ```
+</CodeGroup>
 
-```js
-const axios = require('axios');
+</Col>
 
-let config = {
-  method: 'delete',
-  maxBodyLength: Infinity,
-  url: '/api/users/{userId}/tokens/{tokenId}',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/users/{userId}/tokens/{tokenId}"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("DELETE", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/users/{userId}/tokens/{tokenId}"
-  method := "DELETE"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/users/{userId}/tokens/{tokenId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Delete.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/users/{userId}/tokens/{tokenId}")
-  .method("DELETE")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}/tokens/{tokenId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'DELETE',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
 </Row>
-
 ---

--- a/src/pages/ipa/resources/tokens.mdx
+++ b/src/pages/ipa/resources/tokens.mdx
@@ -29,16 +29,16 @@ curl -X GET https://api.netbird.io/api/users/{userId}/tokens \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/users/{userId}/tokens" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
-    "name": "string",
-    "expiration_date": "string",
-    "created_by": "string",
-    "created_at": "string",
-    "last_used": "string"
+    "id": "ch8i54g6lnn4g9hqv7n0",
+    "name": "My first token",
+    "expiration_date": "2023-05-05T14:38:28.977616Z",
+    "created_by": "google-oauth2|277474792786460067937",
+    "created_at": "2023-05-02T14:48:20.465209Z",
+    "last_used": "2023-05-04T12:45:25.9723616Z"
   }
 ]
 ```
@@ -90,7 +90,7 @@ The unique identifier of a user
 <Property name="name" type="string" required={true} >
 Name of the token
 </Property>
-<Property name="expires_in" type="integer" required={true} >
+<Property name="expires_in" type="integer" required={true} min={1} max={365} >
 Expiration in days
 </Property>
 
@@ -102,10 +102,18 @@ Expiration in days
 <CodeGroup title="Request" tag="POST" label="/api/users/{userId}/tokens" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/users/{userId}/tokens \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "name": "My first token",
+  "expires_in": 30
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "plain_token": "2023-05-02T14:48:20.465209Z",
   "personal_access_token": {
     "id": "ch8i54g6lnn4g9hqv7n0",
@@ -114,21 +122,6 @@ curl -X POST https://api.netbird.io/api/users/{userId}/tokens \
     "created_by": "google-oauth2|277474792786460067937",
     "created_at": "2023-05-02T14:48:20.465209Z",
     "last_used": "2023-05-04T12:45:25.9723616Z"
-  }
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="POST" label="/api/users/{userId}/tokens" >
-```json {{ title: 'Example' }}
-{
-  "plain_token": "string",
-  "personal_access_token": {
-    "id": "string",
-    "name": "string",
-    "expiration_date": "string",
-    "created_by": "string",
-    "created_at": "string",
-    "last_used": "string"
   }
 }
 ```
@@ -186,15 +179,15 @@ curl -X GET https://api.netbird.io/api/users/{userId}/tokens/{tokenId} \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/users/{userId}/tokens/{tokenId}" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 {
-  "id": "string",
-  "name": "string",
-  "expiration_date": "string",
-  "created_by": "string",
-  "created_at": "string",
-  "last_used": "string"
+  "id": "ch8i54g6lnn4g9hqv7n0",
+  "name": "My first token",
+  "expiration_date": "2023-05-05T14:38:28.977616Z",
+  "created_by": "google-oauth2|277474792786460067937",
+  "created_at": "2023-05-02T14:48:20.465209Z",
+  "last_used": "2023-05-04T12:45:25.9723616Z"
 }
 ```
 

--- a/src/pages/ipa/resources/tokens.mdx
+++ b/src/pages/ipa/resources/tokens.mdx
@@ -5,8 +5,7 @@ export const title = 'Tokens'
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all tokens for a user
 
 ### Path Parameters
@@ -20,8 +19,7 @@ The unique identifier of a user
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/users/{userId}/tokens" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/users/{userId}/tokens \
@@ -60,6 +58,7 @@ curl -X GET https://api.netbird.io/api/users/{userId}/tokens \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -68,8 +67,7 @@ curl -X GET https://api.netbird.io/api/users/{userId}/tokens \
 
 
 <Row>
-
-<Col>
+ <Col>
 Create a new token for a user
 
 ### Path Parameters
@@ -97,8 +95,7 @@ Expiration in days
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="POST" label="/api/users/{userId}/tokens" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/users/{userId}/tokens \
@@ -144,6 +141,7 @@ curl -X POST https://api.netbird.io/api/users/{userId}/tokens \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -152,8 +150,7 @@ curl -X POST https://api.netbird.io/api/users/{userId}/tokens \
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a specific token for a user
 
 ### Path Parameters
@@ -170,8 +167,7 @@ The unique identifier of a token
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/users/{userId}/tokens/{tokenId}" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/users/{userId}/tokens/{tokenId} \
@@ -206,6 +202,7 @@ curl -X GET https://api.netbird.io/api/users/{userId}/tokens/{tokenId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -214,8 +211,7 @@ curl -X GET https://api.netbird.io/api/users/{userId}/tokens/{tokenId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Delete a token for a user
 
 ### Path Parameters
@@ -232,8 +228,7 @@ The unique identifier of a token
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/users/{userId}/tokens/{tokenId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/users/{userId}/tokens/{tokenId} \
@@ -244,4 +239,5 @@ curl -X DELETE https://api.netbird.io/api/users/{userId}/tokens/{tokenId} \
 </Col>
 
 </Row>
+
 ---

--- a/src/pages/ipa/resources/tokens.mdx
+++ b/src/pages/ipa/resources/tokens.mdx
@@ -26,6 +26,141 @@ curl -X GET https://api.netbird.io/api/users/{userId}/tokens \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/users/{userId}/tokens',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/users/{userId}/tokens"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/users/{userId}/tokens"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/users/{userId}/tokens")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/users/{userId}/tokens")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}/tokens',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
 </CodeGroup>
 <CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
@@ -99,13 +234,179 @@ Expiration in days
 <CodeGroup title="Request" tag="POST" label="/api/users/{userId}/tokens" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/users/{userId}/tokens \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "name": "My first token",
   "expires_in": 30
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "name": "My first token",
+  "expires_in": 30
+});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/users/{userId}/tokens',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/users/{userId}/tokens"
+payload = json.dumps({
+  "name": "My first token",
+  "expires_in": 30
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/users/{userId}/tokens"
+  method := "POST"
+  
+  payload := strings.NewReader(`{
+  "name": "My first token",
+  "expires_in": 30
+}`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/users/{userId}/tokens")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "name": "My first token",
+  "expires_in": 30
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{
+  \"name\": \"My first token\",
+  \"expires_in\": 30
+}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/users/{userId}/tokens")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}/tokens',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{
+  "name": "My first token",
+  "expires_in": 30
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -174,6 +475,141 @@ curl -X GET https://api.netbird.io/api/users/{userId}/tokens/{tokenId} \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/users/{userId}/tokens/{tokenId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/users/{userId}/tokens/{tokenId}"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/users/{userId}/tokens/{tokenId}"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/users/{userId}/tokens/{tokenId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/users/{userId}/tokens/{tokenId}")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}/tokens/{tokenId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
 </CodeGroup>
 <CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
@@ -232,7 +668,131 @@ The unique identifier of a token
 <CodeGroup title="Request" tag="DELETE" label="/api/users/{userId}/tokens/{tokenId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/users/{userId}/tokens/{tokenId} \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/users/{userId}/tokens/{tokenId}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/users/{userId}/tokens/{tokenId}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/users/{userId}/tokens/{tokenId}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/users/{userId}/tokens/{tokenId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/users/{userId}/tokens/{tokenId}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}/tokens/{tokenId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 

--- a/src/pages/ipa/resources/users.mdx
+++ b/src/pages/ipa/resources/users.mdx
@@ -1,211 +1,79 @@
 export const title = 'Users'
 
 
+## List all Users {{ tag: 'GET', label: '/api/users' }}
 
-## List all Users  {{ tag: 'GET' , label: '/api/users' }}
 
 <Row>
-  <Col>
-    Returns a list of all users
-        
-    ### Query Parameters
-    <Properties>
-        
-            <Property name="service_user" type="boolean" required={false}>
-              Filters users and returns either regular users or service users
-            </Property>
-            </Properties>
-          </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/users">
+<Col>
+Returns a list of all users
+
+### Path Parameters
+
+
+<Properties>
+<Property name="service_user" type="boolean" >
+Filters users and returns either regular users or service users
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/users" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/users \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/users',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/users"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/users"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/users")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/users")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/users',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/users" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "google-oauth2|277474792786460067937",
-    "email": "demo@netbird.io",
-    "name": "Tom Schulz",
-    "role": "admin",
-    "status": "active",
-    "last_login": "2023-05-05T09:00:35.477782Z",
+    "id": "string",
+    "email": "string",
+    "name": "string",
+    "role": "string",
+    "status": "string",
+    "last_login": "string",
     "auto_groups": [
-      "ch8i4ug6lnn4g9hqv7m0"
+      "string"
     ],
-    "is_current": true,
-    "is_service_user": false,
-    "is_blocked": false,
-    "issued": "api",
+    "is_current": "boolean",
+    "is_service_user": "boolean",
+    "is_blocked": "boolean",
+    "issued": "string",
     "permissions": {
-      "is_restricted": {
-        "type": "boolean",
-        "description": "Indicates whether this User's Peers view is restricted"
-      },
+      "is_restricted": "boolean",
       "modules": {
-        "networks": {
-          "read": true,
-          "create": false,
-          "update": false,
-          "delete": false
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": "boolean"
         },
-        "peers": {
-          "read": false,
-          "create": false,
-          "update": false,
-          "delete": false
+        "example": {
+          "networks": {
+            "read": true,
+            "create": false,
+            "update": false,
+            "delete": false
+          },
+          "peers": {
+            "read": false,
+            "create": false,
+            "update": false,
+            "delete": false
+          }
         }
       }
     }
   }
 ]
 ```
+
 ```json {{ title: 'Schema' }}
 [
   {
@@ -228,10 +96,8 @@ echo $response;
         "type": "object",
         "additionalProperties": {
           "type": "object",
-          "additionalProperties": "boolean",
-          "propertyNames": "string"
+          "additionalProperties": "boolean"
         },
-        "propertyNames": "string",
         "example": {
           "networks": {
             "read": true,
@@ -251,274 +117,55 @@ echo $response;
   }
 ]
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Create a User  {{ tag: 'POST' , label: '/api/users' }}
+
+## Create a User {{ tag: 'POST', label: '/api/users' }}
+
 
 <Row>
-  <Col>
-    Creates a new service user or sends an invite to a regular user
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="email" type="string" required={false}>
-        
-            User's Email to send invite to
-        
-        </Property>
-    <Property name="name" type="string" required={false}>
-        
-            User's full name
-        
-        </Property>
-    <Property name="role" type="string" required={true}>
-        
-            User's NetBird account role
-        
-        </Property>
-    <Property name="auto_groups" type="string[]" required={true}>
-        
-            Group IDs to auto-assign to peers registered by this user
-        
-        </Property>
-    <Property name="is_service_user" type="boolean" required={true}>
-        
-            Is true if this user is a service user
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Creates a new service user or sends an invite to a regular user
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/api/users">
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="email" type="string" >
+User's Email to send invite to
+</Property>
+<Property name="name" type="string" >
+User's full name
+</Property>
+<Property name="role" type="string" required={true} >
+User's NetBird account role
+</Property>
+<Property name="auto_groups" type="string[]" required={true} >
+Group IDs to auto-assign to peers registered by this user
+</Property>
+<Property name="is_service_user" type="boolean" required={true} >
+Is true if this user is a service user
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="POST" label="/api/users" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/users \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "email": "demo@netbird.io",
-  "name": "Tom Schulz",
-  "role": "admin",
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "is_service_user": false
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "email": "demo@netbird.io",
-  "name": "Tom Schulz",
-  "role": "admin",
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "is_service_user": false
-});
-let config = {
-  method: 'post',
-  maxBodyLength: Infinity,
-  url: '/api/users',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/users"
-payload = json.dumps({
-  "email": "demo@netbird.io",
-  "name": "Tom Schulz",
-  "role": "admin",
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "is_service_user": false
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("POST", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/users"
-  method := "POST"
-  
-  payload := strings.NewReader(`{
-  "email": "demo@netbird.io",
-  "name": "Tom Schulz",
-  "role": "admin",
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "is_service_user": false
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/users")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Post.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "email": "demo@netbird.io",
-  "name": "Tom Schulz",
-  "role": "admin",
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "is_service_user": false
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "email": "demo@netbird.io",
-  "name": "Tom Schulz",
-  "role": "admin",
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "is_service_user": false
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/users")
-  .method("POST", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/users',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'POST',  
-  CURLOPT_POSTFIELDS => '{
-  "email": "demo@netbird.io",
-  "name": "Tom Schulz",
-  "role": "admin",
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "is_service_user": false
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": "google-oauth2|277474792786460067937",
   "email": "demo@netbird.io",
   "name": "Tom Schulz",
@@ -533,10 +180,7 @@ echo $response;
   "is_blocked": false,
   "issued": "api",
   "permissions": {
-    "is_restricted": {
-      "type": "boolean",
-      "description": "Indicates whether this User's Peers view is restricted"
-    },
+    "is_restricted": false,
     "modules": {
       "networks": {
         "read": true,
@@ -552,8 +196,52 @@ echo $response;
       }
     }
   }
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="POST" label="/api/users" >
+```json {{ title: 'Example' }}
+{
+  "id": "string",
+  "email": "string",
+  "name": "string",
+  "role": "string",
+  "status": "string",
+  "last_login": "string",
+  "auto_groups": [
+    "string"
+  ],
+  "is_current": "boolean",
+  "is_service_user": "boolean",
+  "is_blocked": "boolean",
+  "issued": "string",
+  "permissions": {
+    "is_restricted": "boolean",
+    "modules": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": "boolean"
+      },
+      "example": {
+        "networks": {
+          "read": true,
+          "create": false,
+          "update": false,
+          "delete": false
+        },
+        "peers": {
+          "read": false,
+          "create": false,
+          "update": false,
+          "delete": false
+        }
+      }
+    }
+  }
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -575,10 +263,8 @@ echo $response;
       "type": "object",
       "additionalProperties": {
         "type": "object",
-        "additionalProperties": "boolean",
-        "propertyNames": "string"
+        "additionalProperties": "boolean"
       },
-      "propertyNames": "string",
       "example": {
         "networks": {
           "read": true,
@@ -597,258 +283,60 @@ echo $response;
   }
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Update a User  {{ tag: 'PUT' , label: '/api/users/{userId}' }}
+
+## Update a User {{ tag: 'PUT', label: '/api/users/{userId}' }}
+
 
 <Row>
-  <Col>
-    Update information about a User
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="userId" type="string" required={true}> 
-            The unique identifier of a user
-          </Property>   
-            </Properties>
-            
-    ### Request-Body Parameters
-    
-    <Properties><Property name="role" type="string" required={true}>
-        
-            User's NetBird account role
-        
-        </Property>
-    <Property name="auto_groups" type="string[]" required={true}>
-        
-            Group IDs to auto-assign to peers registered by this user
-        
-        </Property>
-    <Property name="is_blocked" type="boolean" required={true}>
-        
-            If set to true then user is blocked and can't use the system
-        
-        </Property>
-    </Properties>
 
-    
-       </Col>
+<Col>
+Update information about a User
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="PUT" label="/api/users/{userId}">
+### Path Parameters
+
+
+<Properties>
+<Property name="userId" type="string" required={true} >
+The unique identifier of a user
+</Property>
+
+</Properties>
+
+
+### Request-Body Parameters
+
+
+<Properties>
+<Property name="role" type="string" required={true} >
+User's NetBird account role
+</Property>
+<Property name="auto_groups" type="string[]" required={true} >
+Group IDs to auto-assign to peers registered by this user
+</Property>
+<Property name="is_blocked" type="boolean" required={true} >
+If set to true then user is blocked and can't use the system
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="PUT" label="/api/users/{userId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/users/{userId} \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
 --data-raw '{
-  "role": "admin",
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "is_blocked": false
-}'
-```
-
-```js
-const axios = require('axios');
-let data = JSON.stringify({
-  "role": "admin",
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "is_blocked": false
-});
-let config = {
-  method: 'put',
-  maxBodyLength: Infinity,
-  url: '/api/users/{userId}',
-  headers: {     
-    'Accept': 'application/json',    
-    'Content-Type': 'application/json',
-    'Authorization': 'Token <TOKEN>'
-  },  
-  data : data
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/users/{userId}"
-payload = json.dumps({
-  "role": "admin",
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "is_blocked": false
-})
-headers = {   
-  'Content-Type': 'application/json',  
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("PUT", url, headers=headers, data=payload)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/users/{userId}"
-  method := "PUT"
-  
-  payload := strings.NewReader(`{
-  "role": "admin",
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "is_blocked": false
-}`)
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, payload)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-  
-  req.Header.Add("Content-Type", "application/json")  
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/users/{userId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Put.new(url)
-request["Content-Type"] = "application/json"
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-request.body = JSON.dump({
-  "role": "admin",
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "is_blocked": false
-})
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, '{
-  "role": "admin",
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "is_blocked": false
-}');
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/users/{userId}")
-  .method("PUT", body)  
-  .addHeader("Content-Type", "application/json")  
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'PUT',  
-  CURLOPT_POSTFIELDS => '{
-  "role": "admin",
-  "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
-  ],
-  "is_blocked": false
-}',
-  CURLOPT_HTTPHEADER => array(    
-    'Content-Type: application/json',    
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
-```json {{ title: 'Example' }}
-{
   "id": "google-oauth2|277474792786460067937",
   "email": "demo@netbird.io",
   "name": "Tom Schulz",
@@ -863,10 +351,7 @@ echo $response;
   "is_blocked": false,
   "issued": "api",
   "permissions": {
-    "is_restricted": {
-      "type": "boolean",
-      "description": "Indicates whether this User's Peers view is restricted"
-    },
+    "is_restricted": false,
     "modules": {
       "networks": {
         "read": true,
@@ -882,8 +367,52 @@ echo $response;
       }
     }
   }
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" tag="PUT" label="/api/users/{userId}" >
+```json {{ title: 'Example' }}
+{
+  "id": "string",
+  "email": "string",
+  "name": "string",
+  "role": "string",
+  "status": "string",
+  "last_login": "string",
+  "auto_groups": [
+    "string"
+  ],
+  "is_current": "boolean",
+  "is_service_user": "boolean",
+  "is_blocked": "boolean",
+  "issued": "string",
+  "permissions": {
+    "is_restricted": "boolean",
+    "modules": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": "boolean"
+      },
+      "example": {
+        "networks": {
+          "read": true,
+          "create": false,
+          "update": false,
+          "delete": false
+        },
+        "peers": {
+          "read": false,
+          "create": false,
+          "update": false,
+          "delete": false
+        }
+      }
+    }
+  }
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -905,10 +434,8 @@ echo $response;
       "type": "object",
       "additionalProperties": {
         "type": "object",
-        "additionalProperties": "boolean",
-        "propertyNames": "string"
+        "additionalProperties": "boolean"
       },
-      "propertyNames": "string",
       "example": {
         "networks": {
           "read": true,
@@ -927,537 +454,148 @@ echo $response;
   }
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---
 
 
-## Delete a User  {{ tag: 'DELETE' , label: '/api/users/{userId}' }}
+
+## Delete a User {{ tag: 'DELETE', label: '/api/users/{userId}' }}
+
 
 <Row>
-  <Col>
-    This method removes a user from accessing the system. For this leaves the IDP user intact unless the `--user-delete-from-idp` is passed to management startup.
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="userId" type="string" required={true}> 
-            The unique identifier of a user
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="DELETE" label="/api/users/{userId}">
+<Col>
+This method removes a user from accessing the system. For this leaves the IDP user intact unless the `--user-delete-from-idp` is passed to management startup.
+
+### Path Parameters
+
+
+<Properties>
+<Property name="userId" type="string" required={true} >
+The unique identifier of a user
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/users/{userId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/users/{userId} \
--H 'Authorization: Token <TOKEN>' 
+-H 'Authorization: Token <TOKEN>' \
 ```
+</CodeGroup>
 
-```js
-const axios = require('axios');
+</Col>
 
-let config = {
-  method: 'delete',
-  maxBodyLength: Infinity,
-  url: '/api/users/{userId}',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/users/{userId}"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("DELETE", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/users/{userId}"
-  method := "DELETE"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/users/{userId}")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Delete.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/users/{userId}")
-  .method("DELETE")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'DELETE',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
 </Row>
-
 ---
 
 
-## Resend user invitation  {{ tag: 'POST' , label: '/api/users/{userId}/invite' }}
+
+## Resend user invitation {{ tag: 'POST', label: '/api/users/{userId}/invite' }}
+
 
 <Row>
-  <Col>
-    Resend user invitation
-    
-    ### Path Parameters
-    <Properties>
-        
-          <Property name="userId" type="string" required={true}> 
-            The unique identifier of a user
-          </Property>   
-            </Properties>
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/api/users/{userId}/invite">
+<Col>
+Resend user invitation
+
+### Path Parameters
+
+
+<Properties>
+<Property name="userId" type="string" required={true} >
+The unique identifier of a user
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="POST" label="/api/users/{userId}/invite" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/users/{userId}/invite \
--H 'Authorization: Token <TOKEN>' 
+-H 'Accept: application/json' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
+--data-raw ''
 ```
+</CodeGroup>
 
-```js
-const axios = require('axios');
+</Col>
 
-let config = {
-  method: 'post',
-  maxBodyLength: Infinity,
-  url: '/api/users/{userId}/invite',
-  headers: {         
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/users/{userId}/invite"
-
-headers = {     
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("POST", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/users/{userId}/invite"
-  method := "POST"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/users/{userId}/invite")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Post.new(url)
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/users/{userId}/invite")
-  .method("POST")    
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}/invite',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'POST',  
-  CURLOPT_HTTPHEADER => array(        
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
- 
-  </Col>
 </Row>
-
 ---
 
 
-## Retrieve current user  {{ tag: 'GET' , label: '/api/users/current' }}
+
+## Retrieve current user {{ tag: 'GET', label: '/api/users/current' }}
+
 
 <Row>
-  <Col>
-    Get information about the current user
-              </Col>
 
-  <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/api/users/current">
+<Col>
+Get information about the current user
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/users/current" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/users/current \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
-
-```js
-const axios = require('axios');
-
-let config = {
-  method: 'get',
-  maxBodyLength: Infinity,
-  url: '/api/users/current',
-  headers: {     
-    'Accept': 'application/json',    
-    'Authorization': 'Token <TOKEN>'
-  }  
-};
-
-axios(config)
-.then((response) => {
-  console.log(JSON.stringify(response.data));
-})
-.catch((error) => {
-  console.log(error);
-});
-```
-
-```python
-import requests
-import json
-
-url = "https://api.netbird.io/api/users/current"
-
-headers = {     
-  'Accept': 'application/json',
-  'Authorization': 'Token <TOKEN>'
-}
-
-response = requests.request("GET", url, headers=headers)
-
-print(response.text)
-```
-
-```go
-package main
-
-import (
-  "fmt"
-  "strings"
-  "net/http"
-  "io/ioutil"
-)
-
-func main() {
-
-  url := "https://api.netbird.io/api/users/current"
-  method := "GET"
-  
-  client := &http.Client {
-  }
-  req, err := http.NewRequest(method, url, nil)
-
-  if err != nil {
-    fmt.Println(err)
-    return
-  {  
-    
-  req.Header.Add("Accept", "application/json")
-  req.Header.Add("Authorization", "Token <TOKEN>")
-
-  res, err := client.Do(req)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  defer res.Body.Close()
-
-  body, err := ioutil.ReadAll(res.Body)
-  if err != nil {
-    fmt.Println(err)
-    return
-  }
-  fmt.Println(string(body))
-}
-```
-
-```ruby
-require "uri"
-require "json"
-require "net/http"
-
-url = URI("https://api.netbird.io/api/users/current")
-
-https = Net::HTTP.new(url.host, url.port)
-https.use_ssl = true
-
-request = Net::HTTP::Get.new(url)
-request["Accept"] = "application/json"
-request["Authorization"] = "Token <TOKEN>"
-
-response = https.request(request)
-puts response.read_body
-```
-
-```java
-OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-
-Request request = new Request.Builder()
-  .url("https://api.netbird.io/api/users/current")
-  .method("GET")    
-  .addHeader("Accept", "application/json")
-  .addHeader("Authorization: Token <TOKEN>")
-  .build();
-Response response = client.newCall(request).execute();
-```
-
-```php
-<?php
-
-$curl = curl_init();
-
-curl_setopt_array($curl, array(
-  CURLOPT_URL => 'https://api.netbird.io/api/users/current',
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_ENCODING => '',
-  CURLOPT_MAXREDIRS => 10,
-  CURLOPT_TIMEOUT => 0,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => 'GET',  
-  CURLOPT_HTTPHEADER => array(        
-    'Accept: application/json',
-    'Authorization: Token <TOKEN>'
-  ),
-));
-
-$response = curl_exec($curl);
-
-curl_close($curl);
-echo $response;
-```
-
-    </CodeGroup>
-    
-    
-    <CodeGroup title="Response">
+</CodeGroup>
+<CodeGroup title="Response" tag="GET" label="/api/users/current" >
 ```json {{ title: 'Example' }}
 {
-  "id": "google-oauth2|277474792786460067937",
-  "email": "demo@netbird.io",
-  "name": "Tom Schulz",
-  "role": "admin",
-  "status": "active",
-  "last_login": "2023-05-05T09:00:35.477782Z",
+  "id": "string",
+  "email": "string",
+  "name": "string",
+  "role": "string",
+  "status": "string",
+  "last_login": "string",
   "auto_groups": [
-    "ch8i4ug6lnn4g9hqv7m0"
+    "string"
   ],
-  "is_current": true,
-  "is_service_user": false,
-  "is_blocked": false,
-  "issued": "api",
+  "is_current": "boolean",
+  "is_service_user": "boolean",
+  "is_blocked": "boolean",
+  "issued": "string",
   "permissions": {
-    "is_restricted": {
-      "type": "boolean",
-      "description": "Indicates whether this User's Peers view is restricted"
-    },
+    "is_restricted": "boolean",
     "modules": {
-      "networks": {
-        "read": true,
-        "create": false,
-        "update": false,
-        "delete": false
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": "boolean"
       },
-      "peers": {
-        "read": false,
-        "create": false,
-        "update": false,
-        "delete": false
+      "example": {
+        "networks": {
+          "read": true,
+          "create": false,
+          "update": false,
+          "delete": false
+        },
+        "peers": {
+          "read": false,
+          "create": false,
+          "update": false,
+          "delete": false
+        }
       }
     }
   }
 }
 ```
+
 ```json {{ title: 'Schema' }}
 {
   "id": "string",
@@ -1479,10 +617,8 @@ echo $response;
       "type": "object",
       "additionalProperties": {
         "type": "object",
-        "additionalProperties": "boolean",
-        "propertyNames": "string"
+        "additionalProperties": "boolean"
       },
-      "propertyNames": "string",
       "example": {
         "networks": {
           "read": true,
@@ -1501,10 +637,9 @@ echo $response;
   }
 }
 ```
-    </CodeGroup>
-    
- 
-  </Col>
-</Row>
+</CodeGroup>
 
+</Col>
+
+</Row>
 ---

--- a/src/pages/ipa/resources/users.mdx
+++ b/src/pages/ipa/resources/users.mdx
@@ -9,7 +9,7 @@ export const title = 'Users'
 <Col>
 Returns a list of all users
 
-### Path Parameters
+### Query Parameters
 
 
 <Properties>
@@ -29,44 +29,38 @@ curl -X GET https://api.netbird.io/api/users \
 -H 'Authorization: Token <TOKEN>' 
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/users" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
 [
   {
-    "id": "string",
-    "email": "string",
-    "name": "string",
-    "role": "string",
-    "status": "string",
-    "last_login": "string",
+    "id": "google-oauth2|277474792786460067937",
+    "email": "demo@netbird.io",
+    "name": "Tom Schulz",
+    "role": "admin",
+    "status": "active",
+    "last_login": "2023-05-05T09:00:35.477782Z",
     "auto_groups": [
-      "string"
+      "ch8i4ug6lnn4g9hqv7m0"
     ],
-    "is_current": "boolean",
-    "is_service_user": "boolean",
-    "is_blocked": "boolean",
-    "issued": "string",
+    "is_current": true,
+    "is_service_user": false,
+    "is_blocked": false,
+    "pending_approval": false,
+    "issued": "api",
     "permissions": {
-      "is_restricted": "boolean",
+      "is_restricted": false,
       "modules": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "object",
-          "additionalProperties": "boolean"
+        "networks": {
+          "read": true,
+          "create": false,
+          "update": false,
+          "delete": false
         },
-        "example": {
-          "networks": {
-            "read": true,
-            "create": false,
-            "update": false,
-            "delete": false
-          },
-          "peers": {
-            "read": false,
-            "create": false,
-            "update": false,
-            "delete": false
-          }
+        "peers": {
+          "read": false,
+          "create": false,
+          "update": false,
+          "delete": false
         }
       }
     }
@@ -89,6 +83,7 @@ curl -X GET https://api.netbird.io/api/users \
     "is_current": "boolean",
     "is_service_user": "boolean",
     "is_blocked": "boolean",
+    "pending_approval": "boolean",
     "issued": "string",
     "permissions": {
       "is_restricted": "boolean",
@@ -162,10 +157,23 @@ Is true if this user is a service user
 <CodeGroup title="Request" tag="POST" label="/api/users" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/users \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "email": "demo@netbird.io",
+  "name": "Tom Schulz",
+  "role": "admin",
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "is_service_user": false
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "google-oauth2|277474792786460067937",
   "email": "demo@netbird.io",
   "name": "Tom Schulz",
@@ -178,6 +186,7 @@ curl -X POST https://api.netbird.io/api/users \
   "is_current": true,
   "is_service_user": false,
   "is_blocked": false,
+  "pending_approval": false,
   "issued": "api",
   "permissions": {
     "is_restricted": false,
@@ -193,49 +202,6 @@ curl -X POST https://api.netbird.io/api/users \
         "create": false,
         "update": false,
         "delete": false
-      }
-    }
-  }
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="POST" label="/api/users" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "email": "string",
-  "name": "string",
-  "role": "string",
-  "status": "string",
-  "last_login": "string",
-  "auto_groups": [
-    "string"
-  ],
-  "is_current": "boolean",
-  "is_service_user": "boolean",
-  "is_blocked": "boolean",
-  "issued": "string",
-  "permissions": {
-    "is_restricted": "boolean",
-    "modules": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "object",
-        "additionalProperties": "boolean"
-      },
-      "example": {
-        "networks": {
-          "read": true,
-          "create": false,
-          "update": false,
-          "delete": false
-        },
-        "peers": {
-          "read": false,
-          "create": false,
-          "update": false,
-          "delete": false
-        }
       }
     }
   }
@@ -256,6 +222,7 @@ curl -X POST https://api.netbird.io/api/users \
   "is_current": "boolean",
   "is_service_user": "boolean",
   "is_blocked": "boolean",
+  "pending_approval": "boolean",
   "issued": "string",
   "permissions": {
     "is_restricted": "boolean",
@@ -333,10 +300,21 @@ If set to true then user is blocked and can't use the system
 <CodeGroup title="Request" tag="PUT" label="/api/users/{userId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/users/{userId} \
+-H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
--H 'Authorization: Token <TOKEN>' \
 --data-raw '{
+  "role": "admin",
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "is_blocked": false
+}'
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
   "id": "google-oauth2|277474792786460067937",
   "email": "demo@netbird.io",
   "name": "Tom Schulz",
@@ -349,6 +327,7 @@ curl -X PUT https://api.netbird.io/api/users/{userId} \
   "is_current": true,
   "is_service_user": false,
   "is_blocked": false,
+  "pending_approval": false,
   "issued": "api",
   "permissions": {
     "is_restricted": false,
@@ -364,49 +343,6 @@ curl -X PUT https://api.netbird.io/api/users/{userId} \
         "create": false,
         "update": false,
         "delete": false
-      }
-    }
-  }
-}'
-```
-</CodeGroup>
-<CodeGroup title="Response" tag="PUT" label="/api/users/{userId}" >
-```json {{ title: 'Example' }}
-{
-  "id": "string",
-  "email": "string",
-  "name": "string",
-  "role": "string",
-  "status": "string",
-  "last_login": "string",
-  "auto_groups": [
-    "string"
-  ],
-  "is_current": "boolean",
-  "is_service_user": "boolean",
-  "is_blocked": "boolean",
-  "issued": "string",
-  "permissions": {
-    "is_restricted": "boolean",
-    "modules": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "object",
-        "additionalProperties": "boolean"
-      },
-      "example": {
-        "networks": {
-          "read": true,
-          "create": false,
-          "update": false,
-          "delete": false
-        },
-        "peers": {
-          "read": false,
-          "create": false,
-          "update": false,
-          "delete": false
-        }
       }
     }
   }
@@ -427,6 +363,7 @@ curl -X PUT https://api.netbird.io/api/users/{userId} \
   "is_current": "boolean",
   "is_service_user": "boolean",
   "is_blocked": "boolean",
+  "pending_approval": "boolean",
   "issued": "string",
   "permissions": {
     "is_restricted": "boolean",
@@ -522,10 +459,7 @@ The unique identifier of a user
 <CodeGroup title="Request" tag="POST" label="/api/users/{userId}/invite" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/users/{userId}/invite \
--H 'Accept: application/json' \
--H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
---data-raw ''
 ```
 </CodeGroup>
 
@@ -536,25 +470,71 @@ curl -X POST https://api.netbird.io/api/users/{userId}/invite \
 
 
 
-## Retrieve current user {{ tag: 'GET', label: '/api/users/current' }}
+## Approve user {{ tag: 'POST', label: '/api/users/{userId}/approve' }}
 
 
 <Row>
 
 <Col>
-Get information about the current user
+Approve a user that is pending approval
+
+### Path Parameters
+
+
+<Properties>
+<Property name="userId" type="string" required={true} >
+The unique identifier of a user
+</Property>
+
+</Properties>
+
 </Col>
 
 <Col sticky>
-<CodeGroup title="Request" tag="GET" label="/api/users/current" >
+<CodeGroup title="Request" tag="POST" label="/api/users/{userId}/approve" >
 ```bash {{ title: 'cURL' }}
-curl -X GET https://api.netbird.io/api/users/current \
--H 'Accept: application/json' \
--H 'Authorization: Token <TOKEN>' 
+curl -X POST https://api.netbird.io/api/users/{userId}/approve \
+-H 'Authorization: Token <TOKEN>' \
 ```
 </CodeGroup>
-<CodeGroup title="Response" tag="GET" label="/api/users/current" >
+<CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
+{
+  "id": "google-oauth2|277474792786460067937",
+  "email": "demo@netbird.io",
+  "name": "Tom Schulz",
+  "role": "admin",
+  "status": "active",
+  "last_login": "2023-05-05T09:00:35.477782Z",
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "is_current": true,
+  "is_service_user": false,
+  "is_blocked": false,
+  "pending_approval": false,
+  "issued": "api",
+  "permissions": {
+    "is_restricted": false,
+    "modules": {
+      "networks": {
+        "read": true,
+        "create": false,
+        "update": false,
+        "delete": false
+      },
+      "peers": {
+        "read": false,
+        "create": false,
+        "update": false,
+        "delete": false
+      }
+    }
+  }
+}
+```
+
+```json {{ title: 'Schema' }}
 {
   "id": "string",
   "email": "string",
@@ -568,6 +548,7 @@ curl -X GET https://api.netbird.io/api/users/current \
   "is_current": "boolean",
   "is_service_user": "boolean",
   "is_blocked": "boolean",
+  "pending_approval": "boolean",
   "issued": "string",
   "permissions": {
     "is_restricted": "boolean",
@@ -595,6 +576,103 @@ curl -X GET https://api.netbird.io/api/users/current \
   }
 }
 ```
+</CodeGroup>
+
+</Col>
+
+</Row>
+---
+
+
+
+## Reject user {{ tag: 'DELETE', label: '/api/users/{userId}/reject' }}
+
+
+<Row>
+
+<Col>
+Reject a user that is pending approval by removing them from the account
+
+### Path Parameters
+
+
+<Properties>
+<Property name="userId" type="string" required={true} >
+The unique identifier of a user
+</Property>
+
+</Properties>
+
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="DELETE" label="/api/users/{userId}/reject" >
+```bash {{ title: 'cURL' }}
+curl -X DELETE https://api.netbird.io/api/users/{userId}/reject \
+-H 'Authorization: Token <TOKEN>' \
+```
+</CodeGroup>
+
+</Col>
+
+</Row>
+---
+
+
+
+## Retrieve current user {{ tag: 'GET', label: '/api/users/current' }}
+
+
+<Row>
+
+<Col>
+Get information about the current user
+</Col>
+
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/api/users/current" >
+```bash {{ title: 'cURL' }}
+curl -X GET https://api.netbird.io/api/users/current \
+-H 'Accept: application/json' \
+-H 'Authorization: Token <TOKEN>' 
+```
+</CodeGroup>
+<CodeGroup title="Response" >
+```json {{ title: 'Example' }}
+{
+  "id": "google-oauth2|277474792786460067937",
+  "email": "demo@netbird.io",
+  "name": "Tom Schulz",
+  "role": "admin",
+  "status": "active",
+  "last_login": "2023-05-05T09:00:35.477782Z",
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "is_current": true,
+  "is_service_user": false,
+  "is_blocked": false,
+  "pending_approval": false,
+  "issued": "api",
+  "permissions": {
+    "is_restricted": false,
+    "modules": {
+      "networks": {
+        "read": true,
+        "create": false,
+        "update": false,
+        "delete": false
+      },
+      "peers": {
+        "read": false,
+        "create": false,
+        "update": false,
+        "delete": false
+      }
+    }
+  }
+}
+```
 
 ```json {{ title: 'Schema' }}
 {
@@ -610,6 +688,7 @@ curl -X GET https://api.netbird.io/api/users/current \
   "is_current": "boolean",
   "is_service_user": "boolean",
   "is_blocked": "boolean",
+  "pending_approval": "boolean",
   "issued": "string",
   "permissions": {
     "is_restricted": "boolean",

--- a/src/pages/ipa/resources/users.mdx
+++ b/src/pages/ipa/resources/users.mdx
@@ -26,6 +26,141 @@ curl -X GET https://api.netbird.io/api/users \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
 ```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/users',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/users"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/users"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/users")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/users")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/users',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
+```
 </CodeGroup>
 <CodeGroup title="Response" >
 ```json {{ title: 'Example' }}
@@ -154,9 +289,9 @@ Is true if this user is a service user
 <CodeGroup title="Request" tag="POST" label="/api/users" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/users \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "email": "demo@netbird.io",
   "name": "Tom Schulz",
@@ -166,6 +301,202 @@ curl -X POST https://api.netbird.io/api/users \
   ],
   "is_service_user": false
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "email": "demo@netbird.io",
+  "name": "Tom Schulz",
+  "role": "admin",
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "is_service_user": false
+});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/users',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/users"
+payload = json.dumps({
+  "email": "demo@netbird.io",
+  "name": "Tom Schulz",
+  "role": "admin",
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "is_service_user": false
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/users"
+  method := "POST"
+  
+  payload := strings.NewReader(`{
+  "email": "demo@netbird.io",
+  "name": "Tom Schulz",
+  "role": "admin",
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "is_service_user": false
+}`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/users")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "email": "demo@netbird.io",
+  "name": "Tom Schulz",
+  "role": "admin",
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "is_service_user": false
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{
+  \"email\": \"demo@netbird.io\",
+  \"name\": \"Tom Schulz\",
+  \"role\": \"admin\",
+  \"auto_groups\": [
+    \"ch8i4ug6lnn4g9hqv7m0\"
+  ],
+  \"is_service_user\": false
+}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/users")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/users',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{
+  "email": "demo@netbird.io",
+  "name": "Tom Schulz",
+  "role": "admin",
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "is_service_user": false
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -296,9 +627,9 @@ If set to true then user is blocked and can't use the system
 <CodeGroup title="Request" tag="PUT" label="/api/users/{userId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/users/{userId} \
--H 'Authorization: Token <TOKEN>' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/json' \
+-H 'Authorization: Token <TOKEN>' \
 --data-raw '{
   "role": "admin",
   "auto_groups": [
@@ -306,6 +637,190 @@ curl -X PUT https://api.netbird.io/api/users/{userId} \
   ],
   "is_blocked": false
 }'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({
+  "role": "admin",
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "is_blocked": false
+});
+let config = {
+  method: 'put',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/users/{userId}',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/users/{userId}"
+payload = json.dumps({
+  "role": "admin",
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "is_blocked": false
+})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("PUT", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/users/{userId}"
+  method := "PUT"
+  
+  payload := strings.NewReader({
+  "role": "admin",
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "is_blocked": false
+})
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/users/{userId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Put.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({
+  "role": "admin",
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "is_blocked": false
+})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, '{
+  "role": "admin",
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "is_blocked": false
+}');
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/users/{userId}")
+  .method("PUT", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'PUT',  
+  CURLOPT_POSTFIELDS => '{
+  "role": "admin",
+  "auto_groups": [
+    "ch8i4ug6lnn4g9hqv7m0"
+  ],
+  "is_blocked": false
+}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -419,7 +934,131 @@ The unique identifier of a user
 <CodeGroup title="Request" tag="DELETE" label="/api/users/{userId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/users/{userId} \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/users/{userId}',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/users/{userId}"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/users/{userId}"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/users/{userId}")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/users/{userId}")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 
@@ -453,7 +1092,158 @@ The unique identifier of a user
 <CodeGroup title="Request" tag="POST" label="/api/users/{userId}/invite" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/users/{userId}/invite \
+-H 'Accept: application/json' \
+-H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
+--data-raw '{}'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/users/{userId}/invite',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/users/{userId}/invite"
+payload = json.dumps({})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/users/{userId}/invite"
+  method := "POST"
+  
+  payload := strings.NewReader(`{}`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/users/{userId}/invite")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/users/{userId}/invite")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}/invite',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 
@@ -487,7 +1277,158 @@ The unique identifier of a user
 <CodeGroup title="Request" tag="POST" label="/api/users/{userId}/approve" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/users/{userId}/approve \
+-H 'Accept: application/json' \
+-H 'Content-Type: application/json' \
 -H 'Authorization: Token <TOKEN>' \
+--data-raw '{}'
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+let data = JSON.stringify({});
+let config = {
+  method: 'post',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/users/{userId}/approve',
+  headers: {     
+    'Accept': 'application/json',    
+    'Content-Type': 'application/json',
+    'Authorization': 'Token <TOKEN>'
+  },  
+  data : data
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/users/{userId}/approve"
+payload = json.dumps({})
+headers = {   
+  'Content-Type': 'application/json',  
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://api.netbird.io/api/users/{userId}/approve"
+  method := "POST"
+  
+  payload := strings.NewReader(`{}`)
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, payload)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }  
+  
+  req.Header.Add("Content-Type", "application/json")  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  resBody, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(resBody))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/users/{userId}/approve")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = "application/json"
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+request.body = JSON.dump({})
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{}");
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/users/{userId}/approve")
+  .method("POST", body)  
+  .addHeader("Content-Type", "application/json")  
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}/approve',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'POST',  
+  CURLOPT_POSTFIELDS => '{}',
+  CURLOPT_HTTPHEADER => array(    
+    'Content-Type: application/json',    
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >
@@ -601,7 +1542,131 @@ The unique identifier of a user
 <CodeGroup title="Request" tag="DELETE" label="/api/users/{userId}/reject" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/users/{userId}/reject \
--H 'Authorization: Token <TOKEN>' \
+-H 'Authorization: Token <TOKEN>'
+```
+
+```js
+const axios = require('axios');
+
+let config = {
+  method: 'delete',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/users/{userId}/reject',
+  headers: {
+    'Authorization': 'Token <TOKEN>'
+  }
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python
+import requests
+
+url = "https://api.netbird.io/api/users/{userId}/reject"
+
+headers = {
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("DELETE", url, headers=headers)
+print(response.text)
+```
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/users/{userId}/reject"
+  method := "DELETE"
+
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby
+require "uri"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/users/{userId}/reject")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Delete.new(url)
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java
+OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/users/{userId}/reject")
+  .method("DELETE", null)
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+
+Response response = client.newCall(request).execute();
+```
+
+```php
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/users/{userId}/reject',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'DELETE',
+  CURLOPT_HTTPHEADER => array(
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 
@@ -626,6 +1691,141 @@ Get information about the current user
 curl -X GET https://api.netbird.io/api/users/current \
 -H 'Accept: application/json' \
 -H 'Authorization: Token <TOKEN>' 
+```
+
+```js {{ title: 'JavaScript' }}
+const axios = require('axios');
+
+let config = {
+  method: 'get',
+  maxBodyLength: Infinity,
+  url: 'https://api.netbird.io/api/users/current',
+  headers: {     
+    'Accept': 'application/json',    
+    'Authorization': 'Token <TOKEN>'
+  }  
+};
+
+axios(config)
+.then((response) => {
+  console.log(JSON.stringify(response.data));
+})
+.catch((error) => {
+  console.log(error);
+});
+```
+
+```python {{ title: 'Python' }}
+import requests
+import json
+
+url = "https://api.netbird.io/api/users/current"
+
+headers = {     
+  'Accept': 'application/json',
+  'Authorization': 'Token <TOKEN>'
+}
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)
+```
+
+```go {{ title: 'Go' }}
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+  url := "https://api.netbird.io/api/users/current"
+  method := "GET"
+  
+  client := &http.Client{}
+  req, err := http.NewRequest(method, url, nil)
+
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  
+  req.Header.Add("Accept", "application/json")
+  req.Header.Add("Authorization", "Token <TOKEN>")
+
+  res, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer res.Body.Close()
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  fmt.Println(string(body))
+}
+```
+
+```ruby {{ title: 'Ruby' }}
+require "uri"
+require "json"
+require "net/http"
+
+url = URI("https://api.netbird.io/api/users/current")
+
+https = Net::HTTP.new(url.host, url.port)
+https.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+request["Accept"] = "application/json"
+request["Authorization"] = "Token <TOKEN>"
+
+response = https.request(request)
+puts response.read_body
+```
+
+```java {{ title: 'Java' }}
+OkHttpClient client = new OkHttpClient().newBuilder()
+  .build();
+
+Request request = new Request.Builder()
+  .url("https://api.netbird.io/api/users/current")
+  .method("GET", null)    
+  .addHeader("Accept", "application/json")
+  .addHeader("Authorization", "Token <TOKEN>")
+  .build();
+Response response = client.newCall(request).execute();
+```
+
+```php {{ title: 'PHP' }}
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => 'https://api.netbird.io/api/users/current',
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => '',
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 0,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => 'GET',  
+  CURLOPT_HTTPHEADER => array(        
+    'Accept: application/json',
+    'Authorization: Token <TOKEN>'
+  ),
+));
+
+$response = curl_exec($curl);
+
+curl_close($curl);
+echo $response;
 ```
 </CodeGroup>
 <CodeGroup title="Response" >

--- a/src/pages/ipa/resources/users.mdx
+++ b/src/pages/ipa/resources/users.mdx
@@ -5,8 +5,7 @@ export const title = 'Users'
 
 
 <Row>
-
-<Col>
+ <Col>
 Returns a list of all users
 
 ### Query Parameters
@@ -20,8 +19,7 @@ Filters users and returns either regular users or service users
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/users" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/users \
@@ -117,6 +115,7 @@ curl -X GET https://api.netbird.io/api/users \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -125,8 +124,7 @@ curl -X GET https://api.netbird.io/api/users \
 
 
 <Row>
-
-<Col>
+ <Col>
 Creates a new service user or sends an invite to a regular user
 
 ### Request-Body Parameters
@@ -152,8 +150,7 @@ Is true if this user is a service user
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="POST" label="/api/users" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/users \
@@ -255,6 +252,7 @@ curl -X POST https://api.netbird.io/api/users \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -263,8 +261,7 @@ curl -X POST https://api.netbird.io/api/users \
 
 
 <Row>
-
-<Col>
+ <Col>
 Update information about a User
 
 ### Path Parameters
@@ -295,8 +292,7 @@ If set to true then user is blocked and can't use the system
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="PUT" label="/api/users/{userId}" >
 ```bash {{ title: 'cURL' }}
 curl -X PUT https://api.netbird.io/api/users/{userId} \
@@ -396,6 +392,7 @@ curl -X PUT https://api.netbird.io/api/users/{userId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -404,8 +401,7 @@ curl -X PUT https://api.netbird.io/api/users/{userId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 This method removes a user from accessing the system. For this leaves the IDP user intact unless the `--user-delete-from-idp` is passed to management startup.
 
 ### Path Parameters
@@ -419,8 +415,7 @@ The unique identifier of a user
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/users/{userId}" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/users/{userId} \
@@ -431,6 +426,7 @@ curl -X DELETE https://api.netbird.io/api/users/{userId} \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -439,8 +435,7 @@ curl -X DELETE https://api.netbird.io/api/users/{userId} \
 
 
 <Row>
-
-<Col>
+ <Col>
 Resend user invitation
 
 ### Path Parameters
@@ -454,8 +449,7 @@ The unique identifier of a user
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="POST" label="/api/users/{userId}/invite" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/users/{userId}/invite \
@@ -466,6 +460,7 @@ curl -X POST https://api.netbird.io/api/users/{userId}/invite \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -474,8 +469,7 @@ curl -X POST https://api.netbird.io/api/users/{userId}/invite \
 
 
 <Row>
-
-<Col>
+ <Col>
 Approve a user that is pending approval
 
 ### Path Parameters
@@ -489,8 +483,7 @@ The unique identifier of a user
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="POST" label="/api/users/{userId}/approve" >
 ```bash {{ title: 'cURL' }}
 curl -X POST https://api.netbird.io/api/users/{userId}/approve \
@@ -581,6 +574,7 @@ curl -X POST https://api.netbird.io/api/users/{userId}/approve \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -589,8 +583,7 @@ curl -X POST https://api.netbird.io/api/users/{userId}/approve \
 
 
 <Row>
-
-<Col>
+ <Col>
 Reject a user that is pending approval by removing them from the account
 
 ### Path Parameters
@@ -604,8 +597,7 @@ The unique identifier of a user
 </Properties>
 
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="DELETE" label="/api/users/{userId}/reject" >
 ```bash {{ title: 'cURL' }}
 curl -X DELETE https://api.netbird.io/api/users/{userId}/reject \
@@ -616,6 +608,7 @@ curl -X DELETE https://api.netbird.io/api/users/{userId}/reject \
 </Col>
 
 </Row>
+
 ---
 
 
@@ -624,12 +617,10 @@ curl -X DELETE https://api.netbird.io/api/users/{userId}/reject \
 
 
 <Row>
-
-<Col>
+ <Col>
 Get information about the current user
 </Col>
-
-<Col sticky>
+ <Col sticky>
 <CodeGroup title="Request" tag="GET" label="/api/users/current" >
 ```bash {{ title: 'cURL' }}
 curl -X GET https://api.netbird.io/api/users/current \
@@ -721,4 +712,5 @@ curl -X GET https://api.netbird.io/api/users/current \
 </Col>
 
 </Row>
+
 ---


### PR DESCRIPTION
## This PR introduces a new openapi-gen parser that replaces the old EJS-based generator.

### Why?
- The old approach relied on templates and third-party tools like swagger-codegen.
- It was brittle, hard to extend, and not easy to maintain.

### What’s new
- No external deps → everything runs with plain TypeScript and TSX, no swagger-codegen or other codegen libraries.
- Full OpenAPI 3.1 support → handles $ref, allOf, oneOf, arrays, enums, nullables, min/max constraints.
- Consistent request/response schema → produces a clean, predictable object model (works great for docs + UI components).
- Examples preserved → examples are extracted and aligned with the schema.
- Extensible → easy to plug in custom rules (e.g. Markdown/MDX generation, TSX components, etc.).

### Usage

#### Run the parser with npm
```bash
npm run api-gen
```

#### Run the parser directly with ts-node:
```bash
ts-node index.ts <openapi-url> [output-dir]
```
- `<openapi-url>` → Path or URL to an OpenAPI YAML file
- `[output-dir]` → (optional) Output directory, defaults to `src/pages/ipa/resources`

Example:
```bash
ts-node index.ts ./openapi.yml ./docs/api
```

This will parse the spec, generate MDX files per tag, and write them into ` ./docs/api`.