### PR TITLE
docs: drop inaccurate containerized routing peer ip_forward note

### DIFF
--- a/src/pages/manage/networks/how-routing-peers-work.mdx
+++ b/src/pages/manage/networks/how-routing-peers-work.mdx
@@ -70,8 +70,6 @@ echo "net.ipv4.ip_forward=1" | sudo tee /etc/sysctl.d/99-netbird.conf
 echo "net.ipv6.conf.all.forwarding=1" | sudo tee -a /etc/sysctl.d/99-netbird.conf
 ```
 
-For containerized routing peers, set this on the **host** that runs the container — sysctl is a host-level setting and a container cannot enable IP forwarding on its own.
-
 On Windows, no extra setup is needed to forward traffic to routed subnets. Only enable `NB_ENABLE_LOCAL_FORWARDING` if you also need clients to reach services bound to the routing peer's own local addresses — for example, a dashboard or service running on the routing peer host itself:
 
 ```powershell


### PR DESCRIPTION
## Summary

Removes this sentence from the IP forwarding section of *How routing peers work*:

> For containerized routing peers, set this on the **host** that runs the container — sysctl is a host-level setting and a container cannot enable IP forwarding on its own.

## Why

`net.ipv4.ip_forward` is namespaced per network namespace in modern Linux kernels. A container that has its own netns and `NET_ADMIN` (which the docs already require a couple of paragraphs further down) writes to its own namespaced copy of the sysctl — and that is exactly what the NetBird agent does on startup. So the blanket claim that a container "cannot enable IP forwarding on its own" is incorrect for the normal containerized routing peer setup.

The preceding paragraph already covers the fallback case ("If the agent cannot modify sysctl on its own, set it yourself on the host and persist it"), which is the right place for the host-level guidance — it naturally covers the edge cases where the in-container set fails (host networking, restricted runtimes, rootless containers without the right caps, etc.) without misrepresenting how `ip_forward` works inside a normal container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined routing peers configuration guidance with improved clarity in setup instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/docs/pull/761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->