### PR TITLE
fix: promote routing-peer section headings to h2

### DIFF
--- a/src/pages/manage/integrations/kubernetes/routing-peer.mdx
+++ b/src/pages/manage/integrations/kubernetes/routing-peer.mdx
@@ -2,7 +2,7 @@
 
 The operator exposes Kubernetes services to your NetBird network by combining two resources, a `NetworkRouter` and a `NetworkResource`.
 
-### NetworkRouter
+## NetworkRouter
 
 A `NetworkRouter` creates a network in NetBird and deploys routing peer pods in the cluster. These pods are configured as routing peers for the network, handling traffic between NetBird clients and services running in the cluster.
 
@@ -19,7 +19,7 @@ spec:
     name: prod.company.internal
 ```
 
-### NetworkResource
+## NetworkResource
 
 A `NetworkResource` exposes a Kubernetes service in NetBird by creating a matching resource in the routers network. The cluster IP of the service will be used as the resource IP. A record in the routers zone will also be created using the name and namespace of the service. The following example creates an nignx deployment and exposes the service with the record `nginx.default.prod.company.internal`.
 


### PR DESCRIPTION
## Summary

- `src/pages/manage/integrations/kubernetes/routing-peer.mdx` jumped from `# Routing Peer` (h1) straight to `### NetworkRouter` (h3), skipping h2 entirely and breaking the docs build.
- Promotes both `### NetworkRouter` and `### NetworkResource` to `##` so the heading hierarchy is contiguous (h1 → h2).