### PR TITLE
Removed duplicate entry for 'Number of peers' in metrics list in FAQ

### DIFF
--- a/src/pages/about-netbird/faq.mdx
+++ b/src/pages/about-netbird/faq.mdx
@@ -72,7 +72,6 @@ We are collecting the following metrics:
 * Number of accounts
 * Number of users
 * Number of peers
-* Number of peers 
 * Number of active peers in the last 24 hours
 * Number of peers per operating system
 * Number of setup keys usage


### PR DESCRIPTION
## Issue
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/c1069846-e1a4-41dc-9827-b3c77dd7b222" />
