### PR TITLE
fix(docs): correct code fence language for PowerShell blocks

### DIFF
--- a/src/pages/help/troubleshooting-client.mdx
+++ b/src/pages/help/troubleshooting-client.mdx
@@ -306,7 +306,7 @@ sudo netbird service start
 
 You need to run the following commands with an elevated PowerShell or `cmd.exe` window.
 
-```shell
+```powershell
 [Environment]::SetEnvironmentVariable("NB_LOG_LEVEL", "debug", "Machine")
 netbird service restart
 ```
@@ -360,7 +360,7 @@ netbird service stop
 In case you need to configure environment variables, you need to add them as system variables so they get picked up by
 the agent on the next psexec run:
 
-```shell
+```powershell
 [Environment]::SetEnvironmentVariable("PIONS_LOG_DEBUG", "all", "Machine")
 ````
 


### PR DESCRIPTION
## Summary
- Fix incorrect code fence language identifier in two PowerShell code blocks in the troubleshooting guide
- `[Environment]::SetEnvironmentVariable(...)` is PowerShell syntax and should use `powershell` fences, not `shell`

Addresses the one remaining valid fix from #374 (which is stale with merge conflicts due to docs restructuring).


🤖 Generated with [Claude Code](https://claude.com/claude-code)