### PR TITLE
All group clarification for Network Resources

### DIFF
--- a/src/pages/manage/networks/index.mdx
+++ b/src/pages/manage/networks/index.mdx
@@ -104,7 +104,8 @@ On a technical level the feature works as follows:
 
 ## Manage access to resources
 
-To manage access to resources, you can assign them to groups and create [access control policies](/manage/access-control/manage-network-access#creating-policies) to define which peers can access them.
+To manage access to resources, you should assign them to groups and create [access control policies](/manage/access-control/manage-network-access#creating-policies) to grant access from the specific peer groups. A peer will "see" the resource only after a policy allows access from one of peer's (source) groups to one of the resource's (destination) groups.
+
 See the image below with an example resource `CRM`:
 <p>
     <img src="/docs-static/img/manage/networks/index/resources-2.png" alt="resource-group" className="imagewrapper"/>
@@ -113,6 +114,11 @@ See the image below with an example resource `CRM`:
 Access control policies are rules that define which peers can access the resources in your network. You can create policies based on the source and destination groups, and the type of traffic allowed (e.g., TCP, UDP, ICMP).
 The groups assigned to resources should always be placed in the destination input field of the policy.
 The peers belonging to the source groups will receive the resources linked to the policy and the firewall rules will be applied according to what is defined.
+
+<Note>
+  Unlike peers, resources are not members of the built-in `All` group by default. If you want to utilize `All` group rules with resources, you must explicitly add them to this group.
+</Note>
+
 See the example below with a policy that allows the group `Berlin Office` to access the internal CRM system:
 
 <p>


### PR DESCRIPTION
Original PR: [https://github.com/netbirdio/docs/pull/493](https://github.com/netbirdio/docs/pull/493) by @nazarewk 

Updated the section on managing access to resources to clarify the assignment of resources to groups and the creation of access control policies. Added details on how peers access resources based on group policies and included a note about resources not being part of the built-in 'All' group by default.

<img width="1436" height="1060" alt="Screenshot 2025-11-27 at 12 56 36 PM" src="https://github.com/user-attachments/assets/7ef148ac-bf9f-4ab6-8be4-68fb433ee0a8" />

