### PR TITLE
Update backup.mdx - add restore instructions and update backup files

### DIFF
--- a/src/pages/selfhosted/maintenance/backup.mdx
+++ b/src/pages/selfhosted/maintenance/backup.mdx
@@ -2,10 +2,14 @@
 
 To back up your NetBird installation, you need to copy the configuration files and the Management service databases.
 
-The configuration files are located in the folder where you ran [the installation script](/selfhosted/selfhosted-quickstart#installation-script). To back up, copy the files to a backup location:
+The configuration files are located in the folder where you ran [the installation script](/selfhosted/selfhosted-quickstart#installation-script). To back up, copy all the files to a backup location:
 ```bash
 mkdir backup
 cp docker-compose.yml dashboard.env config.yaml backup/
+```
+optionally, copy all remaining files depending on the install method and reverse proxy chosen on install
+```bash
+cp -r crowdsec proxy.env traefik-dynamic.yaml
 ```
 
 <Note>
@@ -32,6 +36,27 @@ docker compose stop management
 docker compose cp -a management:/var/lib/netbird/ backup/
 docker compose start management
 ```
+
+# Restore Your Self-Hosted NetBird Installation
+# Restore Your Self-Hosted NetBird Installation
+
+This amounts to following the above steps in reverse. You do not need to reinstall NetBird using the installation script, and copying partial backups will likely fail due to secrets and configuration keys which would need to be regenerated.
+
+Instead, simply copy all files to a new folder, and restart the containers.
+
+Assuming Traefik has been used as the reverse proxy, and CrowdSec Reputation Scan has been added on install:
+
+```bash
+cd ./backup
+cp -r docker-compose.yml dashboard.env config.yaml crowdsec proxy.env traefik-dynamic.yaml ..
+cd ..
+docker compose create
+docker compose cp -a ./backup/netbird netbird-server:/var/lib/
+docker compose up -d
+``` 
+
+You should now have a working NetBird instance again, and can log into the your backend under netbird.example.com
+
 
 ## Get In Touch
 


### PR DESCRIPTION
Hi there,

First of all, thank you for the amazing project. It is really nice that your documentation caters to all user groups, not just pro-level admins, but also beginners :)
In line with this spirit, I noticed that although there is a backup section in the docs, it was missing the newer configuration files created for the netbird-proxy container, as well as the config files for the traefik and crowdsec containers. 
Since partial backups can lead to headaches (e.g., needing to regenerate setup tokens for the proxy), I clarified that the backup should contain all files from the directory.

I also added a restore section, as I think it should be included, especially for newer users. I tested it and found it to be working for my setup, but I am happy for suggestions or edits, especially regarding this section.

Thank you for taking the time!
Best,
Paula

TL;DR:
- Added section about restoring a backup
- Updated "Back Up" section to include all files currently generated by the installation script (traefik, crowdsec, proxy.env)