### PR TITLE
docs: add Masquerade configuration page

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -192,6 +192,10 @@ export const docsNavigation = [
             href: '/manage/networks/how-routing-peers-work',
           },
           {
+            title: 'Masquerade',
+            href: '/manage/networks/masquerade',
+          },
+          {
             title: 'Use Cases',
             isOpen: false,
             links: [

--- a/src/pages/manage/network-routes/advanced-configuration.mdx
+++ b/src/pages/manage/network-routes/advanced-configuration.mdx
@@ -23,7 +23,7 @@ For the basics — masquerade behavior, ACL Groups, HA — see [Network Routes C
 See [Masquerade](/manage/networks/masquerade) for persistent return-route configuration on the destination host.
 
 <Warning>
-Without masquerade, traffic from unknown source IPs is rejected by NetBird's policy engine. You cannot use ACL Groups or Network Resources with masquerade disabled.
+ACL Groups on **Network Routes** (this page) match against peer NetBird IPs only, which limits source-IP-preserving access control on this path. For masquerade-off deployments with policy-layer ACLs, use the newer **Networks** path — see [Masquerade](/manage/networks/masquerade).
 </Warning>
 
 ### Choosing the right approach

--- a/src/pages/manage/network-routes/advanced-configuration.mdx
+++ b/src/pages/manage/network-routes/advanced-configuration.mdx
@@ -20,6 +20,8 @@ For the basics — masquerade behavior, ACL Groups, HA — see [Network Routes C
 - Required if your compliance regime needs source-IP visibility on the remote network
 - Requires a return route on the remote network's infrastructure back to the NetBird CIDR
 
+See [Masquerade](/manage/networks/masquerade) for persistent return-route configuration on the destination host.
+
 <Warning>
 Without masquerade, traffic from unknown source IPs is rejected by NetBird's policy engine. You cannot use ACL Groups or Network Resources with masquerade disabled.
 </Warning>

--- a/src/pages/manage/networks/how-routing-peers-work.mdx
+++ b/src/pages/manage/networks/how-routing-peers-work.mdx
@@ -225,7 +225,7 @@ Specifics:
             description: 'Use ACL Groups to restrict who reaches a routed network',
         },
         {
-            href: '/manage/network-routes/advanced-configuration',
+            href: '/manage/networks/masquerade',
             name: 'Masquerade',
             description: 'When to enable or disable source IP rewriting on a route',
         },

--- a/src/pages/manage/networks/masquerade.mdx
+++ b/src/pages/manage/networks/masquerade.mdx
@@ -52,7 +52,7 @@ On Ubuntu Server, `/etc/netplan/` usually already has a yaml from cloud-init (`5
 network:
   version: 2
   ethernets:
-    <IFACE>:                         # your interface, e.g. eth0
+    <IFACE>:                         # destination's LAN interface, e.g. eth0
       addresses: [192.168.1.50/24]   # existing
       routes:
         - to: default                # existing

--- a/src/pages/manage/networks/masquerade.mdx
+++ b/src/pages/manage/networks/masquerade.mdx
@@ -52,7 +52,7 @@ On Ubuntu Server, `/etc/netplan/` usually already has a yaml from cloud-init (`5
 network:
   version: 2
   ethernets:
-    <IFACE>:
+    <IFACE>:                         # your interface, e.g. eth0
       addresses: [192.168.1.50/24]   # existing
       routes:
         - to: default                # existing

--- a/src/pages/manage/networks/masquerade.mdx
+++ b/src/pages/manage/networks/masquerade.mdx
@@ -1,0 +1,158 @@
+import { Note, Warning } from '@/components/mdx'
+import { Tiles } from '@/components/Tiles'
+
+# Masquerade
+
+Masquerade is on by default. The routing peer SNATs forwarded traffic to its own LAN-side IP, so the destination network does not need any awareness of NetBird. Turn it off when you need:
+
+- Source IP visibility for auditing, compliance, or application logic.
+- The destination network's existing firewalls to filter NetBird peers by their overlay IP.
+
+## What changes when masquerade is off
+
+- The original NetBird overlay IP is preserved end-to-end.
+- The destination network must have a return route for the NetBird CIDR (default `100.64.0.0/10`) pointing at the routing peer's LAN IP.
+- High availability stops working — return traffic must flow back through one specific routing peer, so the destination network has no way to follow a failover. See [How Routing Peers Work — Masquerade](/manage/networks/how-routing-peers-work#masquerade).
+
+<Note>
+Masquerade can only be turned off on Linux routing peers.
+</Note>
+
+## Inputs to substitute
+
+The examples below use placeholders. Swap in:
+
+- `100.64.0.0/10` — default NetBird CIDR. Substitute your account's range if it's narrower.
+- `<PEER_LAN_IP>` — the routing peer's IP on the destination subnet.
+- `<IFACE>` — the LAN interface on the destination host. Use `ip -br addr` to identify it.
+
+## Test the route before making it persistent
+
+Add the route temporarily on the destination host:
+
+```bash
+sudo ip route add 100.64.0.0/10 via <PEER_LAN_IP>
+```
+
+Verify reachability from a NetBird peer, then remove the test route before committing the persistent version:
+
+```bash
+sudo ip route del 100.64.0.0/10
+```
+
+## Persistent configuration
+
+Pick the section matching how the destination host manages its network.
+
+### Netplan (Ubuntu 18.04+)
+
+Edit the existing yaml in `/etc/netplan/` (e.g. `01-netcfg.yaml` or `50-cloud-init.yaml`):
+
+```yaml
+network:
+  version: 2
+  ethernets:
+    <IFACE>:
+      routes:
+        - to: 100.64.0.0/10
+          via: <PEER_LAN_IP>
+```
+
+Apply:
+
+```bash
+sudo netplan apply
+```
+
+<Note>
+Recent netplan versions require `0600` permissions on yaml files under `/etc/netplan/`. Set with `sudo chmod 0600 /etc/netplan/*.yaml` if `netplan apply` warns.
+</Note>
+
+### systemd-networkd
+
+Either append to the relevant `.network` file in `/etc/systemd/network/`, or drop a snippet into `/etc/systemd/network/<IFACE>.network.d/100-netbird.conf`:
+
+```ini
+[Route]
+Destination=100.64.0.0/10
+Gateway=<PEER_LAN_IP>
+```
+
+Apply:
+
+```bash
+sudo networkctl reload
+```
+
+### NetworkManager (RHEL, Rocky, Alma, Fedora, Ubuntu desktop)
+
+Find the connection name:
+
+```bash
+nmcli connection show
+```
+
+Add the route to that connection profile:
+
+```bash
+sudo nmcli connection modify "<CONN_NAME>" +ipv4.routes "100.64.0.0/10 <PEER_LAN_IP>"
+sudo nmcli connection up "<CONN_NAME>"
+```
+
+The route is stored in `/etc/NetworkManager/system-connections/<CONN_NAME>.nmconnection` and survives reboots.
+
+### ifupdown (legacy Debian, older Ubuntu)
+
+In `/etc/network/interfaces`, under the interface stanza:
+
+```
+post-up ip route add 100.64.0.0/10 via <PEER_LAN_IP>
+pre-down ip route del 100.64.0.0/10 via <PEER_LAN_IP>
+```
+
+### RHEL legacy network-scripts
+
+For RHEL 7 hosts still on the `network` service (rare on modern systems), create or edit `/etc/sysconfig/network-scripts/route-<IFACE>`:
+
+```
+100.64.0.0/10 via <PEER_LAN_IP>
+```
+
+## Verify after reboot
+
+```bash
+ip route show 100.64.0.0/10
+```
+
+Expect output like:
+
+```
+100.64.0.0/10 via 192.168.1.50 dev eth0
+```
+
+## Security considerations
+
+<Warning>
+The return route exposes the destination subnet to the full `100.64.0.0/10` overlay range. The OS-level route does no filtering on its own — source IP transparency is the whole reason masquerade is off, so tighten access at the NetBird policy layer with source groups, ports, and posture checks. If only a subset of the destination subnet should reach NetBird peers, add host-level firewall rules (iptables, nftables, firewalld) alongside the route.
+</Warning>
+
+<Tiles
+    title="Related"
+    items={[
+        {
+            href: '/manage/networks/how-routing-peers-work#masquerade',
+            name: 'How Routing Peers Work — Masquerade',
+            description: 'Conceptual reference for masquerade behavior and HA implications',
+        },
+        {
+            href: '/manage/network-routes/use-cases/by-configuration/access-control',
+            name: 'Access Control on Network Routes',
+            description: 'Restrict who reaches a routed network with ACL Groups',
+        },
+        {
+            href: '/manage/network-routes/use-cases/by-configuration/advanced-configuration',
+            name: 'Advanced Configuration',
+            description: 'Site-to-site routing, access control, and troubleshooting',
+        },
+    ]}
+/>

--- a/src/pages/manage/networks/masquerade.mdx
+++ b/src/pages/manage/networks/masquerade.mdx
@@ -26,6 +26,20 @@ The examples below use placeholders. Swap in:
 - `<PEER_LAN_IP>` — the routing peer's IP on the destination subnet.
 - `<IFACE>` — the LAN interface on the destination host. Use `ip -br addr` to identify it.
 
+## Find your account's NetBird range
+
+NetBird assigns each account a single `/16` block from inside the `100.64.0.0/10` CGNAT range (one of 64 possible blocks such as `100.64.0.0/16`, `100.121.0.0/16`, `100.127.0.0/16`, …). The block is chosen randomly per account and can be customised. Use that `/16` for the return route below — not the whole `/10` — so you don't funnel unrelated CGNAT ranges through your routing peer.
+
+Read it off any enrolled peer:
+
+```bash
+$ netbird status | grep "NetBird IP"
+NetBird IP: 100.121.195.4/16
+# → this account's block is 100.121.0.0/16
+```
+
+Substitute that `/16` for `100.64.0.0/10` in every example below.
+
 ## Test the route before making it persistent
 
 Add the route temporarily on the destination host:

--- a/src/pages/manage/networks/masquerade.mdx
+++ b/src/pages/manage/networks/masquerade.mdx
@@ -1,5 +1,4 @@
 import { Note, Warning } from '@/components/mdx'
-import { Tiles } from '@/components/Tiles'
 
 # Masquerade
 
@@ -129,24 +128,3 @@ Trailing fields such as `proto static`, `onlink`, or `metric 100` may appear dep
 <Warning>
 The return route exposes the destination subnet to the full `100.64.0.0/10` overlay range. The OS-level route does no filtering on its own — source IP transparency is the whole reason masquerade is off, so tighten access at the NetBird policy layer with source groups, ports, and posture checks. If only a subset of the destination subnet should reach NetBird peers, add host-level firewall rules (iptables, nftables, firewalld) alongside the route.
 </Warning>
-
-<Tiles
-    title="Related"
-    items={[
-        {
-            href: '/manage/networks/how-routing-peers-work#masquerade',
-            name: 'How Routing Peers Work — Masquerade',
-            description: 'Conceptual reference for masquerade behavior and HA implications',
-        },
-        {
-            href: '/manage/network-routes/use-cases/by-configuration/access-control',
-            name: 'Access Control on Network Routes',
-            description: 'Restrict who reaches a routed network with ACL Groups',
-        },
-        {
-            href: '/manage/network-routes/use-cases/by-configuration/advanced-configuration',
-            name: 'Advanced Configuration',
-            description: 'Site-to-site routing, access control, and troubleshooting',
-        },
-    ]}
-/>

--- a/src/pages/manage/networks/masquerade.mdx
+++ b/src/pages/manage/networks/masquerade.mdx
@@ -34,7 +34,7 @@ Add the route temporarily on the destination host:
 sudo ip route add 100.64.0.0/10 via <PEER_LAN_IP>
 ```
 
-Verify reachability from a NetBird peer, then remove the test route before committing the persistent version:
+From a NetBird peer, confirm reachability — for example `ping <destination-ip>` or `curl http://<destination-ip>:<port>`. Then remove the test route before committing the persistent version:
 
 ```bash
 sudo ip route del 100.64.0.0/10
@@ -46,15 +46,18 @@ Pick the section matching how the destination host manages its network.
 
 ### Netplan (Ubuntu 18.04+)
 
-Edit the existing yaml in `/etc/netplan/` (e.g. `01-netcfg.yaml` or `50-cloud-init.yaml`):
+Edit the existing yaml in `/etc/netplan/` (e.g. `01-netcfg.yaml` or `50-cloud-init.yaml`) and add a `routes:` entry to the interface stanza. Keep the existing `addresses:` / `dhcp4:` lines — this is a fragment, not a standalone file:
 
 ```yaml
 network:
   version: 2
   ethernets:
     <IFACE>:
+      addresses: [192.168.1.50/24]   # existing
       routes:
-        - to: 100.64.0.0/10
+        - to: default                # existing
+          via: 192.168.1.1
+        - to: 100.64.0.0/10          # add this
           via: <PEER_LAN_IP>
 ```
 
@@ -84,39 +87,9 @@ Apply:
 sudo networkctl reload
 ```
 
-### NetworkManager (RHEL, Rocky, Alma, Fedora, Ubuntu desktop)
-
-Find the connection name:
-
-```bash
-nmcli connection show
-```
-
-Add the route to that connection profile:
-
-```bash
-sudo nmcli connection modify "<CONN_NAME>" +ipv4.routes "100.64.0.0/10 <PEER_LAN_IP>"
-sudo nmcli connection up "<CONN_NAME>"
-```
-
-The route is stored in `/etc/NetworkManager/system-connections/<CONN_NAME>.nmconnection` and survives reboots.
-
-### ifupdown (legacy Debian, older Ubuntu)
-
-In `/etc/network/interfaces`, under the interface stanza:
-
-```
-post-up ip route add 100.64.0.0/10 via <PEER_LAN_IP>
-pre-down ip route del 100.64.0.0/10 via <PEER_LAN_IP>
-```
-
-### RHEL legacy network-scripts
-
-For RHEL 7 hosts still on the `network` service (rare on modern systems), create or edit `/etc/sysconfig/network-scripts/route-<IFACE>`:
-
-```
-100.64.0.0/10 via <PEER_LAN_IP>
-```
+<Note>
+The drop-in path only takes effect when a `.network` file already matches the interface. Run `networkctl status <IFACE>` and check the **Network File** line to confirm which one — on netplan-managed hosts it's generated under `/run/systemd/network/`.
+</Note>
 
 ## Verify after reboot
 
@@ -129,6 +102,8 @@ Expect output like:
 ```
 100.64.0.0/10 via 192.168.1.50 dev eth0
 ```
+
+Trailing fields such as `proto static`, `onlink`, or `metric 100` may appear depending on the network manager — those are normal.
 
 ## Security considerations
 

--- a/src/pages/manage/networks/masquerade.mdx
+++ b/src/pages/manage/networks/masquerade.mdx
@@ -46,7 +46,7 @@ Pick the section matching how the destination host manages its network.
 
 ### Netplan (Ubuntu 18.04+)
 
-Edit the existing yaml in `/etc/netplan/` (e.g. `01-netcfg.yaml` or `50-cloud-init.yaml`) and add a `routes:` entry to the interface stanza. Keep the existing `addresses:` / `dhcp4:` lines — this is a fragment, not a standalone file:
+On Ubuntu Server, `/etc/netplan/` usually already has a yaml from cloud-init (`50-cloud-init.yaml`) or the installer (`00-installer-config.yaml`). Add a `routes:` entry to the interface stanza. The `addresses:` and default-route values shown below are placeholders for whatever is already in your file — not values to copy as-is:
 
 ```yaml
 network:
@@ -60,6 +60,8 @@ network:
         - to: 100.64.0.0/10          # add this
           via: <PEER_LAN_IP>
 ```
+
+If `/etc/netplan/` is empty (uncommon, but possible on minimal installs or when netplan was just `apt install`ed), create `/etc/netplan/01-netbird.yaml` with the full stanza, substituting real values for `addresses:` and the default gateway.
 
 Apply:
 

--- a/src/pages/manage/networks/masquerade.mdx
+++ b/src/pages/manage/networks/masquerade.mdx
@@ -10,18 +10,33 @@ Masquerade is on by default. The routing peer SNATs forwarded traffic to its own
 ## What changes when masquerade is off
 
 - The original NetBird overlay IP is preserved end-to-end.
-- The destination network must have a return route for the NetBird CIDR (default `100.64.0.0/10`) pointing at the routing peer's LAN IP.
+- The destination host (or, if it sits in a different subnet, its gateway) must have a return route for the NetBird CIDR (default `100.64.0.0/10`) pointing at the routing peer's LAN IP.
 - High availability stops working — return traffic must flow back through one specific routing peer, so the destination network has no way to follow a failover. See [How Routing Peers Work — Masquerade](/manage/networks/how-routing-peers-work#masquerade).
 
 <Note>
 Masquerade can only be turned off on Linux routing peers.
 </Note>
 
+## Disable masquerade on the routing peer
+
+In the dashboard: **Networks** → your network → the **routing peer** row → toggle **Masquerade** off. The change takes effect within seconds; the routing peer stops SNATing forwarded traffic for this network.
+
+You can also flip it through the API:
+
+```bash
+curl -X PUT https://api.netbird.io/api/networks/<NETWORK_ID>/routers/<ROUTER_ID> \
+  -H "Authorization: Token <API_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"peer": "<PEER_ID>", "masquerade": false, "metric": 9999, "enabled": true}'
+```
+
+The rest of this page covers the return-route prerequisite the destination network needs once masquerade is off.
+
 ## Inputs to substitute
 
 The examples below use placeholders. Swap in:
 
-- `100.64.0.0/10` — default NetBird CIDR. Substitute your account's range if it's narrower.
+- `100.64.0.0/10` — default NetBird CIDR. See [Find your account's NetBird range](#find-your-accounts-netbird-range) below for the narrower `/16` you should use in practice.
 - `<PEER_LAN_IP>` — the routing peer's IP on the destination subnet.
 - `<IFACE>` — the LAN interface on the destination host. Use `ip -br addr` to identify it.
 
@@ -50,7 +65,7 @@ sudo ip route add 100.64.0.0/10 via <PEER_LAN_IP>
 From a NetBird peer, confirm reachability with a protocol/port your NetBird policy allows — for example `curl http://<destination-ip>:<port>`, or `nc -zv <destination-ip> <port>` for a non-HTTP service. Then remove the test route before committing the persistent version:
 
 ```bash
-sudo ip route del 100.64.0.0/10
+sudo ip route del 100.64.0.0/10 via <PEER_LAN_IP>
 ```
 
 ## Persistent configuration
@@ -62,7 +77,7 @@ Pick **one** of the methods below — your host uses one network manager, not bo
 
 ### Netplan (Ubuntu 18.04+)
 
-On Ubuntu Server, `/etc/netplan/` usually already has a yaml from cloud-init (`50-cloud-init.yaml`) or the installer (`00-installer-config.yaml`). Add a `routes:` entry to the interface stanza. The `addresses:` and default-route values shown below are placeholders for whatever is already in your file — not values to copy as-is:
+On Ubuntu Server, `/etc/netplan/` usually already has a yaml from cloud-init (`50-cloud-init.yaml`) or the installer (`00-installer-config.yaml`). Append a new entry to the interface's `routes:` list (don't add a second `routes:` key — YAML won't accept that). The `addresses:` and default-route values shown below are placeholders for whatever is already in your file — not values to copy as-is:
 
 ```yaml
 network:
@@ -115,13 +130,25 @@ The drop-in path only takes effect when a `.network` file already matches the in
 ip route show 100.64.0.0/10
 ```
 
-Expect output like:
+Expect output like (where `192.168.1.10` stands for the routing peer's LAN IP — not the destination's own address):
 
 ```
-100.64.0.0/10 via 192.168.1.50 dev eth0
+100.64.0.0/10 via 192.168.1.10 dev eth0
 ```
 
 Trailing fields such as `proto static`, `onlink`, or `metric 100` may appear depending on the network manager — those are normal.
+
+Then send a request from a NetBird peer and confirm the destination logs the original overlay IP:
+
+```bash
+# from a NetBird peer
+curl http://<destination-ip>:<port>
+
+# on the destination, tail the relevant log or capture briefly:
+sudo tcpdump -ni <IFACE> "src net 100.64.0.0/10 and port <port>"
+```
+
+The source IP should fall inside your account's `/16` (e.g. `100.121.x.x`), not the routing peer's LAN IP.
 
 ## Security considerations
 

--- a/src/pages/manage/networks/masquerade.mdx
+++ b/src/pages/manage/networks/masquerade.mdx
@@ -42,7 +42,10 @@ sudo ip route del 100.64.0.0/10
 
 ## Persistent configuration
 
-Pick the section matching how the destination host manages its network.
+Pick **one** of the methods below — your host uses one network manager, not both:
+
+- **Netplan** if `/etc/netplan/` already has yaml files (most Ubuntu hosts).
+- **systemd-networkd** otherwise (Debian Server, minimal installs, or hosts using systemd-networkd directly without a netplan frontend).
 
 ### Netplan (Ubuntu 18.04+)
 

--- a/src/pages/manage/networks/masquerade.mdx
+++ b/src/pages/manage/networks/masquerade.mdx
@@ -53,7 +53,7 @@ NetBird IP: 100.121.195.4/16
 ```
 
 <Note>
-Substitute that `/16` for `100.64.0.0/10` in every example below.
+Wherever the examples below show `100.64.0.0/10`, use your account's `/16` instead.
 </Note>
 
 ## Test the route before making it persistent

--- a/src/pages/manage/networks/masquerade.mdx
+++ b/src/pages/manage/networks/masquerade.mdx
@@ -52,7 +52,9 @@ NetBird IP: 100.121.195.4/16
 # → this account's block is 100.121.0.0/16
 ```
 
+<Note>
 Substitute that `/16` for `100.64.0.0/10` in every example below.
+</Note>
 
 ## Test the route before making it persistent
 

--- a/src/pages/manage/networks/masquerade.mdx
+++ b/src/pages/manage/networks/masquerade.mdx
@@ -47,7 +47,7 @@ Add the route temporarily on the destination host:
 sudo ip route add 100.64.0.0/10 via <PEER_LAN_IP>
 ```
 
-From a NetBird peer, confirm reachability — for example `ping <destination-ip>` or `curl http://<destination-ip>:<port>`. Then remove the test route before committing the persistent version:
+From a NetBird peer, confirm reachability with a protocol/port your NetBird policy allows — for example `curl http://<destination-ip>:<port>`, or `nc -zv <destination-ip> <port>` for a non-HTTP service. Then remove the test route before committing the persistent version:
 
 ```bash
 sudo ip route del 100.64.0.0/10

--- a/src/pages/manage/networks/masquerade.mdx
+++ b/src/pages/manage/networks/masquerade.mdx
@@ -126,5 +126,5 @@ Trailing fields such as `proto static`, `onlink`, or `metric 100` may appear dep
 ## Security considerations
 
 <Warning>
-The return route exposes the destination subnet to the full `100.64.0.0/10` overlay range. The OS-level route does no filtering on its own — source IP transparency is the whole reason masquerade is off, so tighten access at the NetBird policy layer with source groups, ports, and posture checks. If only a subset of the destination subnet should reach NetBird peers, add host-level firewall rules (iptables, nftables, firewalld) alongside the route.
+The return route exposes the destination subnet to whatever NetBird range you configured — your account's `/16` if you narrowed it (recommended), otherwise the full `100.64.0.0/10`. The OS-level route does no filtering on its own — source IP transparency is the whole reason masquerade is off, so tighten access at the NetBird policy layer with source groups, ports, and posture checks. If only a subset of the destination subnet should reach NetBird peers, add host-level firewall rules (iptables, nftables, firewalld) alongside the route.
 </Warning>

--- a/src/pages/manage/networks/masquerade.mdx
+++ b/src/pages/manage/networks/masquerade.mdx
@@ -58,7 +58,7 @@ network:
         - to: default                # existing
           via: 192.168.1.1
         - to: 100.64.0.0/10          # add this
-          via: <PEER_LAN_IP>         # routing peer's IP on this subnet
+          via: <PEER_LAN_IP>         # routing peer's local IP on this subnet
 ```
 
 If `/etc/netplan/` is empty (uncommon, but possible on minimal installs or when netplan was just `apt install`ed), create `/etc/netplan/01-netbird.yaml` with the full stanza, substituting real values for `addresses:` and the default gateway.

--- a/src/pages/manage/networks/masquerade.mdx
+++ b/src/pages/manage/networks/masquerade.mdx
@@ -58,7 +58,7 @@ network:
         - to: default                # existing
           via: 192.168.1.1
         - to: 100.64.0.0/10          # add this
-          via: <PEER_LAN_IP>
+          via: <PEER_LAN_IP>         # routing peer's IP on this subnet
 ```
 
 If `/etc/netplan/` is empty (uncommon, but possible on minimal installs or when netplan was just `apt install`ed), create `/etc/netplan/01-netbird.yaml` with the full stanza, substituting real values for `addresses:` and the default gateway.


### PR DESCRIPTION
## Summary

- Adds `/manage/networks/masquerade` with persistent return-route configuration for Netplan, systemd-networkd, NetworkManager, ifupdown, and RHEL legacy network-scripts.
- Covers when/why to disable masquerade, the HA caveat, the return-route requirement, verification, and a security note about firewalling at the policy layer.
- Resolves the previously dangling "Related" tile in `how-routing-peers-work.mdx` that pointed at a non-existent `masquerade` page.
- Adds a cross-link from `advanced-configuration.mdx` → "Without Masquerade" to the new page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Added comprehensive Masquerade documentation page with feature overview, configuration instructions for return routes, operator workflows, and security considerations
- Updated navigation menu to surface the new Masquerade documentation link in the Networks section
- Enhanced masquerade-off guidance with clarified warnings about policy limitations and access control considerations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/docs/pull/751?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->