### PR TITLE
Fix group & policy link in Android install docs

### DIFF
--- a/src/pages/get-started/install/android.mdx
+++ b/src/pages/get-started/install/android.mdx
@@ -62,7 +62,7 @@ Select 'OK'. If you didn't enter a setup key in the 'Change Server' menu, then y
 After logging in, NetBird will confirm your authentication. Once you close the browser window, your device should be connected!
 
 ## What's next?
-- Configure the device's [group & policy](example.com) memberships
+- Configure the device's [group & policy](/manage/access-control) memberships
 
 
 


### PR DESCRIPTION
I went through the Android installation and noticed that the link under "What's next" ([here](https://docs.netbird.io/get-started/install/android#whats-next)), which is named "group & policy" goes to `https://docs.netbird.io/get-started/install/example.com`, which doesn't exist.

This PR fixes the link to go to [Groups & Policies](https://docs.netbird.io/manage/access-control).

Tested with `npm install && npm run dev` , visiting <http://localhost:3000/get-started/install/android>, then clicking the link goes to <http://localhost:3000/manage/access-control> ✅️