### PR TITLE
fix(api-template): repair Go brace and collapse summary whitespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ package-lock.json
 /generator/openapi/
 /generator/openapi.yml
 /generator/expandOpenAPIRef
+/generator/tsconfig.tsbuildinfo
 
 # LLM documentation (generated)
 /public/llms/

--- a/generator/templates/ApiTemplate.ts
+++ b/generator/templates/ApiTemplate.ts
@@ -65,7 +65,7 @@ function renderProperties(properties, required = [], depth = 0) {
         %>>%>
         <% if ((type === 'object' && value.properties) || (type === 'object[]' && value.items.properties)) { %>
             <details className="custom-details" open>
-                <summary><%- value.description || 'More Information' %></summary>
+                <summary><%- (value.description || 'More Information').replace(/\\s+/g, ' ').trim() %></summary>
                 <Properties>
                 <% if (type === 'object[]') { %>
                     <% renderProperties(value.items.properties, value.items.required || [], depth + 1); %>
@@ -178,7 +178,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  <% if(true){%>{<% }; -%>
+  }
   
   <% if(operation.requestBody?.content && operation.requestBody?.content['application/json']){ %>
   req.Header.Add("Content-Type", "application/json")<% }; -%>

--- a/src/pages/ipa/resources/accounts.mdx
+++ b/src/pages/ipa/resources/accounts.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -346,7 +346,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -847,7 +847,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")

--- a/src/pages/ipa/resources/dns-zones.mdx
+++ b/src/pages/ipa/resources/dns-zones.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -378,7 +378,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -641,7 +641,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -946,7 +946,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1206,7 +1206,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -1373,7 +1373,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1621,7 +1621,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1839,7 +1839,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -2087,7 +2087,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -2302,7 +2302,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 

--- a/src/pages/ipa/resources/dns.mdx
+++ b/src/pages/ipa/resources/dns.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -443,7 +443,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -727,7 +727,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1097,7 +1097,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1378,7 +1378,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -1537,7 +1537,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1754,7 +1754,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")

--- a/src/pages/ipa/resources/edr-falcon-integrations.mdx
+++ b/src/pages/ipa/resources/edr-falcon-integrations.mdx
@@ -215,7 +215,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -540,7 +540,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -924,7 +924,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1246,7 +1246,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 

--- a/src/pages/ipa/resources/edr-fleetdm-integrations.mdx
+++ b/src/pages/ipa/resources/edr-fleetdm-integrations.mdx
@@ -315,7 +315,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -718,7 +718,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1229,7 +1229,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1632,7 +1632,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/edr-huntress-integrations.mdx
+++ b/src/pages/ipa/resources/edr-huntress-integrations.mdx
@@ -266,7 +266,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -617,7 +617,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1060,7 +1060,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1411,7 +1411,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/edr-intune-integrations.mdx
+++ b/src/pages/ipa/resources/edr-intune-integrations.mdx
@@ -232,7 +232,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -568,7 +568,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -968,7 +968,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1304,7 +1304,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/edr-peers.mdx
+++ b/src/pages/ipa/resources/edr-peers.mdx
@@ -80,7 +80,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -253,7 +253,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -412,7 +412,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/edr-sentinelone-integrations.mdx
+++ b/src/pages/ipa/resources/edr-sentinelone-integrations.mdx
@@ -406,7 +406,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -885,7 +885,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1506,7 +1506,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1985,7 +1985,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/event-streaming-integrations.mdx
+++ b/src/pages/ipa/resources/event-streaming-integrations.mdx
@@ -145,7 +145,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -380,7 +380,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -585,7 +585,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -853,7 +853,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1088,7 +1088,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/events.mdx
+++ b/src/pages/ipa/resources/events.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -334,7 +334,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -706,7 +706,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/geo-locations.mdx
+++ b/src/pages/ipa/resources/geo-locations.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -261,7 +261,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/groups.mdx
+++ b/src/pages/ipa/resources/groups.mdx
@@ -85,7 +85,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -385,7 +385,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -641,7 +641,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -945,7 +945,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1198,7 +1198,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 

--- a/src/pages/ipa/resources/identity-providers.mdx
+++ b/src/pages/ipa/resources/identity-providers.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -326,7 +326,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -543,7 +543,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -796,7 +796,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1010,7 +1010,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 

--- a/src/pages/ipa/resources/idp-azure-integrations.mdx
+++ b/src/pages/ipa/resources/idp-azure-integrations.mdx
@@ -197,7 +197,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -461,7 +461,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -671,7 +671,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1049,7 +1049,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1352,7 +1352,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1527,7 +1527,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1703,7 +1703,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/idp-google-integrations.mdx
+++ b/src/pages/ipa/resources/idp-google-integrations.mdx
@@ -179,7 +179,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -433,7 +433,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -639,7 +639,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -992,7 +992,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1279,7 +1279,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1454,7 +1454,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1630,7 +1630,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/idp-okta-scim-integrations.mdx
+++ b/src/pages/ipa/resources/idp-okta-scim-integrations.mdx
@@ -161,7 +161,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -407,7 +407,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -611,7 +611,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -895,7 +895,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1141,7 +1141,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1316,7 +1316,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1492,7 +1492,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/idp-scim-integrations.mdx
+++ b/src/pages/ipa/resources/idp-scim-integrations.mdx
@@ -194,7 +194,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -471,7 +471,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -685,7 +685,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1000,7 +1000,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1268,7 +1268,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1443,7 +1443,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1619,7 +1619,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/ingress-ports.mdx
+++ b/src/pages/ipa/resources/ingress-ports.mdx
@@ -93,7 +93,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -436,7 +436,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -701,7 +701,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1044,7 +1044,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1306,7 +1306,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -1465,7 +1465,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1708,7 +1708,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1931,7 +1931,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -2169,7 +2169,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -2386,7 +2386,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 

--- a/src/pages/ipa/resources/instance.mdx
+++ b/src/pages/ipa/resources/instance.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -253,7 +253,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -499,7 +499,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")

--- a/src/pages/ipa/resources/invoice.mdx
+++ b/src/pages/ipa/resources/invoice.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -278,7 +278,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -459,7 +459,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 

--- a/src/pages/ipa/resources/jobs.mdx
+++ b/src/pages/ipa/resources/jobs.mdx
@@ -85,7 +85,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -445,7 +445,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -687,7 +687,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/msp.mdx
+++ b/src/pages/ipa/resources/msp.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -365,7 +365,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -682,7 +682,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -947,7 +947,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1124,7 +1124,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -1313,7 +1313,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1493,7 +1493,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1755,7 +1755,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/networks.mdx
+++ b/src/pages/ipa/resources/networks.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -315,7 +315,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -539,7 +539,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -781,7 +781,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1002,7 +1002,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -1169,7 +1169,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1454,7 +1454,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1701,7 +1701,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1986,7 +1986,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -2230,7 +2230,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -2397,7 +2397,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -2668,7 +2668,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -2901,7 +2901,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -3172,7 +3172,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -3402,7 +3402,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -3561,7 +3561,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/notifications.mdx
+++ b/src/pages/ipa/resources/notifications.mdx
@@ -80,7 +80,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -261,7 +261,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -634,7 +634,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -947,7 +947,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1314,7 +1314,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1627,7 +1627,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/peers.mdx
+++ b/src/pages/ipa/resources/peers.mdx
@@ -89,7 +89,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -380,7 +380,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -735,7 +735,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1045,7 +1045,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -1212,7 +1212,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1471,7 +1471,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")

--- a/src/pages/ipa/resources/policies.mdx
+++ b/src/pages/ipa/resources/policies.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -732,7 +732,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1185,7 +1185,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1844,7 +1844,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -2294,7 +2294,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 

--- a/src/pages/ipa/resources/posture-checks.mdx
+++ b/src/pages/ipa/resources/posture-checks.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -462,10 +462,7 @@ echo $response;
     <Property name="peer_network_range_check" type="object" required={false}>
         
             <details className="custom-details" open>
-                <summary>Posture check for allow or deny access based on the peer's IP addresses. A range matches when it
-contains any of the peer's local network interface IPs or its public connection (NAT egress) IP,
-so ranges may target private subnets, public CIDRs, or single hosts via a /32 or /128.
-</summary>
+                <summary>Posture check for allow or deny access based on the peer's IP addresses. A range matches when it contains any of the peer's local network interface IPs or its public connection (NAT egress) IP, so ranges may target private subnets, public CIDRs, or single hosts via a /32 or /128.</summary>
                 <Properties>
                 
                     <Properties><Property name="ranges" type="string[]" required={true}>
@@ -820,7 +817,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1270,7 +1267,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1659,10 +1656,7 @@ echo $response;
     <Property name="peer_network_range_check" type="object" required={false}>
         
             <details className="custom-details" open>
-                <summary>Posture check for allow or deny access based on the peer's IP addresses. A range matches when it
-contains any of the peer's local network interface IPs or its public connection (NAT egress) IP,
-so ranges may target private subnets, public CIDRs, or single hosts via a /32 or /128.
-</summary>
+                <summary>Posture check for allow or deny access based on the peer's IP addresses. A range matches when it contains any of the peer's local network interface IPs or its public connection (NAT egress) IP, so ranges may target private subnets, public CIDRs, or single hosts via a /32 or /128.</summary>
                 <Properties>
                 
                     <Properties><Property name="ranges" type="string[]" required={true}>
@@ -2017,7 +2011,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -2464,7 +2458,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 

--- a/src/pages/ipa/resources/routes.mdx
+++ b/src/pages/ipa/resources/routes.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -466,7 +466,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -767,7 +767,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1160,7 +1160,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1458,7 +1458,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 

--- a/src/pages/ipa/resources/services.mdx
+++ b/src/pages/ipa/resources/services.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -259,7 +259,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1219,7 +1219,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1816,7 +1816,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -2780,7 +2780,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -3374,7 +3374,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -3533,7 +3533,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -3761,7 +3761,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -4127,7 +4127,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -4291,7 +4291,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 

--- a/src/pages/ipa/resources/setup-keys.mdx
+++ b/src/pages/ipa/resources/setup-keys.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -376,7 +376,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -629,7 +629,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -887,7 +887,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1122,7 +1122,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 

--- a/src/pages/ipa/resources/tokens.mdx
+++ b/src/pages/ipa/resources/tokens.mdx
@@ -85,7 +85,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -317,7 +317,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -537,7 +537,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -732,7 +732,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 

--- a/src/pages/ipa/resources/usage.mdx
+++ b/src/pages/ipa/resources/usage.mdx
@@ -77,7 +77,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")

--- a/src/pages/ipa/resources/users.mdx
+++ b/src/pages/ipa/resources/users.mdx
@@ -85,7 +85,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -410,7 +410,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -752,7 +752,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -1034,7 +1034,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -1198,7 +1198,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -1365,7 +1365,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1622,7 +1622,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -1820,7 +1820,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -1995,7 +1995,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -2247,7 +2247,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -2516,7 +2516,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -2748,7 +2748,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Authorization", "Token <TOKEN>")
 
@@ -2940,7 +2940,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")
@@ -3139,7 +3139,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
     
   req.Header.Add("Accept", "application/json")
   req.Header.Add("Authorization", "Token <TOKEN>")
@@ -3356,7 +3356,7 @@ func main() {
   if err != nil {
     fmt.Println(err)
     return
-  {  
+  }
   
   req.Header.Add("Content-Type", "application/json")  
   req.Header.Add("Accept", "application/json")


### PR DESCRIPTION
## Summary
- Restore the missing `}` after the early-return error check in the Go example block of `generator/templates/ApiTemplate.ts`. The template was emitting `{` instead of `}`, leaving every generated Go snippet under `src/pages/ipa/resources/` syntactically invalid.
- Collapse whitespace in `<summary>` content from the OpenAPI `description` so multi-line descriptions don't push the closing tag into an MDX paragraph and crash the parser (the failure mode that 500'd `/api/resources/posture-checks`).
- Regenerate the affected resource MDX files in place so the docs build cleanly without waiting for a fresh `npm run gen` pull from upstream `main`.

## Notes
- Source-of-truth fix lives in the template; the regenerated files are mechanical updates from that change.
- The bad brace was introduced in 4c51e12 when the literal `}` got wrapped in `<% if(true){%>{<% }; -%>` and the output character was changed by mistake.