### PR TITLE
Update references to outdated server addresses

### DIFF
--- a/src/pages/get-started/cli.mdx
+++ b/src/pages/get-started/cli.mdx
@@ -38,7 +38,7 @@ Below is the list of global flags:
       --daemon-addr string      Daemon service address to serve CLI requests [unix|tcp]://[path|host:port] (default "unix:///var/run/netbird.sock")
       --log-file string         sets NetBird log path. If console is specified the the log will be output to stdout (default "/var/log/netbird/client.log")
   -l, --log-level string        sets NetBird log level (default "info")
-  -m, --management-url string   Management Service URL [http|https]://[host]:[port] (default "https://api.wiretrustee.com:443")
+  -m, --management-url string   Management Service URL [http|https]://[host]:[port] (default "https://api.netbird.io:443")
   -p, --preshared-key string    Sets Wireguard PreSharedKey property. If set, then only peers that have the same key can communicate.
   -k, --setup-key string        Setup key obtained from the Management Service Dashboard (used to register peer)
 
@@ -52,10 +52,10 @@ Every flag of a `netbird` command can be passed as an environment variable. We a
 For example, let's check how we can pass `--config` and `--management-url` as environment variables:
 ```shell
 export NB_CONFIG="/opt/netbird/config.json"
-export NB_MANAGEMENT_URL="https://api.self-hosted.com:33073"
+export NB_MANAGEMENT_URL="https://api.self-hosted.com:443"
 netbird up
 ```
-The `up` command would process the variables, read the configuration file on `/opt/netbird/config.json` and attempt to connect to the management service running at `https://api.self-hosted.com:33073`.
+The `up` command would process the variables, read the configuration file on `/opt/netbird/config.json` and attempt to connect to the management service running at `https://api.self-hosted.com:443`.
 
 Here are some additional examples of environment variables:
 ```shell
@@ -105,7 +105,7 @@ netbird up
 ```
 If you are running on a self-hosted environment, you can pass your management url by running the following:
 ```shell
-netbird up --management-url https://api.self-hosted.com:33073
+netbird up --management-url https://api.self-hosted.com:443
 ```
 if you want to run in the foreground, you can use "console" as the value for `--log-file` and run the command with sudo:
 ```shell
@@ -136,7 +136,7 @@ netbird login
 ```
 If you are running on a self-hosted environment, you can pass your management url by running the following:
 ```shell
-netbird login --management-url https://api.self-hosted.com:33073
+netbird login --management-url https://api.self-hosted.com:443
 ```
 In case you need to use a setup key, use the `--setup-key` flag:
 ```shell
@@ -144,7 +144,7 @@ netbird login --setup-key AAAA-BBB-CCC-DDDDDD
 ```
 Passing a management url and a setup key:
 ```shell
-netbird login --setup-key AAAA-BBB-CCC-DDDDDD --management-url https://api.self-hosted.com:33073
+netbird login --setup-key AAAA-BBB-CCC-DDDDDD --management-url https://api.self-hosted.com:443
 ```
 
 ### down
@@ -248,8 +248,8 @@ Peers detail:
 OS: linux/amd64
 Daemon version: 0.27.4
 CLI version: 0.27.4
-Management: Connected to https://api.netbird.io:33073
-Signal:  Connected to https://signal2.wiretrustee.com:10000
+Management: Connected to https://api.netbird.io:443
+Signal:  Connected to https://signal.netbird.io:443
 Relays:
   [stun:stun.netbird.io:5555] is Available
   [turns:turn.netbird.io:443?transport=tcp] is Available
@@ -303,8 +303,8 @@ Peers detail:
 OS: linux/amd64
 Daemon version: 0.27.4
 CLI version: 0.27.4
-Management: Connected to https://api.netbird.io:33073
-Signal:  Connected to https://signal2.wiretrustee.com:10000
+Management: Connected to https://api.netbird.io:443
+Signal:  Connected to https://signal.netbird.io:443
 Relays:
   [stun:stun.netbird.io:5555] is Available
   [turns:turn.netbird.io:443?transport=tcp] is Available
@@ -342,8 +342,8 @@ Peers detail:
 OS: linux/amd64
 Daemon version: 0.27.4
 CLI version: 0.27.4
-Management: Connected to https://api.netbird.io:33073
-Signal:  Connected to https://signal2.wiretrustee.com:10000
+Management: Connected to https://api.netbird.io:443
+Signal:  Connected to https://signal.netbird.io:443
 Relays:
   [stun:stun.netbird.io:5555] is Available
   [turns:turn.netbird.io:443?transport=tcp] is Available
@@ -382,8 +382,8 @@ Peers detail:
 OS: linux/amd64
 Daemon version: 0.27.4
 CLI version: 0.27.4
-Management: Connected to https://api.netbird.io:33073
-Signal:  Connected to https://signal2.wiretrustee.com:10000
+Management: Connected to https://api.netbird.io:443
+Signal:  Connected to https://signal.netbird.io:443
 Relays:
   [stun:stun.netbird.io:5555] is Available
   [turns:turn.netbird.io:443?transport=tcp] is Available


### PR DESCRIPTION
The document has several outdated references to server addresses (e.g. api.wiretrustee.com, signal2.wiretrustee.com) and ports.

I've updated the document with the current addresses and ports according to https://docs.netbird.io/about-netbird/faq