### PR TITLE
docs: fix Client > Settings nav jumping to Manage > Peers

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -756,10 +756,6 @@ export const docsNavigation = [
         isOpen: false,
         links: [
           {
-            title: 'Allow SSH',
-            href: '/client/allow-ssh',
-          },
-          {
             title: 'Block Inbound Connections',
             href: '/client/block-inbound-connections',
           },
@@ -768,12 +764,16 @@ export const docsNavigation = [
             href: '/client/connect-on-startup',
           },
           {
-            title: 'Enable Lazy Connections',
-            href: '/client/enable-lazy-connections',
-          },
-          {
             title: 'Enable Quantum-Resistance',
             href: '/client/post-quantum-cryptography',
+          },
+          {
+            title: 'Allow SSH',
+            href: '/client/allow-ssh',
+          },
+          {
+            title: 'Enable Lazy Connections',
+            href: '/client/enable-lazy-connections',
           },
         ],
       },


### PR DESCRIPTION
## Summary

Clicking **Client > Settings** in the sidebar took you to **Manage > Peers > SSH** instead of staying in the Client section.

The nav group-header `onClick` auto-navigates to `group.links[0].href` when expanding a closed group ([`NavigationDocs.jsx:922-924`](src/components/NavigationDocs.jsx#L922-L924)). The first child was "Allow SSH" → `/client/allow-ssh`, which `next.config.mjs` permanent-redirects to `/manage/peers/ssh#enabling-ssh`, pulling the user out of Client.

Introduced in #688, which intentionally surfaces the SSH and Lazy Connections tray settings via redirect so they're discoverable from Client > Settings — the per-entry redirect behaviour is preserved.

## Fix

Reorder Settings children so the three real `/client/` pages come first:

1. Block Inbound Connections
2. Connect on Startup
3. Enable Quantum-Resistance
4. Allow SSH _(redirects to /manage/peers/ssh)_
5. Enable Lazy Connections _(redirects to /manage/peers/lazy-connection)_

Now clicking the Settings header lands on `/client/block-inbound-connections` — same section, no jarring jump. The redirect entries remain in the group.