### PR TITLE
chore: add docs for group filter

### DIFF
--- a/src/pages/ipa/resources/groups.mdx
+++ b/src/pages/ipa/resources/groups.mdx
@@ -7,6 +7,14 @@ export const title = 'Groups'
 <Row>
   <Col>
     Returns a list of all groups
+    
+    ### Query Parameters
+    <Properties>
+        
+          <Property name="name" type="string" required={false}> 
+            Filter groups by name
+          </Property>   
+            </Properties>
               </Col>
 
   <Col sticky>


### PR DESCRIPTION
### Add name query parameter to List Groups API

**Summary**
Added support for filtering groups by name in the List Groups endpoint (GET /api/groups).

**Changes**
- Added optional name query parameter to the List Groups API documentation
- Users can now filter groups by name instead of retrieving all groups and filtering client-side

**API Updates**
- Endpoint: GET /api/groups

**New Query Parameter:**
- name (string, optional) - Filter groups by name

```bash
# Get all groups
curl -X GET https://api.netbird.io/api/groups \
  -H 'Accept: application/json' \
  -H 'Authorization: Token <TOKEN>'

# Get groups filtered by name
curl -X GET https://api.netbird.io/api/groups?name=devs \
  -H 'Accept: application/json' \
  -H 'Authorization: Token <TOKEN>'
```

**Benefits**
- Improved API efficiency by allowing server-side filtering
- Reduces data transfer for clients looking for specific groups
- Better developer experience when searching for groups by name