### PR TITLE
docs: tighten Networks vs. Network Routes list

### DIFF
--- a/src/pages/manage/networks/index.mdx
+++ b/src/pages/manage/networks/index.mdx
@@ -26,11 +26,8 @@ Your Laptop ──────► NetBird Tunnel ──────► Routing P
 
 Networks is the newer, simpler replacement for Network Routes — for VPN-to-Site, prefer Networks. Use [Network Routes](/manage/network-routes) when you need:
 
-- Clientless devices initiating connections (Site-to-VPN)
-- Two networks communicating with each other (Site-to-Site)
-- Source-IP preservation (masquerade disabled)
-
-For a detailed comparison, see our [site-to-site documentation](/use-cases/site-to-site).
+- Two networks communicating with each other ([Site-to-Site](/manage/network-routes/use-cases/site-to-site))
+- Routing internet-bound traffic through a designated peer ([Exit Nodes](/manage/network-routes/use-cases/exit-nodes))
 
 ## Concepts
 


### PR DESCRIPTION
## Summary
- Drop the Site-to-VPN and source-IP preservation (masquerade disabled) bullets from the Networks vs. Network Routes list on `/manage/networks`.
- Add an Exit Nodes bullet alongside Site-to-Site, and link both inline to their Network Routes use case pages.
- Remove the now-redundant "For a detailed comparison, see our site-to-site documentation" trailer.