### PR TITLE
docs(pfsense): remove hardcoded version from install instructions

### DIFF
--- a/src/pages/get-started/install/pfsense.mdx
+++ b/src/pages/get-started/install/pfsense.mdx
@@ -22,27 +22,35 @@ This installation is intended for early adopters while the pfSense package is un
    ```
    If remote SSH is enabled or use the built-in shell via the pfSense Web UI (`Diagnostics` > `Command Prompt`).
 
-3. **Download the NetBird client(agent)**
+2. **Download the NetBird packages**
 
-   From a shell on your pfSense system, run:
+   Go to the [latest pfSense NetBird release](https://github.com/netbirdio/pfsense-netbird/releases/latest). On the release page you will see:
+   - The **release tag** at the top of the page (e.g. `v0.1.34`)
+   - Two `.pkg` files for each architecture listed under **Assets** — the version numbers are embedded in the filenames
+
+   Pick the files that match your system architecture:
+   - `x86_64` — standard Intel/AMD-based pfSense installations
+   - `aarch64` — ARM-based pfSense installations
+
+   For example, a release with tag `v0.1.34` might list these assets:
+   - `netbird-0.69.0-x86_64.pkg`
+   - `pfSense-pkg-NetBird-0.2.2-x86_64.pkg`
+
+   From a shell on your pfSense system, use `fetch` with the download URLs, replacing the tag, version, and architecture values with those from the release page:
    ```sh
-   fetch https://github.com/netbirdio/pfsense-netbird/releases/download/v0.1.2/netbird-0.55.1.pkg
+   fetch https://github.com/netbirdio/pfsense-netbird/releases/download/<RELEASE_TAG>/netbird-<VERSION>-<ARCH>.pkg
+   fetch https://github.com/netbirdio/pfsense-netbird/releases/download/<RELEASE_TAG>/pfSense-pkg-NetBird-<VERSION>-<ARCH>.pkg
    ```
-3. **Download the NetBird pfSense package**
 
-   From a shell on your pfSense system, run:
+3. **Install the packages**
+
+   Install both packages using the filenames you downloaded:
    ```sh
-   fetch https://github.com/netbirdio/pfsense-netbird/releases/download/v0.1.2/pfSense-pkg-NetBird-0.1.0.pkg
+   pkg add -f netbird-<VERSION>-<ARCH>.pkg
+   pkg add -f pfSense-pkg-NetBird-<VERSION>-<ARCH>.pkg
    ```
 
-4. **Install the packages**
-
-   ```sh
-   pkg add -f netbird-0.55.1.pkg
-   pkg add -f pfSense-pkg-NetBird-0.1.0.pkg
-   ```
-
-5. **Verify the installation**
+4. **Verify the installation**
 
    The NetBird GUI should now appear under `VPN` > `NetBird` in the pfSense menu.
 
@@ -142,7 +150,7 @@ By default, pfSense uses automatic outbound NAT which randomizes source ports. T
 From a shell on your pfSense system, run:
 <p>
 ```sh
-pkg delete netbird-0.55.1 pfSense-pkg-NetBird-0.1.0
+pkg delete netbird pfSense-pkg-NetBird
 ```
 </p>
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `v0.1.2` / `netbird-0.55.1` / `pfSense-pkg-NetBird-0.1.0` URLs with version-agnostic placeholders that point users to the latest GitHub release
- Add architecture guidance (`x86_64` vs `aarch64`) and a concrete example showing how to read values from the release page
- Fix step numbering (was 1, 3, 3, 4, 5 → now 1, 2, 3, 4) and remove version-specific package names from uninstall command

Fixes an issue where users following the docs downloaded an outdated NetBird binary (`0.55.1`) incompatible with newer pfSense versions (e.g. 2.8.1), causing a SIGSEGV crash.

## Test plan
- [x] `npm run build` passes
- [ ] Verify the pfSense install page renders correctly with no hydration errors
- [ ] Confirm placeholder values in code blocks display as literal text (not parsed as JSX)