### PR TITLE
[selfhosted] Add selfhosted instructions for activity events on mysql

### DIFF
--- a/src/pages/selfhosted/activity-mysql-store.mdx
+++ b/src/pages/selfhosted/activity-mysql-store.mdx
@@ -1,0 +1,15 @@
+# Activity Events MySQL store
+
+## Using MySQL for fresh installations
+
+To enable MySQL add to your management service the following environmental variable:
+```bash
+NB_ACTIVITY_EVENT_STORE_ENGINE=mysql
+NB_ACTIVITY_EVENT_MYSQL_DSN="mysql://<username>:<password>@<host>:<port>/<db_name>"
+```
+
+You can switch back to sqlite storage by setting the `NB_ACTIVITY_EVENT_STORE_ENGINE` variable to `sqlite`.
+<Note>
+    Switching between storage options requires migration steps to prevent data loss.
+</Note>
+


### PR DESCRIPTION
Added a basic set of instructions on how to use a MySQL database to store activity events.