### PR TITLE
feat: `All` group clarification for Network Resources

### DIFF
--- a/src/pages/how-to/networks.mdx
+++ b/src/pages/how-to/networks.mdx
@@ -104,15 +104,29 @@ On a technical level the feature works as follows:
 
 ## Manage access to resources
 
-To manage access to resources, you can assign them to groups and create [access control policies](/manage/access-control/manage-network-access#creating-policies) to define which peers can access them.
+
+To manage access to resources, you should assign them to groups and create
+[access control policies](/manage/access-control/manage-network-access#creating-policies)
+to grant access from the specific peer groups.
+A peer will "see" the resource only after a policy allows access from one of peer's (source) groups to one of
+the resource's (destination) groups.
+
 See the image below with an example resource `CRM`:
 <p>
     <img src="/docs-static/img/how-to-guides/networks/resources-2.png" alt="resource-group" className="imagewrapper"/>
 </p>
 
-Access control policies are rules that define which peers can access the resources in your network. You can create policies based on the source and destination groups, and the type of traffic allowed (e.g., TCP, UDP, ICMP).
+Access control policies are rules that define which peers can access the resources in your network. 
+You can create policies based on the source and destination groups, and the type of traffic allowed (e.g., TCP, UDP, ICMP).
 The groups assigned to resources should always be placed in the destination input field of the policy.
 The peers belonging to the source groups will receive the resources linked to the policy and the firewall rules will be applied according to what is defined.
+
+<Note>
+  Unlike peers, resources are not members of the built-in `All` group by default.
+
+  If you want to utilize `All` group rules with resources, you must explicitly add them to this group.
+</Note>
+
 See the example below with a policy that allows the group `Berlin Office` to access the internal CRM system:
 
 <p>


### PR DESCRIPTION
<img width="1792" height="2658" alt="image" src="https://github.com/user-attachments/assets/c6a279a4-dd24-48a4-a92c-4e21190657d3" />