### PR TITLE
docs: rewrite traffic events logging Limitations section

### DIFF
--- a/src/pages/manage/activity/traffic-events-logging.mdx
+++ b/src/pages/manage/activity/traffic-events-logging.mdx
@@ -267,8 +267,7 @@ Events can be correlated by observing the traffic from both peers involved in a 
 you will see up to 4 events from these peers. If the connection was successful, you will see a started and a stopped event from Peer A and Peer B. But, if one peer blocks the connection, then you will see a started and stopped events from the initiator and
 a blocked event from the responder.
 <Note>
- The blocked event will be available only if the destination uses the NetBird client in userspace mode.
- This is the case for Windows and MacOs nodes. For Linux, you can enable userspace mode with the environment variable `NB_WG_KERNEL_DISABLED=true` and `NB_FORCE_USERSPACE_ROUTER=true`
+ Blocked events are only reported when the destination peer is in userspace mode. See [Limitations](#limitations).
 </Note>
 
 ### Viewing TCP and UDP connections
@@ -309,8 +308,7 @@ Key differences:
 - There are no events that have started or stopped on the refusing side. The connection is blocked right after the request.
 - Depending on the application making a request in the initiator, you may see multiple blocked events from the receiving side of the connection due to retries:
 <Note>
- The blocked event will be available only if the destination is using the NetBird client in userspace mode.
- This is the case for Windows and MacOs nodes. For Linux, you can enable userspace mode with the environment variable `NB_WG_KERNEL_DISABLED=true` and `NB_FORCE_USERSPACE_ROUTER=true`
+ Blocked events are only reported when the destination peer is in userspace mode. See [Limitations](#limitations).
 </Note>
 
 ### Viewing ICMP connections
@@ -343,16 +341,15 @@ For site-2-site connections, the events will be similar to the above examples, b
 </p>
 
 ## Limitations
-There are a few differences between the different WireGuard modes NetBird supports and the data captured by the NetBird client.
-| Feature | Kernel Mode | Userspace Mode | Netstack Mode |
-|:---------:|:-------------:|:----------------:|:---------------:|
-| Blocked traffic event | No | Yes | Yes |
-| Site-2-Site events | No | Yes | Yes |
-| Rule IDs | No | Yes | Yes |
-| Allowed rule ID for routed events | Yes | No | No |
-| Byte counters for routed events | Yes | No | No |
+<Note>
+Policy IDs and blocked traffic events are not reported when the destination peer (or routing peer) is running in kernel mode.
+</Note>
 
-We are actively working to improve the data captured by the NetBird client in Kernel and userspace modes to align with customers' expectations.
+On Linux, you can force a routing peer into userspace mode with two [environment variables](/client/environment-variables):
+
+```bash
+sudo netbird service reconfigure --service-env NB_WG_KERNEL_DISABLED=true,NB_FORCE_USERSPACE_ROUTER=true
+```
 
 ## Conclusion
 Traffic events logging provides a powerful tool for monitoring and analyzing network traffic across your infrastructure.

--- a/src/pages/manage/activity/traffic-events-logging.mdx
+++ b/src/pages/manage/activity/traffic-events-logging.mdx
@@ -345,10 +345,10 @@ For site-2-site connections, the events will be similar to the above examples, b
 Policy IDs and blocked traffic events are not reported when the destination peer (or routing peer) is running in kernel mode.
 </Note>
 
-On Linux, you can force a routing peer into userspace mode with two [environment variables](/client/environment-variables):
+On Linux, you can force a routing peer into userspace mode with three [environment variables](/client/environment-variables):
 
 ```bash
-sudo netbird service reconfigure --service-env NB_WG_KERNEL_DISABLED=true,NB_FORCE_USERSPACE_ROUTER=true
+sudo netbird service reconfigure --service-env NB_WG_KERNEL_DISABLED=true,NB_FORCE_USERSPACE_FIREWALL=true,NB_FORCE_USERSPACE_ROUTER=true
 ```
 
 ## Conclusion


### PR DESCRIPTION
## Summary

- Replace the WireGuard-mode matrix in **Traffic Events Logging → Limitations** with a single Note: policy IDs and blocked traffic events are not reported when the destination peer (or routing peer) is running in kernel mode.
- Add the canonical command Linux operators use to force a routing peer into userspace mode, with a link to `/client/environment-variables` for what `NB_WG_KERNEL_DISABLED` and `NB_FORCE_USERSPACE_ROUTER` actually do.
- Collapse the two near-duplicate inline notes in **Correlating events** into short pointers to the Limitations section, so the constraint and command live in one place.