### PR TITLE
Document Windows installer UI autostart behavior

### DIFF
--- a/src/pages/get-started/install/windows.mdx
+++ b/src/pages/get-started/install/windows.mdx
@@ -14,6 +14,60 @@ The NetBird client (agent) allows a peer to join a pre-existing NetBird deployme
     To uninstall the client and service, you can use Add/Remove programs
 </Note>
 
+## Silent and Automated Installation
+
+Both installers support silent (unattended) installation for use with RMM tools, MDM platforms, and scripted deployments. By default, silent installations automatically configure the NetBird UI to start at user login, so the system tray icon is available without manual intervention.
+
+### EXE Installer (NSIS)
+
+Run the EXE installer with the `/S` flag for a silent installation:
+
+```bash
+netbird_installer_<VERSION>_windows_amd64.exe /S
+```
+
+The UI tray autostart is enabled by default for both interactive and silent installs. The installer writes the autostart entry to `HKLM\Software\Microsoft\Windows\CurrentVersion\Run`, which applies to all users on the machine.
+
+### MSI Installer
+
+Run the MSI installer with `msiexec` for a silent installation:
+
+```bash
+msiexec /i netbird_installer_<VERSION>_windows_amd64.msi /quiet
+```
+
+The MSI installer includes an `AUTOSTART` property that defaults to `1` (enabled). When enabled, it registers `netbird-ui.exe` in `HKLM\Software\Microsoft\Windows\CurrentVersion\Run` so the UI tray starts automatically at login for all users.
+
+To disable the UI tray autostart during installation:
+
+```bash
+msiexec /i netbird_installer_<VERSION>_windows_amd64.msi AUTOSTART=0 /quiet
+```
+
+<Note>
+    Disabling `AUTOSTART` only prevents the UI tray from launching at login. The NetBird background service still runs and maintains connectivity regardless of this setting.
+</Note>
+
+### Combining with a Setup Key
+
+For fully automated deployments where peers should register without user interaction, combine silent installation with a [setup key](/manage/peers/register-machines-using-setup-keys):
+
+```bash
+netbird_installer_<VERSION>_windows_amd64.exe /S
+netbird up --setup-key <SETUP KEY>
+```
+
+Or with the MSI installer:
+
+```bash
+msiexec /i netbird_installer_<VERSION>_windows_amd64.msi /quiet
+netbird up --setup-key <SETUP KEY>
+```
+
+<Note>
+    For MDM-specific deployment guides, see [Deploy with Intune](/manage/integrations/mdm-deployment/intune-netbird-integration) or [Deploy with Acronis](/manage/for-partners/acronis-integration).
+</Note>
+
 ## Running NetBird with SSO Login
 ### Desktop UI Application
 If you installed the Desktop UI client, you can launch it and click on Connect.

--- a/src/pages/manage/for-partners/acronis-integration.mdx
+++ b/src/pages/manage/for-partners/acronis-integration.mdx
@@ -81,7 +81,7 @@ In the `Install / Uninstall commands` tab, configure the silent installation par
 
 The `/S` parameter ensures silent installation without user prompts for NetBird's EXE installer, while `{{full_path}}` and `{{uninstall_cmd}}` are Acronis variables that automatically resolve to the correct paths during deployment. Click `Next` when ready.
 
-> **Note**: If you're using NetBird's MSI installer instead of the EXE installer, use `/qn` in the **Installation options** field instead of `"{{full_path}}" /S`. The **Uninstallation options** field remains the same (`{{uninstall_cmd}} /S`) for both installer types. The `/qn` parameter provides quiet installation with no user interface for MSI packages.
+> **Note**: Both the EXE and MSI installers automatically enable the NetBird UI tray autostart when installed silently, so users will see the system tray icon after login. If you're using NetBird's MSI installer instead of the EXE installer, use `/qn` in the **Installation options** field instead of `"{{full_path}}" /S`. The **Uninstallation options** field remains the same (`{{uninstall_cmd}} /S`) for both installer types. The `/qn` parameter provides quiet installation with no user interface for MSI packages. To disable UI autostart with the MSI installer, add `AUTOSTART=0` to the installation options (e.g., `/qn AUTOSTART=0`).
 
 ![Install / Uninstall commands](/docs-static/img/manage/for-partners/acronis-windows-netbird-integration/acronis-windows-08.png)
 

--- a/src/pages/manage/integrations/mdm-deployment/intune-netbird-integration.mdx
+++ b/src/pages/manage/integrations/mdm-deployment/intune-netbird-integration.mdx
@@ -104,7 +104,7 @@ You can leave the rest of the fields empty.
 - **Install command:** `netbird_installer_0.43.0_windows_amd64.exe /S`
 - **Uninstall command:** `"%ProgramFiles%\Netbird\netbird_uninstall.exe" /S`
 
->**Note:** The commands above assume a standard installation using the `/S` flag to specify "silent mode". Change them accordingly if you require NetBird installed on a different path.
+>**Note:** The commands above assume a standard installation using the `/S` flag to specify "silent mode". Change them accordingly if you require NetBird installed on a different path. The `/S` flag automatically enables the UI tray autostart, so users will see the NetBird system tray icon after login without any additional configuration.
 
 For this example, leave the rest of the configuration unchanged. Note that you can change the install behavior and users' ability to uninstall NetBird if required.
 
@@ -182,7 +182,7 @@ Click `Next` to configure NetBird with the following details:
 - **Publisher**: NetBird
 - **App install context**: Device
 - **Ignore app version**: No (This ensures updates will be applied when available)
-- **Command-line arguments**: Leave empty
+- **Command-line arguments**: Leave empty (the default MSI installation enables UI tray autostart; to disable it, enter `AUTOSTART=0`)
 - **Category**: Select any category that fits your needs (optional)
 - **Show this as a featured app in the Company Portal**: Yes
 - **Information URL**: https://docs.netbird.io/


### PR DESCRIPTION
## Summary
- Add a "Silent and Automated Installation" section to the Windows install page documenting the `AUTOSTART` MSI property and fixed EXE silent install autostart default
- Update Intune deployment guide to mention autostart behavior for both Win32 (EXE) and LOB (MSI) methods
- Update Acronis deployment guide to note autostart behavior and the `AUTOSTART=0` opt-out

Windows installation page: 

<img width="1624" height="1523" alt="grafik" src="https://github.com/user-attachments/assets/ab16d7c3-25dc-4d64-8fef-3712c7d69f2e" />

Acronis integration page: 

<img width="1067" height="1181" alt="grafik" src="https://github.com/user-attachments/assets/6f682fb3-bf6d-44bb-b9f3-6c14c8f8899f" />


Intune integration page: 

<img width="1126" height="1225" alt="grafik" src="https://github.com/user-attachments/assets/4b7b37c2-5e0f-4ff5-a3e3-2845586a282e" />


## Context
Companion docs for netbirdio/netbird#6026, which fixes the NetBird UI tray not auto-starting after silent/RMM deployments.