### PR TITLE
docs: rework Site-to-VPN SNAT guidance, verified end-to-end

### DIFF
--- a/src/pages/manage/networks/use-cases/site-to-vpn.mdx
+++ b/src/pages/manage/networks/use-cases/site-to-vpn.mdx
@@ -349,12 +349,23 @@ If the Step 3 rule is missing or its counters stay at zero, re-install it
 sudo iptables -t nat -A POSTROUTING -s 192.168.50.0/24 -o wt0 -j MASQUERADE
 ```
 
-**DNS resolution returns NXDOMAIN.**
+**DNS resolution returns NXDOMAIN or times out.**
 
-Confirm the routing peer's NetBird IP is correct in `dnsmasq.conf` (it
-changes if the peer is re-enrolled), and that `dnsmasq` is not bound to
-`lo` — binding loopback causes it to refuse forwarding to its own
-`127.0.0.1`-co-located NetBird resolver.
+Confirm the `server=/netbird.cloud/...` line in
+`/etc/dnsmasq.d/netbird.conf` still matches the routing peer's current
+NetBird IP — re-enrolling the peer changes it. Isolate from the
+clientless device:
+
+```bash
+dig @<ROUTING_PEER_SITE_IP> <hostname>.netbird.cloud
+```
+
+A timeout means `dnsmasq` isn't reachable on the routing peer's site IP
+(check `listen-address` in the config). `SERVFAIL` means `dnsmasq`
+received the query but its forward to the NetBird resolver failed.
+`NXDOMAIN` means the NetBird resolver answered but doesn't know that
+hostname — verify the target peer's actual FQDN with `netbird status`
+on the peer itself.
 
 ## Appendix: Per-Service Port Forwarding
 

--- a/src/pages/manage/networks/use-cases/site-to-vpn.mdx
+++ b/src/pages/manage/networks/use-cases/site-to-vpn.mdx
@@ -97,28 +97,63 @@ the Site-to-VPN direction — see
 
 ### Linux
 
-With iptables (or iptables-nft):
+Two equivalent persistent options. Use **iptables-persistent** unless you
+specifically want to manage rules with `nft`.
+
+**Option 1: iptables-persistent (recommended)**
 
 ```bash
+sudo apt-get install -y iptables-persistent
 sudo iptables -t nat -A POSTROUTING -s 192.168.50.0/24 -o wt0 -j MASQUERADE
-# Persist via iptables-persistent / netfilter-persistent
+sudo netfilter-persistent save
 ```
 
-Or natively with nftables:
+The rule survives reboot because `iptables-persistent` reloads
+`/etc/iptables/rules.v4` at boot. Works on systems using either
+`iptables-legacy` or `iptables-nft` underneath.
+
+**Option 2: native nftables**
+
+Do **not** append the rule to `/etc/nftables.conf` — the default file
+starts with `flush ruleset`, which wipes NetBird's own firewall rules.
+Use a dedicated drop-in file plus a systemd unit ordered after the
+NetBird daemon:
 
 ```bash
-sudo nft add table ip custom-nat
-sudo nft add chain ip custom-nat postrouting \
-  '{ type nat hook postrouting priority 100 ; }'
-sudo nft add rule ip custom-nat postrouting \
-  oifname "wt0" ip saddr 192.168.50.0/24 masquerade
-# Persist by adding the same rules to /etc/nftables.conf
-# and enabling: sudo systemctl enable --now nftables
+sudo mkdir -p /etc/nftables.d
+sudo tee /etc/nftables.d/netbird-snat.nft > /dev/null <<'EOF'
+table ip netbird-snat {
+    chain postrouting {
+        type nat hook postrouting priority 100;
+        oifname "wt0" ip saddr 192.168.50.0/24 masquerade
+    }
+}
+EOF
+
+sudo tee /etc/systemd/system/netbird-snat.service > /dev/null <<'EOF'
+[Unit]
+Description=NetBird Site-to-VPN outbound SNAT
+After=netbird.service
+Requires=netbird.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/nft -f /etc/nftables.d/netbird-snat.nft
+ExecStop=/usr/sbin/nft delete table ip netbird-snat
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now netbird-snat.service
 ```
 
 If you run a host firewall (UFW, firewalld) with the `FORWARD` chain
 default set to `DROP`, also allow forwarding between the site-facing
-interface and `wt0`:
+interface and `wt0` and persist it via your firewall's config tool. The
+runtime equivalent is:
 
 ```bash
 sudo iptables -I FORWARD 1 -i <site-iface> -o wt0 -j ACCEPT

