### PR TITLE
Update known limitations posture checks

### DIFF
--- a/src/pages/manage/access-control/posture-checks/index.mdx
+++ b/src/pages/manage/access-control/posture-checks/index.mdx
@@ -102,6 +102,28 @@ If you revisit the `Posture Checks` dashboard, you'll notice a green dot next to
 
 Following these steps, you can effectively implement and manage NetBird's Posture Checks, significantly enhancing your network's security posture.
 
+## Known Limitations
+
+### Peer Network Range Check on Mobile Platforms
+
+The Peer Network Range posture check is not supported on iOS and Android clients. These operating systems do not allow applications to fetch local IP information, which prevents the posture check from evaluating the device's network range.
+
+**Affected platforms:**
+- iOS
+- Android
+
+**Impact:**
+
+When a policy with a Peer Network Range posture check is applied to mobile clients, the check cannot be evaluated. This may cause routes to become unavailable on these devices, even when the device is outside the blocked network range.
+
+**Recommendation:**
+
+If your deployment includes iOS or Android clients, consider one of the following approaches:
+
+- Create separate policies for mobile clients that do not include Peer Network Range posture checks
+- Use alternative posture checks (such as Geo Location) that are supported on mobile platforms
+- Apply Peer Network Range posture checks only to policies targeting desktop platforms (Windows, macOS, Linux)
+
 ## Get started with NetBird
 <p float="center" >
     <Button name="button" className="button-5" onClick={() => window.open("https://netbird.io/pricing")}>Use NetBird</Button>


### PR DESCRIPTION
Documents that the Peer Network Range posture check is not supported on iOS and Android clients due to OS-level restrictions on accessing local IP information.

Changes
- Adds a "Known Limitations" section to the Posture Checks documentation
- Explains why mobile platforms cannot support this check
- Documents the impact on route availability
- Provides recommendations for administrators with mixed desktop/mobile deployments

Context
iOS and Android do not allow applications to fetch local IP information, which is required for the Peer Network Range posture check to evaluate a device's network. This limitation causes routes to become unavailable on mobile clients when this posture check is applied.