### PR TITLE
docs: note gen:sitemap runs with dev/build in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,8 @@ There is no test suite in this project. Validate changes with `npm run build`.
 
 ```bash
 npm install              # Install dependencies
-npm run dev              # Start dev server (also runs gen:llm, gen:edit-routes, gen:last-updated)
-npm run build            # Production build (also runs gen:llm, gen:edit-routes, gen:last-updated)
+npm run dev              # Start dev server (also runs gen:llm, gen:edit-routes, gen:last-updated, gen:sitemap)
+npm run build            # Production build (also runs gen:llm, gen:edit-routes, gen:last-updated, gen:sitemap)
 npm run start            # Serve the production build
 npm run lint             # ESLint (next/core-web-vitals) on src/
 npm run gen              # Regenerate API docs from NetBird OpenAPI spec


### PR DESCRIPTION
## Summary
- The `npm run dev` and `npm run build` annotations in CLAUDE.md listed the auto-running gen scripts but omitted `gen:sitemap` (added in #742). Updated to match the actual script.