### PR TITLE
Add minimum access policy note for exit nodes

### DIFF
--- a/src/pages/manage/network-routes/use-cases/by-scenario/exit-nodes.mdx
+++ b/src/pages/manage/network-routes/use-cases/by-scenario/exit-nodes.mdx
@@ -24,6 +24,10 @@ The routing peer acts as the exit node for internet traffic. It applies masquera
 
 Peers in the distribution groups send their internet traffic through the routing peer once it connects.
 
+<Note>
+    The minimum access policy required for peers to use an exit node is **Users** (source) → **Routing Peer** (destination) over **ICMP**. Ensure a policy with this configuration exists for the distribution groups assigned to the exit node route.
+</Note>
+
 ### Exit Node Selection and Auto Apply
 
 Administrators configure exit nodes from the dashboard and can enable **Auto Apply** to have clients automatically use the exit node.


### PR DESCRIPTION
## Summary
- Adds a note under the Distribution Groups section of the exit nodes documentation clarifying the minimum access policy required for peers to use an exit node: **Users** (source) → **Routing Peer** (destination) over **ICMP**