### PR TITLE
Add --disable-default-route CLI flag documentation

### DIFF
--- a/src/pages/get-started/cli.mdx
+++ b/src/pages/get-started/cli.mdx
@@ -82,6 +82,7 @@ The command will check if the peer is logged in and connect to the management se
       
       --allow-server-ssh                      Allow SSH server on peer. If enabled, the SSH server will be permitted
       --disable-auto-connect                  Disables auto-connect feature. If enabled, then the client won't connect automatically when the service starts.
+      --disable-default-route                  Prevents installation of the default route (0.0.0.0/0) into the system routing table while preserving WireGuard AllowedIPs configuration. Useful when you want to manage routing externally.
       --disable-ssh-auth                      Disable SSH JWT authentication. If enabled, any peer with network access can connect without user authentication
       --dns-resolver-address string           Sets a custom address for NetBird's local DNS resolver. If set, the agent won't attempt to discover the best ip and port to listen on. An empty string "" clears the previous configuration. E.g. --dns-resolver-address 127.0.0.1:5053 or --dns-resolver-address ""
       --ssh-jwt-cache-ttl int                 SSH JWT token cache TTL in seconds. Set to 0 to disable caching (default). E.g. --ssh-jwt-cache-ttl 3600 for 1-hour cache

--- a/src/pages/manage/network-routes/use-cases/by-scenario/exit-nodes.mdx
+++ b/src/pages/manage/network-routes/use-cases/by-scenario/exit-nodes.mdx
@@ -93,6 +93,20 @@ Add a DNS server with the match domain set to `ALL`. Local DNS servers may not b
 
 See [Manage DNS in your network](/manage/dns) for details.
 
+## Disabling Default Route Installation
+
+In some scenarios, you may want an exit node to be enabled on a peer without automatically routing all host traffic through the tunnel. For example, when you need custom policy-based routing or want to manage routes externally.
+
+The `--disable-default-route` CLI flag prevents the default route (`0.0.0.0/0`) from being installed into the system routing table while preserving the WireGuard AllowedIPs configuration. This means WireGuard will still accept and encrypt traffic for all destinations, but the operating system won't automatically send all traffic into the tunnel unless your own routing rules direct it there.
+
+```shell
+netbird up --disable-default-route
+```
+
+<Note>
+    This flag only affects the system routing table. WireGuard AllowedIPs remain configured as usual, so traffic explicitly routed into the WireGuard interface will still be handled correctly.
+</Note>
+
 ## High Availability
 
 Exit nodes support high availability configurations. See [Creating Highly Available Routes](/manage/network-routes#creating-highly-available-routes) for more information.


### PR DESCRIPTION
This PR documents the new `--disable-default-route` client flag that prevents installation of the `0.0.0.0/0` route into the system routing table while preserving WireGuard AllowedIPs, enabling custom routing management outside NetBird.

- Added `--disable-default-route` flag to the `netbird up` CLI reference
- Added "Disabling Default Route Installation" section to the exit node configuration guide
