### PR TITLE
Fix build by adding --webpack flag for Next.js 16 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "npm run gen:llm && next dev --webpack",
-    "build": "npm run gen:llm && next build",
+    "build": "npm run gen:llm && next build --webpack",
     "gen": "swagger-codegen generate -i https://raw.githubusercontent.com/netbirdio/netbird/main/management/server/http/api/openapi.yml -l openapi -o generator/openapi && npx ts-node generator/index.ts gen --input generator/openapi/openapi.json --output src/pages/ipa/resources",
     "gen:llm": "node scripts/generate-llm-docs.mjs",
     "start": "next start",


### PR DESCRIPTION
Next.js 16 defaults to Turbopack, which fails to process the MDX files in this project. Adding --webpack to the build script forces webpack bundler usage until Turbopack compatibility is resolved.