### PR TITLE
docs: remove Related section from Site-to-VPN guide

### DIFF
--- a/src/pages/manage/networks/use-cases/site-to-vpn.mdx
+++ b/src/pages/manage/networks/use-cases/site-to-vpn.mdx
@@ -361,13 +361,6 @@ changes if the peer is re-enrolled), and that `dnsmasq` is not bound to
 `lo` — binding loopback causes it to refuse forwarding to its own
 `127.0.0.1`-co-located NetBird resolver.
 
-## Related
-
-- [Networks — Concept](/manage/networks)
-- [Network Routes — Concept](/manage/network-routes)
-- [Site-to-Site](/manage/network-routes/use-cases/site-to-site)
-- [Site-to-Site Overview](/use-cases/site-to-site)
-
 ## Appendix: Per-Service Port Forwarding
 
 If you cannot change routing on the site — for example, the clientless


### PR DESCRIPTION
## Summary

- Removes the `## Related` section from the Site-to-VPN use-case page.