### PR TITLE
Rename docker-compose.yml to compose.yml

### DIFF
--- a/src/pages/selfhosted/selfhosted-quickstart.mdx
+++ b/src/pages/selfhosted/selfhosted-quickstart.mdx
@@ -85,7 +85,7 @@ The script generates the following files:
 
 | File | Description |
 |------|-------------|
-| `docker-compose.yml` | Docker Compose configuration with all services |
+| `compose.yml` | Docker Compose configuration with all services |
 | `config.yaml` | Combined server configuration (management, signal, relay, STUN) |
 | `dashboard.env` | Environment variables for the dashboard container |
 | `proxy.env` | Environment variables for the proxy container (only when proxy is enabled) |


### PR DESCRIPTION
~~smol change, as per [docs.docker.com](https://docs.docker.com/compose/intro/compose-application-model/), the default filename is `compose.yml`~~

having looked more into this netbird still uses `docker-compose.yml` throughout the self-hosted setup; so this PR is a good first start but maybe for consistency not merge yet.