### PR TITLE
fix the advanced self-hosting guide link

### DIFF
--- a/src/pages/selfhosted/selfhosted-guide.mdx
+++ b/src/pages/selfhosted/selfhosted-guide.mdx
@@ -86,7 +86,7 @@ This can be any email address. [Let's Encrypt](https://letsencrypt.org/) will cr
 </Note>
 
 <Note>
-    If you want to setup NetBird with your own reverse-Proxy and without using the integrated letsencrypt, follow [this step here instead](#advanced-running-netbird-behind-an-existing-reverse-proxy).
+    If you want to setup NetBird with your own reverse-Proxy and without using the integrated letsencrypt, follow [this step here instead](#advanced-running-net-bird-behind-an-existing-reverse-proxy).
 </Note>
 
 ### Step 3: Configure Identity Provider (IDP)


### PR DESCRIPTION
branding `Netbird` as `NetBird` added a `-` to the link form for `net-bird`