### PR TITLE
Add clarification to jwt group sync docs that groups with same name i…

### DIFF
--- a/src/pages/selfhosted/identity-providers/index.mdx
+++ b/src/pages/selfhosted/identity-providers/index.mdx
@@ -169,6 +169,10 @@ Your IdP may require specific configuration in order to pass a groups claim to N
 - [Authentik](/selfhosted/identity-providers/authentik#configuring-jwt-groups-claim)
 - [Keycloak](/selfhosted/identity-providers/keycloak#configuring-jwt-groups-claim)
 
+<Note> 
+Groups with matching names in NetBird and your IdP will **not** sync. To import a group from your IdP, first delete the existing group with that name in NetBird.
+</Note>
+
 #### SCIM 
 NetBird supports provisioning users and groups through SCIM. However, this functionality is not available in the open source Community Edition. It is offered only in the cloud-managed version of NetBird or through a [Commercial License](https://netbird.io/pricing#on-prem) for enterprise self-hosted deployments.
 


### PR DESCRIPTION
…n netbird will not be synced

<img width="1667" height="1323" alt="grafik" src="https://github.com/user-attachments/assets/12af8320-f4ee-46a4-9df3-fd01cf7f4248" />
