### PR TITLE
update docs for NB_DISABLE_CERT_VALIDATION env variable

### DIFF
--- a/src/pages/selfhosted/environment-variables.mdx
+++ b/src/pages/selfhosted/environment-variables.mdx
@@ -124,6 +124,7 @@ These variables can override CLI flags at runtime. The naming convention is `NB_
 | `NB_CERT_KEY` | TLS certificate key file |
 | `NB_DNS_DOMAIN` | DNS domain for peers |
 | `NB_DISABLE_GEOLITE_UPDATE` | Disable GeoLite database updates |
+| `NB_DISABLE_CERT_VALIDATION` | When set to true, disables SSL certificate validation when making external HTTP requests. Default is false. |
 
 ### Advanced Runtime Variables
 


### PR DESCRIPTION
1. Created `util.NewTransport()` and `util.NewHTTPClient()` to standardize HTTP transport configuration
2. If `NB_DISABLE_CERT_VALIDATION=true`, the transport is configured with `InsecureSkipVerify: true` which will disable certificate validation
3. If it is set to false which is by default, secure transport is used just like previous versions
4. The new config is used in GeoIP download logic, OIDC requests, version check and IDP managers





More info: https://github.com/netbirdio/netbird/pull/5216