### PR TITLE
Crowdsec integration: update health check command from capi to lapi

### DIFF
--- a/src/pages/selfhosted/migration/enable-reverse-proxy.mdx
+++ b/src/pages/selfhosted/migration/enable-reverse-proxy.mdx
@@ -279,7 +279,7 @@ Add the following service to your `docker-compose.yml`:
       - ./crowdsec:/etc/crowdsec
       - crowdsec_db:/var/lib/crowdsec/data
     healthcheck:
-      test: ["CMD", "cscli", "capi", "status"]
+      test: ["CMD", "cscli", "lapi", "status"]
       interval: 10s
       timeout: 5s
       retries: 15
@@ -313,7 +313,7 @@ docker compose up -d crowdsec
 Wait for the container to become healthy:
 
 ```bash
-docker compose exec crowdsec cscli capi status
+docker compose exec crowdsec cscli lapi status
 ```
 
 Then register a bouncer:


### PR DESCRIPTION
Hello,

Crowdsec maintainer here !

I just saw that you've added an integration with crowdsec in your latest release, thanks !

After a quick look at your documentation, I spotted an issue in the example compose file: you are using `cscli capi status` as the health check for the container, but this command is not intended to be used like this.

`cscli capi status` will attempt to login to the central API (hosted by us), and this tells nothing about the state of the local instance, but simply that the instance has valid CAPI credentials.

The command that you actually want to use is `cscli lapi status`: this will query the local API running in the container.

The Pangolin team made the same mistake a few months back, and we had to put in place more drastic rate limiting on CAPI for instances querying too often (see [this issue](https://github.com/crowdsecurity/crowdsec/issues/4165) for more context), so a check every 10s will definitely lead to very harsh rate limiting.

This PR simply replaces `capi` with `lapi` in the health check command, and in the command used to verify if the container is up before adding a new bouncer.