### PR TITLE
Fix 5 broken internal links across docs

### DIFF
--- a/src/pages/get-started/install/index.mdx
+++ b/src/pages/get-started/install/index.mdx
@@ -13,7 +13,7 @@ The NetBird client (agent) allows a peer to join a pre-existing NetBird deployme
 * [Install on macOS](/get-started/install/macos)
 * [Install on Windows](/get-started/install/windows)
 * [Install on Android](/get-started/install/android)
-* [Install on iOS](/get-started/install/iOS)
+* [Install on iOS](/get-started/install/ios)
 
 ## Additional Platforms
 * [Install on Synology](/get-started/install/synology)

--- a/src/pages/get-started/install/truenas.mdx
+++ b/src/pages/get-started/install/truenas.mdx
@@ -6,7 +6,7 @@ import {YouTube} from "@/components/YouTube";
 NetBird can now be installed on TrueNAS via [TrueNAS Apps](https://apps.truenas.com/catalog/netbird-client/) (the built-in app catalog). If you need help setting up TrueNAS from scratch (install, storage pools, datasets, users, SMB sharing, and more), see our [Knowledge Hub Guide: TrueNAS Made Easy](https://netbird.io/knowledge-hub/truenas-setup-and-remote-access).
 
 <Note>
-The NetBird app on TrueNAS runs in a Docker container. You **cannot** use the peer's NetBird IP address or [NetBird domain (hostname)](/manage/dns/index) to connect directly to your TrueNAS instance traffic to those addresses reaches the container, not the TrueNAS host. See [Access TrueNAS via NetBird Networks](#access-truenas-via-netbird-networks) below for the full steps.
+The NetBird app on TrueNAS runs in a Docker container. You **cannot** use the peer's NetBird IP address or [NetBird domain (hostname)](/manage/dns) to connect directly to your TrueNAS instance traffic to those addresses reaches the container, not the TrueNAS host. See [Access TrueNAS via NetBird Networks](#access-truenas-via-netbird-networks) below for the full steps.
 </Note>
 
 ## Install NetBird from Catalog

--- a/src/pages/use-cases/homelab/index.mdx
+++ b/src/pages/use-cases/homelab/index.mdx
@@ -30,7 +30,7 @@ For connecting entire home networks (accessing devices that don't have NetBird i
             description: 'Set up VPN-to-Site access to reach home network devices from anywhere',
         },
         {
-            href: '/manage/network-routes/use-cases/site-to-site-home',
+            href: '/manage/network-routes/use-cases/by-scenario/site-to-site-home',
             name: 'Connect Home Networks',
             description: 'Link multiple home networks together using Site-to-Site routing',
         },

--- a/src/pages/use-cases/site-to-site/index.mdx
+++ b/src/pages/use-cases/site-to-site/index.mdx
@@ -118,12 +118,12 @@ All scenarios use a routing peer—a device running NetBird that forwards traffi
     title="Site-to-Site Guides (Network Routes)"
     items={[
         {
-            href: '/manage/network-routes/use-cases/site-to-site-home',
+            href: '/manage/network-routes/use-cases/by-scenario/site-to-site-home',
             name: 'Connect Home Networks',
             description: 'Link multiple home networks so devices can communicate across locations',
         },
         {
-            href: '/manage/network-routes/use-cases/site-to-site-office',
+            href: '/manage/network-routes/use-cases/by-scenario/site-to-site-office',
             name: 'Connect Office Networks',
             description: 'Connect branch offices to headquarters and enable cross-site communication',
         },


### PR DESCRIPTION
- Fix case mismatch: /get-started/install/iOS → /ios (would 404 on Linux)
- Remove literal /index from /manage/dns/index → /manage/dns
- Add missing /by-scenario/ segment to 3 network-routes links