### PR TITLE
docs: unhyphenate "Zero Trust" across the docs

### DIFF
--- a/src/pages/get-started/install/truenas.mdx
+++ b/src/pages/get-started/install/truenas.mdx
@@ -69,7 +69,7 @@ After you define an [access control policy](/manage/networks/homelab/access-home
 
 <YouTube videoId="NkP6J3hJew4" />
 
-Install and configure TrueNAS for home server storage, then securely access it from anywhere using NetBird. Covers ZFS pools, SMB sharing, apps, and zero-trust remote access, see our [Knowledge Hub Guide: TrueNAS Made Easy](https://netbird.io/knowledge-hub/truenas-setup-and-remote-access).
+Install and configure TrueNAS for home server storage, then securely access it from anywhere using NetBird. Covers ZFS pools, SMB sharing, apps, and zero trust remote access, see our [Knowledge Hub Guide: TrueNAS Made Easy](https://netbird.io/knowledge-hub/truenas-setup-and-remote-access).
 
 - Make sure to [star us on GitHub](https://github.com/netbirdio/netbird)
 - Follow us [on X](https://x.com/netbird)

--- a/src/pages/manage/access-control/index.mdx
+++ b/src/pages/manage/access-control/index.mdx
@@ -9,9 +9,9 @@ NetBird's access control system is built on Zero Trust security principles, ensu
     **NEW:** For a visual overview of your access policies and how peers, groups, and their relationships connect, check out the [**Control Center**](https://docs.netbird.io/manage/control-center) feature in NetBird. The Control Center provides an interactive graph view that makes it easy to understand your network's access structure at a glance.
 </Note>
 
-## Zero-Trust Principles and NetBird
+## Zero Trust Principles and NetBird
 
-Zero-trust networking operates on the principle of "never trust, always verify." Unlike traditional perimeter-based security models, zero-trust assumes that threats can exist both inside and outside the network. NetBird implements this through:
+Zero trust networking operates on the principle of "never trust, always verify." Unlike traditional perimeter-based security models, zero trust assumes that threats can exist both inside and outside the network. NetBird implements this through:
 
 - **Deny-by-default behavior:** Without policies, no peer can communicate with another peer
 - **Explicit access grants:** Every connection must be explicitly allowed through a policy
@@ -22,7 +22,7 @@ Zero-trust networking operates on the principle of "never trust, always verify."
 ## Default ALL to ALL Policy (Not Recommended)
 
 <Note>
-    **TLDR:**  NetBird automatically creates a Default policy that allows all devices to communicate with each other. While this helps with onboarding, the Default policy completely undermines zero-trust principles and should be removed once you create proper access control policies. Make sure to have replacement policies ready before deleting it, or all peer communication will stop.
+    **TLDR:**  NetBird automatically creates a Default policy that allows all devices to communicate with each other. While this helps with onboarding, the Default policy completely undermines zero trust principles and should be removed once you create proper access control policies. Make sure to have replacement policies ready before deleting it, or all peer communication will stop.
 </Note>
 
 When you first create a NetBird account, a **Default policy** is automatically created that allows all peers to communicate with each other using any protocol. This policy exists because early NetBird users were confused and frustrated when their devices couldn't communicate—NetBird's deny-by-default security model meant nothing worked without policies defined, and users thought the platform was broken. 
@@ -33,7 +33,7 @@ When you first create a NetBird account, a **Default policy** is automatically c
 
 The Default policy, which uses the special `All` group as both source and destination, solves this onboarding friction by letting new users immediately see NetBird working while they learn the platform.
 
-However, **the Default policy completely undermines zero-trust security principles** and should be removed as soon as you're ready to implement proper access control. It violates the principle of least privilege, provides no network segmentation (a compromised device has direct access to everything), and allows all-to-all communication even after you create restrictive policies. Think of it as training wheels: helpful for getting started, but you should remove it when moving to production. 
+However, **the Default policy completely undermines zero trust security principles** and should be removed as soon as you're ready to implement proper access control. It violates the principle of least privilege, provides no network segmentation (a compromised device has direct access to everything), and allows all-to-all communication even after you create restrictive policies. Think of it as training wheels: helpful for getting started, but you should remove it when moving to production. 
 
 ## Understanding Groups
 
@@ -120,7 +120,7 @@ Even though NetBird treats all groups the same way technically, maintaining this
 - If you create an `engineering` → `engineering` policy to allow access, you've now granted all devices in that group access to each other, creating an unclear mesh where laptops can access servers AND servers can access laptops
 - It makes your access control messy and difficult to audit
 - You lose clarity about which devices are users vs. infrastructure
-- It violates zero-trust principles by not maintaining clear source and destination boundaries
+- It violates zero trust principles by not maintaining clear source and destination boundaries
 
 **Correct approach:**
 ✅ Add engineering team users into a  `engineering-users` group and set machines or resources to a `engineering-servers` group. Create a setup key with `engineering-servers` as an auto-assigned group, then use that key when deploying servers. Finally, create a policy allowing `engineering-users` (source) to access `engineering-servers` (destination). This keeps your access control clear: users access servers, not the other way around.
@@ -138,7 +138,7 @@ NetBird policies control network traffic by defining:
 
 ### Best Practice: Users as Source, Infrastructure as Destination
 
-Following zero-trust principles, your policies should generally follow this pattern:
+Following zero trust principles, your policies should generally follow this pattern:
 
 **✅ Recommended Pattern:**
 
@@ -199,7 +199,7 @@ While NetBird’s peer-to-peer technology allows servers to connect to laptops a
 
 **Why avoid this?**
 
-- Violates zero-trust principles
+- Violates zero trust principles
 - Increases attack surface
 - If a server is compromised, it could initiate connections to user devices
 - Doesn't align with typical network communication patterns
@@ -421,7 +421,7 @@ Direction: One-way
 
 ## Conclusion
 
-NetBird's access control system provides powerful, flexible tools for implementing zero-trust networking. By understanding the distinction between user groups and peer groups, following the principle of users-as-source and infrastructure-as-destination, and creating specific policies for each access requirement, you can build a secure, manageable network that follows security best practices.
+NetBird's access control system provides powerful, flexible tools for implementing zero trust networking. By understanding the distinction between user groups and peer groups, following the principle of users-as-source and infrastructure-as-destination, and creating specific policies for each access requirement, you can build a secure, manageable network that follows security best practices.
 
 **Key takeaways:**
 
@@ -433,4 +433,4 @@ NetBird's access control system provides powerful, flexible tools for implementi
 6. **Implement posture checks** for sensitive resources
 7. **Document your policies** and review them regularly
 
-By following these principles, you'll create a network that embodies zero-trust security while remaining manageable and understandable for your team.
+By following these principles, you'll create a network that embodies zero trust security while remaining manageable and understandable for your team.

--- a/src/pages/manage/access-control/manage-network-access.mdx
+++ b/src/pages/manage/access-control/manage-network-access.mdx
@@ -3,7 +3,7 @@
 NetBird empowers administrators to effectively manage and control access between resources (referred to as peers) using groups and access policies.
 These access policies define which peers or peer groups are allowed to connect, specify the protocols and ports available
 for these connections, and optionally incorporate posture checks. By integrating posture checks, NetBird enforces
-zero-trust principles, enabling dynamic and context-aware access control that adapts to the specific security needs of
+zero trust principles, enabling dynamic and context-aware access control that adapts to the specific security needs of
 your environment.
 
 Watch our Access Control video on YouTube:

--- a/src/pages/manage/for-partners/acronis-integration.mdx
+++ b/src/pages/manage/for-partners/acronis-integration.mdx
@@ -25,7 +25,7 @@ Before beginning this tutorial, ensure you have the following prerequisites in p
 
 ## Setting Up NetBird Access Policies for Team-Specific Permissions
 
-[NetBird's Access Control Policies](https://docs.netbird.io/manage/access-control/manage-network-access) let you implement a zero-trust security approach alongside Acronis Cyber Protect Cloud. They enable you to define precise permissions based on user groups and resource categories, ensuring that team members can only access what they need for their specific roles. This granular approach aligns with MSP requirements for managing multiple client environments with distinct access requirements.
+[NetBird's Access Control Policies](https://docs.netbird.io/manage/access-control/manage-network-access) let you implement a zero trust security approach alongside Acronis Cyber Protect Cloud. They enable you to define precise permissions based on user groups and resource categories, ensuring that team members can only access what they need for their specific roles. This granular approach aligns with MSP requirements for managing multiple client environments with distinct access requirements.
 
 These policies work in tandem with Acronis RMM's monitoring and management capabilities. While Acronis monitors system compliance and maintains device health, NetBird enforces network-level access restrictions based on predefined group memberships.
 

--- a/src/pages/manage/integrations/mdm-deployment/intune-netbird-integration.mdx
+++ b/src/pages/manage/integrations/mdm-deployment/intune-netbird-integration.mdx
@@ -10,7 +10,7 @@ NetBird enhances this security ecosystem by providing a WireGuard-based overlay 
 - **Entra ID** provides identity verification and conditional access decisions
 - **NetBird** establishes secure network pathways with granular access controls
 
-This division of security responsibilities creates a comprehensive zero-trust implementation in which devices are verified as compliant before they can establish network connections to protected resources.
+This division of security responsibilities creates a comprehensive zero trust implementation in which devices are verified as compliant before they can establish network connections to protected resources.
 
 In this hands-on tutorial, you'll learn how to deploy NetBird with Intune to grant tailored access permissions for different teams.
 
@@ -26,7 +26,7 @@ Before beginning this tutorial, ensure you have the following prerequisites in p
 
 ## Setting Up NetBird Access Policies for Team-Specific Permissions
 
-[NetBird's Access Control Policies](https://docs.netbird.io/manage/access-control/manage-network-access) provide the foundation for implementing a zero-trust architecture with Intune. They enable you to define precise permissions based on user groups and resource categories. This ensures that team members can only access what they need for their specific roles.
+[NetBird's Access Control Policies](https://docs.netbird.io/manage/access-control/manage-network-access) provide the foundation for implementing a zero trust architecture with Intune. They enable you to define precise permissions based on user groups and resource categories. This ensures that team members can only access what they need for their specific roles.
 
 These policies work in tandem with Intune's device compliance mechanisms, creating a powerful security layer where identity and device posture determine access rights to the network.
 
@@ -45,7 +45,7 @@ Provide a descriptive name for the policy, such as "Dev Team Server Access" that
 
 This access policy will automatically apply to all devices enrolled in Intune that belong to users in the `Development` group (as synchronized from **Entra ID**), providing them secure access to designated resources while preventing lateral movement to unauthorized systems.
 
-Moreover, users will only gain this network access when using compliant devices that meet your organization's security standards, creating a true zero-trust environment where user identity and device security status are verified before granting resource access.
+Moreover, users will only gain this network access when using compliant devices that meet your organization's security standards, creating a true zero trust environment where user identity and device security status are verified before granting resource access.
 
 > **Note**: For maximum security, create separate policies rather than overly broad policies for each distinct access requirement. This approach minimizes your attack surface by ensuring precise access controls aligned with job responsibilities.
 
@@ -215,4 +215,4 @@ To verify that NetBird was added to Intune, navigate to `Home > Apps | Windows` 
 
 While each platform has slightly different configuration options, adding NetBird and assigning it to groups follows the same pattern across Intune. For more information, refer to [Intune app management](https://learn.microsoft.com/en-us/intune/intune-service/apps/app-management).
 
-With NetBird successfully deployed through Intune, your organization has the foundation for implementing a comprehensive zero-trust access model that verifies user identity and device compliance before granting network access.
+With NetBird successfully deployed through Intune, your organization has the foundation for implementing a comprehensive zero trust access model that verifies user identity and device compliance before granting network access.

--- a/src/pages/manage/networks/use-cases/by-resource-type/accessing-restricted-domain-resources.mdx
+++ b/src/pages/manage/networks/use-cases/by-resource-type/accessing-restricted-domain-resources.mdx
@@ -6,7 +6,7 @@ This guide shows how to access restricted websites or services using NetBird [Ne
 
 A company hosts an accounting application at `accounting.example.com` on AWS infrastructure in the EU Central region. The application runs on an EC2 instance behind a load balancer.
 
-The company wants to implement zero-trust access with role-based permissions:
+The company wants to implement zero trust access with role-based permissions:
 - **Finance team**: HTTP/HTTPS access to `accounting.example.com` (ports 80 and 443)
 - **Support team**: SSH access to the backend at `example.com` (port 22)
 

--- a/src/pages/manage/peers/access-infrastructure/peer-approval-for-remote-worker-access.mdx
+++ b/src/pages/manage/peers/access-infrastructure/peer-approval-for-remote-worker-access.mdx
@@ -11,7 +11,7 @@ The conventional approach to remote worker access presents several security and 
 
 This guide introduces NetBird's Peer Approval as a robust solution for secure remote worker access by:
 
-* **Implementing Zero-Trust Principles**: Ensuring that every device and user is verified before granting network access, regardless of their location.
+* **Implementing Zero Trust Principles**: Ensuring that every device and user is verified before granting network access, regardless of their location.
 * **Simplifying Device Trust Management**: Providing a streamlined process for approving and managing trusted devices within the network.
 * **Enhancing Access Control**: Offering granular control over network resources, allowing organizations to tailor access based on user roles and device status.
 * **Improving Scalability**: Facilitating easy onboarding and offboarding of remote workers, including freelancers, without compromising network security.
@@ -37,7 +37,7 @@ With these prerequisites in place, you're ready to simulate granting network acc
 
 ## 1. Setting Up NetBird's Access Control Policies For Enhanced Security
 
-Before onboarding remote workers, ensure your organization has appropriate [access control policies](/manage/access-control/manage-network-access) in place. Adhering to zero-trust principles, create or modify policies to grant new users access only to necessary resources.
+Before onboarding remote workers, ensure your organization has appropriate [access control policies](/manage/access-control/manage-network-access) in place. Adhering to zero trust principles, create or modify policies to grant new users access only to necessary resources.
 
 Navigate to `Access Control > Policies` in the NetBird admin console, then click `Add Policy` or edit an existing one to define these restrictions. Here's a sample policy that grant any member of the `Freelancers` group access to the resources in the group `On-Premise-DB`.
 

--- a/src/pages/manage/peers/access-infrastructure/secure-remote-webserver-access.mdx
+++ b/src/pages/manage/peers/access-infrastructure/secure-remote-webserver-access.mdx
@@ -10,7 +10,7 @@ The problem is that conventional remote SSH access introduces security and opera
 
 This guide introduces NetBird as a secure solution for remote SSH access into a server without compromising safety by:
 
-* **Enhancing Security**: Creating a secure overlay network that implements zero-trust principles, eliminating the need for exposed inbound ports.
+* **Enhancing Security**: Creating a secure overlay network that implements zero trust principles, eliminating the need for exposed inbound ports.
 * **Simplifying Network Management**: Simplifying network architecture and removing the need for complex firewall rules or VPN configurations.
 * **Centralizing Access Control**: Providing a unified platform for managing user access across all servers, simplifying policy enforcement and auditing.
 

--- a/src/pages/manage/team/single-sign-on/index.mdx
+++ b/src/pages/manage/team/single-sign-on/index.mdx
@@ -72,7 +72,7 @@ to integrate with NetBird. Below are the steps to set up different OIDC-complian
 
 ### Duo Security
 
-[Duo Security](https://duo.com/) is a cloud-based security platform that provides secure access through single sign-on (SSO), multi-factor authentication (MFA), and device trust. Duo offers comprehensive identity verification and access policies to protect applications and data, with a focus on zero-trust security architecture.
+[Duo Security](https://duo.com/) is a cloud-based security platform that provides secure access through single sign-on (SSO), multi-factor authentication (MFA), and device trust. Duo offers comprehensive identity verification and access policies to protect applications and data, with a focus on zero trust security architecture.
 
 <Button href="/manage/team/single-sign-on/duo-security" variant="outline">Setup Duo Security</Button>
 

--- a/src/pages/use-cases/cloud/distributed-multi-cloud-ai.mdx
+++ b/src/pages/use-cases/cloud/distributed-multi-cloud-ai.mdx
@@ -2,7 +2,7 @@ import {Note} from "@/components/mdx";
 
 # Open Source Distributed AI Stack: ArgoCD, MicroK8s, vLLM, and NetBird
 
-We are building a distributed AI infrastructure project that connects GPU clusters across many different cloud providers using Kubernetes orchestration. After some trial and error we got everything working. If you want to learn more about the process, the why, and how we got here check out our [article on the Knowledge Hub](https://netbird.io/knowledge-hub/multi-cloud-ai-mega-mesh). This setup uses ArgoCD as a GitOps control plane to manage workloads across multiple MicroK8s clusters, with NetBird providing secure zero-trust networking between all components.
+We are building a distributed AI infrastructure project that connects GPU clusters across many different cloud providers using Kubernetes orchestration. After some trial and error we got everything working. If you want to learn more about the process, the why, and how we got here check out our [article on the Knowledge Hub](https://netbird.io/knowledge-hub/multi-cloud-ai-mega-mesh). This setup uses ArgoCD as a GitOps control plane to manage workloads across multiple MicroK8s clusters, with NetBird providing secure zero trust networking between all components.
 
 <Note>
     This document is actively being changed and tested. Please see 'Known Issues and Future Improvements' at the bottom of the page.


### PR DESCRIPTION
## Summary

House style writes "Zero Trust" / "zero trust" without a hyphen in prose. This sweep unhyphenates every prose occurrence under `src/pages/`.

- **Files changed:** 10. **Lines:** 22 swapped (`zero-trust` → `zero trust`, `Zero-Trust`/`Zero-trust` → `Zero Trust`).
- **Intentionally preserved:** URL slugs (`href: '/use-cases/security/implement-zero-trust'`) and external links that include `zero-trust` as a path segment (CrowdStrike press release and blog URLs in `crowdstrike-edr.mdx`).
- **No content/meaning changes** — purely stylistic.