--- a/src/pages/manage/networks/use-cases/site-to-vpn.mdx
+++ b/src/pages/manage/networks/use-cases/site-to-vpn.mdx
@@ -34,10 +34,9 @@ control.
 ## Prerequisites
 
 - A device on the local network to serve as the routing peer. Linux is
-  the most common choice (the SNAT examples below assume it), but pfSense,
-  OPNsense, MikroTik, Windows, and macOS all work — see
-  [Step 3](#step-3-configure-the-outbound-snat) for the per-platform SNAT
-  syntax you'll need.
+  assumed throughout this guide; on other platforms the steps are the
+  same but the [Step 3](#step-3-configure-the-outbound-snat) SNAT rule
+  has to be installed via the platform's native NAT mechanism.
 - A separate device running the NetBird client that the clientless device
   needs to reach
 - The ability to either add a static route on the clientless device (or its
@@ -107,23 +106,12 @@ sudo iptables -t nat -A POSTROUTING -s 192.168.50.0/24 -o wt0 -j MASQUERADE
 sudo netfilter-persistent save
 ```
 
-### pfSense / OPNsense
+### Other platforms
 
-Add an outbound NAT rule on the `wt0` (or equivalent) interface that
-translates traffic sourced from `192.168.50.0/24` to the interface
-address. Switch outbound NAT mode to **Manual** (or **Hybrid**) so this
-rule is honoured.
-
-### MikroTik (RouterOS)
-
-```
-/ip firewall nat add chain=srcnat src-address=192.168.50.0/24 \
-  out-interface=wt0 action=masquerade
-```
-
-Any outbound source NAT mechanism that rewrites the site-CIDR source to the
-routing peer's NetBird IP (or to the `wt0` interface address) on the
-NetBird egress path is sufficient.
+On non-Linux routing peers, install the equivalent rule via the
+platform's native NAT mechanism. Any outbound source NAT that rewrites
+the site-CIDR source to the routing peer's NetBird IP (or to the `wt0`
+interface address) on egress from `wt0` is sufficient.
 
 ## Step 4: Create the Network
 

--- a/src/pages/manage/networks/use-cases/site-to-vpn.mdx
+++ b/src/pages/manage/networks/use-cases/site-to-vpn.mdx
@@ -24,19 +24,20 @@ Clientless Device ──► Routing Peer ──► NetBird Overlay ──► Net
 
 <Warning>
 The routing peer must perform **outbound source NAT** for site traffic
-entering the NetBird overlay. NetBird performs this automatically only when
-the routing peer is **Linux running in kernel mode**. On any other platform
-(pfSense, OPNsense, MikroTik, Windows, macOS, or Linux in userspace mode),
-you must configure the outbound NAT yourself on the routing peer or on its
-upstream firewall. Without this, the overlay peer drops the traffic at its
-access control. See [Outbound SNAT requirement](#outbound-snat-requirement).
+entering the NetBird overlay. The dashboard **Masquerade** flag does not
+cover this direction on any route — you must install the SNAT rule
+manually on the routing peer (or on its upstream firewall) on every
+platform. Without this, the overlay peer drops the traffic at its access
+control. See [Outbound SNAT requirement](#outbound-snat-requirement).
 </Warning>
 
 ## Prerequisites
 
-- A device on the local network to serve as the routing peer. **Linux is
-  strongly recommended** for the routing peer because it can install the
-  required outbound SNAT automatically (see the warning above).
+- A device on the local network to serve as the routing peer. Linux is
+  the most common choice (the SNAT examples below assume it), but pfSense,
+  OPNsense, MikroTik, Windows, and macOS all work — see
+  [Step 3](#step-3-configure-the-outbound-snat) for the per-platform SNAT
+  syntax you'll need.
 - A separate device running the NetBird client that the clientless device
   needs to reach
 - The ability to either add a static route on the clientless device (or its
@@ -83,34 +84,54 @@ sudo netbird up --setup-key YOUR_SITE_SETUP_KEY
 Confirm the peer appears in the dashboard and shows the `site-routing-peers`
 group.
 
-## Step 3: Configure the Outbound SNAT (If applicable)
+## Step 3: Configure the Outbound SNAT
 
 The routing peer must SNAT site traffic onto its NetBird interface so the
 overlay peer's access control sees a NetBird IP it recognises. See
 [Outbound SNAT requirement](#outbound-snat-requirement) for the reasoning.
 
-**On Linux:** no manual SNAT configuration is needed. NetBird enables IP
-forwarding and installs the SNAT itself when masquerade is enabled on the
-routing peer (Step 4).
+This step is **required on every routing peer**, regardless of OS or
+WireGuard mode. The dashboard **Masquerade** flag (Step 4) does not cover
+the Site-to-VPN direction — see
+[Outbound SNAT requirement](#outbound-snat-requirement) for why.
 
-The only Linux-side caveat is if you run a host firewall (UFW, firewalld)
-with the `FORWARD` chain default set to `DROP` — in that case, allow
-forwarding between the site-facing interface and `wt0`:
+### Linux
+
+With iptables (or iptables-nft):
+
+```bash
+sudo iptables -t nat -A POSTROUTING -s 192.168.50.0/24 -o wt0 -j MASQUERADE
+# Persist via iptables-persistent / netfilter-persistent
+```
+
+Or natively with nftables:
+
+```bash
+sudo nft add table ip custom-nat
+sudo nft add chain ip custom-nat postrouting \
+  '{ type nat hook postrouting priority 100 ; }'
+sudo nft add rule ip custom-nat postrouting \
+  oifname "wt0" ip saddr 192.168.50.0/24 masquerade
+# Persist by adding the same rules to /etc/nftables.conf
+# and enabling: sudo systemctl enable --now nftables
+```
+
+If you run a host firewall (UFW, firewalld) with the `FORWARD` chain
+default set to `DROP`, also allow forwarding between the site-facing
+interface and `wt0`:
 
 ```bash
 sudo iptables -I FORWARD 1 -i <site-iface> -o wt0 -j ACCEPT
 ```
 
-**On any other platform** — pfSense, OPNsense, MikroTik, Windows, macOS, or
-Linux running in userspace mode — NetBird does not install the SNAT for
-you. Configure it manually on the routing peer or its upstream firewall.
+### pfSense / OPNsense
 
-For pfSense / OPNsense, add an outbound NAT rule on the `wt0` (or
-equivalent) interface that translates traffic sourced from `192.168.50.0/24`
-to the interface address. Switch outbound NAT mode to **Manual** (or
-**Hybrid**) so this rule is honoured.
+Add an outbound NAT rule on the `wt0` (or equivalent) interface that
+translates traffic sourced from `192.168.50.0/24` to the interface
+address. Switch outbound NAT mode to **Manual** (or **Hybrid**) so this
+rule is honoured.
 
-For MikroTik (RouterOS):
+### MikroTik (RouterOS)
 
 ```
 /ip firewall nat add chain=srcnat src-address=192.168.50.0/24 \
@@ -144,10 +165,12 @@ Attach the routing peer:
 
 1. In the network, click **Add Routing Peer**
 2. Select `site-router` (or the `site-routing-peers` group)
-3. **Masquerade:** Enabled is fine, but does not replace
-   [Step 3](#step-3-configure-the-outbound-snat) — this dashboard flag does
-   not install a working SNAT on non-Linux routing peers and is unreliable in
-   userspace mode
+3. **Masquerade:** Leave at the default. This flag controls SNAT for
+   traffic flowing **outbound from NetBird peers through the routing
+   peer** (the VPN-to-Site direction). It has no effect on Site-to-VPN
+   traffic, which is what this guide configures — the manual SNAT from
+   [Step 3](#step-3-configure-the-outbound-snat) is what makes Site-to-VPN
+   work.
 4. Click **Save**
 
 ## Step 5: Create the Access Policy
@@ -293,12 +316,15 @@ enters the overlay, replacing the site IP with the routing peer's NetBird
 IP. That NetBird IP **is** in the policy's source group, so the access
 control matches and the packet is accepted.
 
-On a Linux routing peer running in kernel mode, NetBird installs the SNAT
-itself via the kernel netfilter hooks when masquerade is enabled on the
-routing peer. On any other platform — pfSense, OPNsense, MikroTik,
-Windows, macOS, or Linux in userspace mode — that hook isn't available, so
-the SNAT must be configured manually on the routing peer or on its
-upstream firewall, as shown in [Step 3](#step-3-configure-the-outbound-snat).
+The dashboard **Masquerade** flag does not do this on its own. NetBird's
+automatic masquerade only applies to traffic flowing **outbound from
+NetBird peers through the routing peer** — for example, a NetBird client
+reaching a LAN host in a VPN-to-Site setup, or a client egressing to the
+internet via an exit node. Site-to-VPN traffic flows in the opposite
+direction (site → overlay) and is not covered by the masquerade flag on
+any route in current NetBird releases. That is why
+[Step 3](#step-3-configure-the-outbound-snat) installs the SNAT
+explicitly on the routing peer.
 
 ## Troubleshooting
 
@@ -335,20 +361,21 @@ allows `site-routing-peers` → target peer's group on the required port.
 
 **Target peer receives packets but drops them.**
 
-The outbound SNAT in [Step 3](#step-3-configure-the-outbound-snat) is
-missing or not effective. On the routing peer, packets going out `wt0` must
-have their source IP rewritten to the routing peer's NetBird IP:
+The outbound SNAT from
+[Step 3](#step-3-configure-the-outbound-snat) is missing or not effective.
+On the routing peer, packets going out `wt0` must have their source IP
+rewritten to the routing peer's NetBird IP:
 
 ```bash
-# On the routing peer, verify packet counters on the MASQUERADE rule:
+# Verify packet counters on the MASQUERADE rule installed in Step 3:
 sudo iptables -t nat -L POSTROUTING -n -v
 # Or watch overlay traffic on the way out:
 sudo tcpdump -ni wt0 'src net 192.168.50.0/24'
 # Seeing site IPs here means SNAT is NOT firing; the target peer will drop.
 ```
 
-If the routing peer is Linux in kernel mode and masquerade is enabled but
-the SNAT counters stay at zero, drop in an explicit rule as a fallback:
+If the Step 3 rule is missing or its counters stay at zero, re-install it
+(and add it to your persistence layer so it survives a reboot):
 
 ```bash
 sudo iptables -t nat -A POSTROUTING -s 192.168.50.0/24 -o wt0 -j MASQUERADE
@@ -391,8 +418,9 @@ local IP and the forwarded port:
 curl http://192.168.50.10:18080/
 ```
 
-The outbound SNAT configured in [Step 3](#step-3-configure-the-outbound-snat)
-applies to this traffic as well — the target peer still observes the
+The outbound SNAT configured in
+[Step 3](#step-3-configure-the-outbound-snat) applies to this
+traffic as well — the target peer still observes the
 routing peer's NetBird IP as the source.
 
 Each forwarded service needs its own DNAT rule. This pattern is a good fit

--- a/src/pages/manage/networks/use-cases/site-to-vpn.mdx
+++ b/src/pages/manage/networks/use-cases/site-to-vpn.mdx
@@ -240,11 +240,12 @@ curl -v http://<TARGET_PEER_NETBIRD_IP>:8080/
 Verify on the target peer that the request arrived:
 
 ```bash
-sudo ss -tnp | grep :8080
+sudo ss -tan | grep :8080
 ```
 
-The connection's remote address on the target peer will be the **routing
-peer's NetBird IP**, not the clientless device's local IP.
+The connection appears as a `TIME-WAIT` entry for about a minute after
+curl closes; its remote address is the **routing peer's NetBird IP**,
+not the clientless device's local IP.
 
 ## Resolving NetBird DNS Names
 

--- a/src/pages/manage/networks/use-cases/site-to-vpn.mdx
+++ b/src/pages/manage/networks/use-cases/site-to-vpn.mdx
@@ -97,57 +97,14 @@ the Site-to-VPN direction — see
 
 ### Linux
 
-Two equivalent persistent options. Use **iptables-persistent** unless you
-specifically want to manage rules with `nft`.
-
-**Option 1: iptables-persistent (recommended)**
+Install the SNAT rule via `iptables-persistent` so it survives reboot.
+This works on systems using either `iptables-legacy` or `iptables-nft`
+underneath:
 
 ```bash
 sudo apt-get install -y iptables-persistent
 sudo iptables -t nat -A POSTROUTING -s 192.168.50.0/24 -o wt0 -j MASQUERADE
 sudo netfilter-persistent save
-```
-
-The rule survives reboot because `iptables-persistent` reloads
-`/etc/iptables/rules.v4` at boot. Works on systems using either
-`iptables-legacy` or `iptables-nft` underneath.
-
-**Option 2: native nftables**
-
-Do **not** append the rule to `/etc/nftables.conf` — the default file
-starts with `flush ruleset`, which wipes NetBird's own firewall rules.
-Use a dedicated drop-in file plus a systemd unit ordered after the
-NetBird daemon:
-
-```bash
-sudo mkdir -p /etc/nftables.d
-sudo tee /etc/nftables.d/netbird-snat.nft > /dev/null <<'EOF'
-table ip netbird-snat {
-    chain postrouting {
-        type nat hook postrouting priority 100;
-        oifname "wt0" ip saddr 192.168.50.0/24 masquerade
-    }
-}
-EOF
-
-sudo tee /etc/systemd/system/netbird-snat.service > /dev/null <<'EOF'
-[Unit]
-Description=NetBird Site-to-VPN outbound SNAT
-After=netbird.service
-Requires=netbird.service
-
-[Service]
-Type=oneshot
-ExecStart=/usr/sbin/nft -f /etc/nftables.d/netbird-snat.nft
-ExecStop=/usr/sbin/nft delete table ip netbird-snat
-RemainAfterExit=yes
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-sudo systemctl daemon-reload
-sudo systemctl enable --now netbird-snat.service
 ```
 
 If you run a host firewall (UFW, firewalld) with the `FORWARD` chain

--- a/src/pages/manage/networks/use-cases/site-to-vpn.mdx
+++ b/src/pages/manage/networks/use-cases/site-to-vpn.mdx
@@ -198,14 +198,34 @@ In the examples below, replace `100.121.0.0/16` with your own block.
 
 ### Install the route
 
-**On a Linux clientless device:**
+**On a Linux clientless device with netplan** (Ubuntu Server default):
 
-```bash
-sudo ip route add 100.121.0.0/16 via 192.168.50.10
-# Persist via /etc/network/interfaces, netplan, or NetworkManager
+```yaml
+# /etc/netplan/99-netbird-route.yaml
+network:
+  version: 2
+  ethernets:
+    eth0:  # the interface holding the device's site IP
+      routes:
+        - to: 100.121.0.0/16
+          via: 192.168.50.10
 ```
 
-**On Windows:**
+```bash
+sudo chmod 600 /etc/netplan/99-netbird-route.yaml
+sudo netplan apply
+```
+
+**On a Linux clientless device with NetworkManager** (RHEL / Fedora /
+desktop distros):
+
+```bash
+sudo nmcli connection modify "<connection>" \
+  +ipv4.routes "100.121.0.0/16 192.168.50.10"
+sudo nmcli connection up "<connection>"
+```
+
+**On Windows** (the `-p` flag persists the route across reboots):
 
 ```powershell
 route -p add 100.121.0.0 mask 255.255.0.0 192.168.50.10

--- a/src/pages/manage/networks/use-cases/site-to-vpn.mdx
+++ b/src/pages/manage/networks/use-cases/site-to-vpn.mdx
@@ -28,7 +28,7 @@ entering the NetBird overlay. The dashboard **Masquerade** flag does not
 cover this direction on any route — you must install the SNAT rule
 manually on the routing peer (or on its upstream firewall) on every
 platform. Without this, the overlay peer drops the traffic at its access
-control. See [Outbound SNAT requirement](#outbound-snat-requirement).
+control.
 </Warning>
 
 ## Prerequisites
@@ -87,13 +87,13 @@ group.
 ## Step 3: Configure the Outbound SNAT
 
 The routing peer must SNAT site traffic onto its NetBird interface so the
-overlay peer's access control sees a NetBird IP it recognises. See
-[Outbound SNAT requirement](#outbound-snat-requirement) for the reasoning.
+overlay peer's access control sees a NetBird IP it recognises — the
+overlay peer's per-policy ipset only contains the NetBird IPs of source
+peers, so unrewritten packets sourced from a routed CIDR are dropped.
 
 This step is **required on every routing peer**, regardless of OS or
-WireGuard mode. The dashboard **Masquerade** flag (Step 4) does not cover
-the Site-to-VPN direction — see
-[Outbound SNAT requirement](#outbound-snat-requirement) for why.
+WireGuard mode. The dashboard **Masquerade** flag (Step 4) does not
+install a SNAT for the Site-to-VPN direction.
 
 ### Linux
 
@@ -284,30 +284,6 @@ not on `127.0.0.1`. Substitute the routing peer's actual NetBird IP into
 the `server=/netbird.cloud/...` line — you can find it with
 `netbird status` on the routing peer.
 </Note>
-
-## Outbound SNAT requirement
-
-NetBird's per-peer access control on the destination peer matches inbound
-traffic against an ipset of allowed source IPs. The ipset is populated from
-the **NetBird IPs of peers in the policy's source group** — it cannot
-contain a routed CIDR like `192.168.50.0/24`. So when a packet from
-`192.168.50.20` arrives at the overlay peer, the access control has no
-matching entry and the packet is dropped.
-
-The fix is to rewrite the source IP at the routing peer before the packet
-enters the overlay, replacing the site IP with the routing peer's NetBird
-IP. That NetBird IP **is** in the policy's source group, so the access
-control matches and the packet is accepted.
-
-The dashboard **Masquerade** flag does not do this on its own. NetBird's
-automatic masquerade only applies to traffic flowing **outbound from
-NetBird peers through the routing peer** — for example, a NetBird client
-reaching a LAN host in a VPN-to-Site setup, or a client egressing to the
-internet via an exit node. Site-to-VPN traffic flows in the opposite
-direction (site → overlay) and is not covered by the masquerade flag on
-any route in current NetBird releases. That is why
-[Step 3](#step-3-configure-the-outbound-snat) installs the SNAT
-explicitly on the routing peer.
 
 ## Troubleshooting
 

--- a/src/pages/manage/networks/use-cases/site-to-vpn.mdx
+++ b/src/pages/manage/networks/use-cases/site-to-vpn.mdx
@@ -107,15 +107,6 @@ sudo iptables -t nat -A POSTROUTING -s 192.168.50.0/24 -o wt0 -j MASQUERADE
 sudo netfilter-persistent save
 ```
 
-If you run a host firewall (UFW, firewalld) with the `FORWARD` chain
-default set to `DROP`, also allow forwarding between the site-facing
-interface and `wt0` and persist it via your firewall's config tool. The
-runtime equivalent is:
-
-```bash
-sudo iptables -I FORWARD 1 -i <site-iface> -o wt0 -j ACCEPT
-```
-
 ### pfSense / OPNsense
 
 Add an outbound NAT rule on the `wt0` (or equivalent) interface that


### PR DESCRIPTION
## Summary

Reworks the [Site-to-VPN guide](https://docs.netbird.io/manage/networks/use-cases/site-to-vpn) in response to support-engineer + customer feedback that the page's SNAT guidance was wrong, plus a pass of tightening informed by an end-to-end lab walkthrough of every remaining instruction.

## Why

A customer following the guide on a Linux kernel-mode routing peer with the dashboard **Masquerade** flag enabled found the setup didn't work — they had to install a manual SNAT rule for it to function. The doc previously said "on Linux in kernel mode, no manual SNAT configuration is needed" because of an assumption that the dashboard Masquerade flag covered both directions.

Lab investigation confirmed the customer's experience. The masquerade flag only installs the marking rules NetBird needs when a **policy targets the resource**, which the Site-to-VPN flow doesn't do (its policy is peer-to-peer: routing-peer-group → overlay-peer-group). So in the documented Site-to-VPN flow, NetBird never wires up the marking rules and the static `MASQUERADE -o wt0` rule never fires. Site traffic egresses wt0 with the LAN source IP and the overlay peer's ACL ipset drops it.

## Changes

- **Step 3 rewritten:** manual SNAT is framed as required on every routing peer, not "optional on Linux kernel mode". Linux block now uses `iptables-persistent` for full persistence (not a runtime command plus a comment). Heading drops "(If applicable)".
- **Step 4 masquerade-flag note** clarifies the flag covers SNAT for the VPN-to-Site direction only — it has no effect on Site-to-VPN.
- **Step 6 static route** is now fully persistent: netplan drop-in for Ubuntu Server, `nmcli` for NetworkManager-based distros, plus the existing Windows `route -p add`.
- **Test Connectivity** verification uses `ss -tan | grep :8080` (catches the TIME-WAIT entry) instead of `ss -tnp | grep :8080`, which filters by process and misses the kernel-owned socket.
- **Troubleshooting → DNS entry** rewritten with a `dig @<RP-site-IP>` isolation flow that distinguishes timeout vs SERVFAIL vs NXDOMAIN. The previous entry referenced a "`127.0.0.1`-co-located NetBird resolver" that doesn't exist (the doc's own DNS section notes NetBird's resolver binds to the peer's NetBird IP).
- **Outbound SNAT requirement** standalone section removed — its load-bearing point (ACL ipset can't contain routed CIDRs) is now in Step 3's opening sentence; the masquerade-flag explanation moved into the Step 4 note inline.
- **Unverified pfSense/OPNsense + MikroTik examples** removed and replaced with a single "Other platforms" paragraph pointing to the general principle.
- **UFW/firewalld FORWARD chain caveat** dropped from Step 3 — it was scoped to a minority of routing peers, and the symptom it covered is already in Troubleshooting.
- **Four broken in-page anchor links** to the old Step 3 heading fixed (all now resolve to `#step-3-configure-the-outbound-snat`).

Single-file change, 89 +/82 −.

## Test plan

Built a three-container lab in the demo NetBird tenant — kernel-mode Ubuntu routing peer + kernel-mode Ubuntu overlay peer running `python3 -m http.server 8080` + netshoot clientless on a separate site bridge. Walked every doc instruction from a clean slate (fresh setup keys, fresh peers, no leftover state):

- [x] Step 1 — setup keys with auto-assigned groups (`site-routing-peers`, `overlay-peers`)
- [x] Step 2 — `netbird up --setup-key` on both peers; auto-group assignment confirmed in dashboard
- [x] Step 3 — `iptables-persistent` install + `iptables -A POSTROUTING …` + `netfilter-persistent save`; rule survives flush + reload
- [x] Step 4 — Network + resource + routing peer attach (Masquerade left at default)
- [x] Step 5 — peer-to-peer policy (`site-routing-peers` → `overlay-peers` TCP/8080)
- [x] Step 6 (Linux/netplan path) — drop-in `99-netbird-route.yaml` merges with a base config; `netplan apply` installs the route
- [x] Step 6 (NetworkManager path) — `nmcli connection modify "<conn>" +ipv4.routes "100.121.0.0/16 192.168.51.10"` persists to `/etc/NetworkManager/system-connections/<conn>.nmconnection` (`route1=…`); `nmcli connection up` activates
- [x] Test Connectivity — `curl` from clientless returns HTTP/1.0 200; overlay peer's `ss -tan | grep :8080` shows TIME-WAIT with the routing peer's NetBird IP as remote (confirms SNAT)
- [x] Resolving NetBird DNS Names — `dnsmasq` config from doc applied verbatim; `curl http://s2v-overlay-peer.netbird.cloud:8080/` returns HTTP 200; `dig` against the routing peer resolves correctly
- [x] Appendix DNAT — removed static route on clientless, installed DNAT on routing peer per doc, `curl http://192.168.51.10:18080/` returned HTTP 200; SNAT counter incremented confirming the appendix-note that "Step 3's SNAT applies here too"
- [x] Counter-test: doc-default state without manual SNAT — curl times out (as the customer originally reported)

Not lab-tested (no platform available):
- pfSense / OPNsense — removed from doc
- MikroTik RouterOS — removed from doc
- Windows `route -p add` — left in doc unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Site-to-VPN setup guide with clearer SNAT configuration requirements and platform-specific examples.
  * Added OS-specific routing instructions for netplan, NetworkManager, and Windows.
  * Improved troubleshooting guidance for connectivity and DNS resolution issues.
  * Clarified Masquerade behavior for different traffic directions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/docs/pull/758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->