### PR TITLE
docs: add Support Matrix section under Get More Help

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -809,6 +809,60 @@ export const docsNavigation = [
         href: '/help/troubleshooting-client',
       },
       { title: 'Report bugs and issues', href: '/help/report-bug-issues' },
+      {
+        title: 'Support Matrix',
+        isOpen: false,
+        links: [
+          { title: 'Overview', href: '/help/support-matrix' },
+          {
+            title: 'NetBird Client',
+            href: '/help/support-matrix/netbird-client',
+            isOpen: false,
+            links: [
+              {
+                title: 'Linux',
+                href: '/help/support-matrix/netbird-client/linux',
+              },
+              {
+                title: 'Windows',
+                href: '/help/support-matrix/netbird-client/windows',
+              },
+              {
+                title: 'macOS',
+                href: '/help/support-matrix/netbird-client/macos',
+              },
+              {
+                title: 'iOS',
+                href: '/help/support-matrix/netbird-client/ios',
+              },
+              {
+                title: 'Android',
+                href: '/help/support-matrix/netbird-client/android',
+              },
+              {
+                title: 'Android TV',
+                href: '/help/support-matrix/netbird-client/android-tv',
+              },
+              {
+                title: 'tvOS',
+                href: '/help/support-matrix/netbird-client/tvos',
+              },
+            ],
+          },
+          {
+            title: 'Kubernetes Operator',
+            href: '/help/support-matrix/kubernetes-operator',
+          },
+          {
+            title: 'Terraform Provider',
+            href: '/help/support-matrix/terraform-provider',
+          },
+          {
+            title: 'Self-Hosted',
+            href: '/help/support-matrix/self-hosted',
+          },
+        ],
+      },
     ],
   },
 ]

--- a/src/pages/help/support-matrix/index.mdx
+++ b/src/pages/help/support-matrix/index.mdx
@@ -1,0 +1,49 @@
+import { Warning } from '@/components/mdx'
+import { Tiles } from '@/components/Tiles'
+
+export const description =
+  'Supported versions for NetBird client, integrations, and tooling.'
+
+# Support Matrix
+
+This page lists the versions of operating systems, runtimes, and platforms officially supported across NetBird's client, integrations, and tooling. Use it to confirm compatibility before deploying or upgrading.
+
+Each sub-page is maintained alongside its component and updated when support windows change.
+
+<Warning>
+  This support matrix is a work in progress. Entries may change as we finalize support windows with the team.
+</Warning>
+
+<Tiles
+  title="Components"
+  items={[
+    {
+      href: '/help/support-matrix/netbird-client',
+      name: 'NetBird Client',
+      description: 'Supported operating systems and Go versions.',
+    },
+    {
+      href: '/help/support-matrix/kubernetes-operator',
+      name: 'Kubernetes Operator',
+      description: 'Supported Kubernetes and NetBird control-plane versions.',
+    },
+    {
+      href: '/help/support-matrix/terraform-provider',
+      name: 'Terraform Provider',
+      description: 'Supported Terraform and NetBird API versions.',
+    },
+    {
+      href: '/help/support-matrix/self-hosted',
+      name: 'Self-Hosted',
+      description: 'Supported operating systems and dependencies for self-hosted deployments.',
+    },
+  ]}
+/>
+
+## How to read these tables
+
+- **Supported** — covered by bug fixes and security updates.
+- **Best-effort** — known to work; issues triaged but not prioritized.
+- **Unsupported** — outside the support window; upgrade recommended.
+
+If you need help confirming compatibility for a version not listed, see [Report bugs and issues](/help/report-bug-issues).

--- a/src/pages/help/support-matrix/kubernetes-operator.mdx
+++ b/src/pages/help/support-matrix/kubernetes-operator.mdx
@@ -1,0 +1,18 @@
+export const description =
+  'Kubernetes and NetBird control-plane versions supported by the NetBird Kubernetes operator.'
+
+# Kubernetes Operator Support Matrix
+
+## Kubernetes compatibility
+
+The NetBird Kubernetes operator targets the Kubernetes minor versions that are currently receiving patch releases from upstream. The [Kubernetes release policy](https://kubernetes.io/releases/) keeps release branches active for the three most recent minor versions, with roughly one year of patch support each — the operator tracks that same window.
+
+In practice this means the operator avoids depending on Kubernetes APIs or features that are not yet available across every supported minor version. When upstream drops a minor version from patch support, the operator may begin adopting capabilities that became generally available during that version's lifetime.
+
+## NetBird control-plane compatibility
+
+The operator is developed against the latest NetBird control-plane release. Older control-plane versions may continue to work, but compatibility is not actively verified outside the current release.
+
+## Reporting compatibility issues
+
+If you hit a problem on a supported combination, see [Report bugs and issues](/help/report-bug-issues). Include your operator version, Kubernetes version (`kubectl version`), and NetBird control-plane version.

--- a/src/pages/help/support-matrix/netbird-client/android-tv.mdx
+++ b/src/pages/help/support-matrix/netbird-client/android-tv.mdx
@@ -1,0 +1,23 @@
+import { Note } from '@/components/mdx'
+
+export const description =
+  'Supported Android TV versions for the NetBird client.'
+
+# Android TV
+
+The NetBird client supports the Android TV versions listed below.
+
+<Note>
+  Entries marked **TBD** will be filled in once the support windows are confirmed with the team.
+</Note>
+
+## Android TV versions
+
+| Version (API level) | Architectures | Version Supported |
+|---|---|---|
+| TBD | TBD | TBD |
+| TBD | TBD | TBD |
+
+## Reporting compatibility issues
+
+See [Report bugs and issues](/help/report-bug-issues). Include your Android TV version, device model, and NetBird client version.

--- a/src/pages/help/support-matrix/netbird-client/android.mdx
+++ b/src/pages/help/support-matrix/netbird-client/android.mdx
@@ -1,0 +1,23 @@
+import { Note } from '@/components/mdx'
+
+export const description =
+  'Supported Android versions and architectures for the NetBird client.'
+
+# Android
+
+The NetBird client supports the Android versions listed below.
+
+<Note>
+  Entries marked **TBD** will be filled in once the support windows are confirmed with the team.
+</Note>
+
+## Android versions
+
+| Version (API level) | Architectures | Version Supported |
+|---|---|---|
+| TBD | TBD | TBD |
+| TBD | TBD | TBD |
+
+## Reporting compatibility issues
+
+See [Report bugs and issues](/help/report-bug-issues). Include your Android version, device model, and NetBird client version.

--- a/src/pages/help/support-matrix/netbird-client/index.mdx
+++ b/src/pages/help/support-matrix/netbird-client/index.mdx
@@ -1,0 +1,70 @@
+import { Note } from '@/components/mdx'
+import { Tiles } from '@/components/Tiles'
+
+export const description =
+  'Operating systems and Go toolchain versions supported by the NetBird client.'
+
+# NetBird Client Support Matrix
+
+The NetBird client runs across desktop, mobile, and TV platforms. Pick an OS family below for its distributions, versions, and architectures.
+
+<Note>
+  Until this matrix is complete, also check the latest [Go-compatible platforms](https://go.dev/wiki/#platform-specific-information) alongside NetBird's own guidance.
+</Note>
+
+<Tiles
+  title="Operating systems"
+  items={[
+    {
+      href: '/help/support-matrix/netbird-client/linux',
+      name: 'Linux',
+      description: 'Distributions, kernel, and libc support.',
+    },
+    {
+      href: '/help/support-matrix/netbird-client/windows',
+      name: 'Windows',
+      description: 'Supported Windows versions and architectures.',
+    },
+    {
+      href: '/help/support-matrix/netbird-client/macos',
+      name: 'macOS',
+      description: 'Supported macOS releases and architectures.',
+    },
+    {
+      href: '/help/support-matrix/netbird-client/ios',
+      name: 'iOS',
+      description: 'Supported iOS versions and devices.',
+    },
+    {
+      href: '/help/support-matrix/netbird-client/android',
+      name: 'Android',
+      description: 'Supported Android API levels and architectures.',
+    },
+    {
+      href: '/help/support-matrix/netbird-client/android-tv',
+      name: 'Android TV',
+      description: 'Supported Android TV API levels.',
+    },
+    {
+      href: '/help/support-matrix/netbird-client/tvos',
+      name: 'tvOS',
+      description: 'Supported tvOS versions.',
+    },
+  ]}
+/>
+
+## Go toolchain
+
+The client is built with the Go versions listed below. Building from source against an unsupported Go release is not guaranteed to succeed. Each Go version sets a floor on OS support for that NetBird release — see the per-OS pages above for the resulting cutoffs.
+
+| NetBird client version | Go version |
+|---|---|
+| v0.20.0 – v0.25.3 | 1.20 |
+| v0.25.4 – v0.29.1 | 1.21 |
+| v0.29.2 – v0.60.2 | 1.23 |
+| v0.60.3 – v0.62.3 | 1.24 |
+| v0.63.0 – current | 1.25 |
+
+## Reporting compatibility issues
+
+If you hit a problem on a supported platform, see [Report bugs and issues](/help/report-bug-issues). Include your client version (`netbird version`) and OS details.

--- a/src/pages/help/support-matrix/netbird-client/ios.mdx
+++ b/src/pages/help/support-matrix/netbird-client/ios.mdx
@@ -1,0 +1,23 @@
+import { Note } from '@/components/mdx'
+
+export const description =
+  'Supported iOS versions for the NetBird client.'
+
+# iOS
+
+The NetBird client supports the iOS versions listed below.
+
+<Note>
+  Entries marked **TBD** will be filled in once the support windows are confirmed with the team.
+</Note>
+
+## iOS versions
+
+| Version | Devices | Version Supported |
+|---|---|---|
+| TBD | TBD | TBD |
+| TBD | TBD | TBD |
+
+## Reporting compatibility issues
+
+See [Report bugs and issues](/help/report-bug-issues). Include your iOS version, device model, and NetBird client version.

--- a/src/pages/help/support-matrix/netbird-client/linux.mdx
+++ b/src/pages/help/support-matrix/netbird-client/linux.mdx
@@ -10,7 +10,14 @@ NetBird's Linux support depends on the client mode you run:
 - **Userspace mode** is supported wherever the Go toolchain is supported. The kernel floor for each NetBird release follows Go's minimum OS requirements (see the table below).
 - **Kernel mode** depends on the iptables / nftables features available on the host distribution.
 
-The NetBird team's end-to-end tests run against **Ubuntu 20.04** as the supported floor.
+The NetBird team's end-to-end tests cover the distributions below — **Ubuntu 20.04** is the oldest tested release:
+
+- Ubuntu 20.04, 22.04, 24.04
+- Debian 12
+- Rocky Linux 9
+- Fedora 41
+
+Other distributions are not actively tested; their compatibility follows the mode-specific rules above.
 
 <Warning>
   The kernel range below is derived from Go's [minimum OS requirements](https://go.dev/wiki/MinimumRequirements) per NetBird release's Go version, and applies to userspace mode. Kernel mode may have stricter requirements depending on the distribution — confirm with the team for production deployments.

--- a/src/pages/help/support-matrix/netbird-client/linux.mdx
+++ b/src/pages/help/support-matrix/netbird-client/linux.mdx
@@ -1,40 +1,29 @@
-import { Note, Warning } from '@/components/mdx'
+import { Warning } from '@/components/mdx'
 
 export const description =
-  'Supported Linux distributions, kernel versions, and architectures for the NetBird client.'
+  'Supported Linux kernel versions and modes for the NetBird client.'
 
 # Linux
 
-The NetBird client runs on most modern Linux distributions. The kernel floor is set by the Go toolchain each NetBird release is built against; distribution coverage is determined by what the NetBird team builds and tests.
+NetBird's Linux support depends on the client mode you run:
+
+- **Userspace mode** is supported wherever the Go toolchain is supported. The kernel floor for each NetBird release follows Go's minimum OS requirements (see the table below).
+- **Kernel mode** depends on the iptables / nftables features available on the host distribution.
+
+The NetBird team's end-to-end tests run against **Ubuntu 20.04** as the supported floor.
 
 <Warning>
-  The kernel cutoffs below are derived from the [Go toolchain's minimum OS requirements](https://go.dev/wiki/MinimumRequirements) for each NetBird release's Go version. Distribution-specific support beyond the kernel floor is determined by the NetBird team's testing — confirm before relying on it.
+  The kernel range below is derived from Go's [minimum OS requirements](https://go.dev/wiki/MinimumRequirements) per NetBird release's Go version, and applies to userspace mode. Kernel mode may have stricter requirements depending on the distribution — confirm with the team for production deployments.
 </Warning>
 
-## Linux kernel
+## Linux kernel (userspace mode)
 
 | Kernel range | NetBird release range |
 |---|---|
 | 3.2 and newer | v0.60.3 onwards (Go 1.24+) |
 | 2.6.32 – 3.1 | ≤ v0.60.2 (Go ≤1.23) |
 
-Most distributions released since ~2012 ship a 3.2+ kernel and run the latest NetBird client. The 2.6.32 floor primarily affected RHEL 6, CentOS 6, Ubuntu 14.04, and Debian 8, all of which are upstream EOL.
-
-<Note>
-  Distribution entries marked **TBD** will be filled in once coverage is confirmed with the team.
-</Note>
-
-## Distributions
-
-| Distro | Minimum release | Architectures | Notes |
-|---|---|---|---|
-| Ubuntu | TBD | TBD | TBD |
-| Debian | TBD | TBD | TBD |
-| Fedora | TBD | TBD | TBD |
-| RHEL / Alma / Rocky | TBD | TBD | TBD |
-| openSUSE | TBD | TBD | TBD |
-| Alpine | TBD | TBD | TBD |
-| Arch | rolling | TBD | TBD |
+The 2.6.32 floor primarily affected RHEL 6, CentOS 6, Ubuntu 14.04, and Debian 8 — all upstream EOL.
 
 ## Reporting compatibility issues
 

--- a/src/pages/help/support-matrix/netbird-client/linux.mdx
+++ b/src/pages/help/support-matrix/netbird-client/linux.mdx
@@ -1,0 +1,41 @@
+import { Note, Warning } from '@/components/mdx'
+
+export const description =
+  'Supported Linux distributions, kernel versions, and architectures for the NetBird client.'
+
+# Linux
+
+The NetBird client runs on most modern Linux distributions. The kernel floor is set by the Go toolchain each NetBird release is built against; distribution coverage is determined by what the NetBird team builds and tests.
+
+<Warning>
+  The kernel cutoffs below are derived from the [Go toolchain's minimum OS requirements](https://go.dev/wiki/MinimumRequirements) for each NetBird release's Go version. Distribution-specific support beyond the kernel floor is determined by the NetBird team's testing — confirm before relying on it.
+</Warning>
+
+## Linux kernel
+
+| Kernel range | NetBird release range |
+|---|---|
+| 3.2 and newer | v0.60.3 onwards (Go 1.24+) |
+| 2.6.32 – 3.1 | ≤ v0.60.2 (Go ≤1.23) |
+
+Most distributions released since ~2012 ship a 3.2+ kernel and run the latest NetBird client. The 2.6.32 floor primarily affected RHEL 6, CentOS 6, Ubuntu 14.04, and Debian 8, all of which are upstream EOL.
+
+<Note>
+  Distribution entries marked **TBD** will be filled in once coverage is confirmed with the team.
+</Note>
+
+## Distributions
+
+| Distro | Minimum release | Architectures | Notes |
+|---|---|---|---|
+| Ubuntu | TBD | TBD | TBD |
+| Debian | TBD | TBD | TBD |
+| Fedora | TBD | TBD | TBD |
+| RHEL / Alma / Rocky | TBD | TBD | TBD |
+| openSUSE | TBD | TBD | TBD |
+| Alpine | TBD | TBD | TBD |
+| Arch | rolling | TBD | TBD |
+
+## Reporting compatibility issues
+
+See [Report bugs and issues](/help/report-bug-issues). Include your distro, kernel version (`uname -r`), and NetBird client version (`netbird version`).

--- a/src/pages/help/support-matrix/netbird-client/macos.mdx
+++ b/src/pages/help/support-matrix/netbird-client/macos.mdx
@@ -1,0 +1,24 @@
+import { Warning } from '@/components/mdx'
+
+export const description =
+  'Supported macOS versions and architectures for the NetBird client.'
+
+# macOS
+
+The NetBird client supports the macOS versions listed below. The floor moves whenever NetBird upgrades its Go toolchain and Go drops an older macOS release.
+
+<Warning>
+  The version cutoffs below are derived from the [Go toolchain's minimum OS requirements](https://go.dev/wiki/MinimumRequirements) for each NetBird release's Go version. NetBird may have stricter requirements than Go — confirm with the team before relying on them.
+</Warning>
+
+## macOS versions
+
+| Version | Architectures | Version Supported |
+|---|---|---|
+| macOS 12 Monterey and newer | x86_64, arm64 | NetBird latest |
+| macOS 11 Big Sur | x86_64, arm64 | ≤ v0.62.3 |
+| macOS 10.15 Catalina | x86_64 | ≤ v0.29.1 |
+
+## Reporting compatibility issues
+
+See [Report bugs and issues](/help/report-bug-issues). Include your macOS version, hardware architecture, and NetBird client version (`netbird version`).

--- a/src/pages/help/support-matrix/netbird-client/tvos.mdx
+++ b/src/pages/help/support-matrix/netbird-client/tvos.mdx
@@ -1,0 +1,23 @@
+import { Note } from '@/components/mdx'
+
+export const description =
+  'Supported tvOS versions for the NetBird client.'
+
+# tvOS
+
+The NetBird client supports the tvOS versions listed below.
+
+<Note>
+  Entries marked **TBD** will be filled in once the support windows are confirmed with the team.
+</Note>
+
+## tvOS versions
+
+| Version | Devices | Version Supported |
+|---|---|---|
+| TBD | TBD | TBD |
+| TBD | TBD | TBD |
+
+## Reporting compatibility issues
+
+See [Report bugs and issues](/help/report-bug-issues). Include your tvOS version, device model, and NetBird client version.

--- a/src/pages/help/support-matrix/netbird-client/windows.mdx
+++ b/src/pages/help/support-matrix/netbird-client/windows.mdx
@@ -1,0 +1,25 @@
+import { Warning } from '@/components/mdx'
+
+export const description =
+  'Supported Windows versions and architectures for the NetBird client.'
+
+# Windows
+
+Windows 10 and 11 run on the latest NetBird client. Windows 7 and 8 are frozen at NetBird **v0.25.3** — the last release built with Go 1.20, the last Go toolchain to target those Windows versions. Older Windows releases may continue to work on pinned client versions but are not covered by bug fixes or security updates.
+
+<Warning>
+  The version cutoffs below are derived from the [Go toolchain's minimum OS requirements](https://go.dev/wiki/MinimumRequirements) for each NetBird release's Go version. NetBird may have stricter requirements than Go — confirm with the team before relying on them.
+</Warning>
+
+## Windows versions
+
+| Version | Architectures | Version Supported |
+|---|---|---|
+| Windows 11 | x86_64, arm64 | NetBird latest |
+| Windows 10 / Server 2016 and newer | x86_64, arm64 | NetBird latest |
+| Windows 8 / Server 2012 / 2012 R2 | all | ≤ v0.25.3 |
+| Windows 7 / Server 2008 R2 | all | ≤ v0.25.3 |
+
+## Reporting compatibility issues
+
+See [Report bugs and issues](/help/report-bug-issues). Include your Windows build (`winver`) and NetBird client version (`netbird version`).

--- a/src/pages/help/support-matrix/self-hosted.mdx
+++ b/src/pages/help/support-matrix/self-hosted.mdx
@@ -1,0 +1,30 @@
+import { Note } from '@/components/mdx'
+
+export const description =
+  'Operating systems and dependencies supported for self-hosted NetBird deployments.'
+
+# Self-Hosted Support Matrix
+
+The self-hosted NetBird stack is tested against the operating systems and dependency versions listed below. Running outside the supported window may work but is not covered by bug fixes or security updates.
+
+<Note>
+  Entries marked **TBD** will be filled in once the support windows are confirmed with the team.
+</Note>
+
+## Operating systems
+
+| OS | Architectures | Version Supported | Status |
+|---|---|---|---|
+| TBD | TBD | TBD | TBD |
+| TBD | TBD | TBD | TBD |
+
+## Dependencies
+
+| Component | Minimum version | Version Supported | Status |
+|---|---|---|---|
+| TBD | TBD | TBD | TBD |
+| TBD | TBD | TBD | TBD |
+
+## Reporting compatibility issues
+
+If you hit a problem on a supported platform, see [Report bugs and issues](/help/report-bug-issues). Include your deployment topology, host OS, and NetBird version.

--- a/src/pages/help/support-matrix/terraform-provider.mdx
+++ b/src/pages/help/support-matrix/terraform-provider.mdx
@@ -1,0 +1,30 @@
+import { Note } from '@/components/mdx'
+
+export const description =
+  'Terraform and NetBird API versions supported by the NetBird Terraform provider.'
+
+# Terraform Provider Support Matrix
+
+The NetBird Terraform provider is tested against the Terraform CLI and NetBird API versions listed below. Running against an unsupported combination may work but is not covered by bug fixes or security updates.
+
+<Note>
+  Entries marked **TBD** will be filled in once the support windows are confirmed with the team.
+</Note>
+
+## Terraform CLI versions
+
+| Provider version | Minimum Terraform | Maximum Terraform | Status |
+|---|---|---|---|
+| TBD | TBD | TBD | TBD |
+| TBD | TBD | TBD | TBD |
+
+## NetBird API compatibility
+
+| Provider version | Minimum NetBird API | Latest tested | Status |
+|---|---|---|---|
+| TBD | TBD | TBD | TBD |
+| TBD | TBD | TBD | TBD |
+
+## Reporting compatibility issues
+
+If you hit a problem on a supported combination, see [Report bugs and issues](/help/report-bug-issues). Include your provider version, Terraform version (`terraform version`), and NetBird API version.


### PR DESCRIPTION
## Summary

Adds a new **Support Matrix** section under *Get More Help* so users have an authoritative place to check what NetBird supports on each platform.

The section lives at `/help/support-matrix/` with:
- An **overview** introducing the matrix and linking out to each component.
- **NetBird Client** — launchpad + per-OS-family pages (Linux, Windows, macOS, iOS, Android, Android TV, tvOS), mirroring the `src/pages/get-started/install/` layout.
- **Kubernetes Operator** — policy-style page explaining the version-window approach (no tables yet; phrasing inspired by [spegel's dependency compatibility docs](https://spegel.dev/docs/releases/#dependency-compatibility)).
- **Terraform Provider** and **Self-Hosted** — TBD stubs for the team to fill in.

## Structure

```
src/pages/help/support-matrix/
├── index.mdx                          → Tiles to each component
├── netbird-client/
│   ├── index.mdx                      → Tiles to each OS + Go toolchain table
│   ├── linux.mdx
│   ├── windows.mdx
│   ├── macos.mdx
│   ├── ios.mdx
│   ├── android.mdx
│   ├── android-tv.mdx
│   └── tvos.mdx
├── kubernetes-operator.mdx
├── terraform-provider.mdx
└── self-hosted.mdx
```

`src/components/NavigationDocs.jsx` adds a nested **Support Matrix** entry to the `GET MORE HELP` group; **NetBird Client** is a sub-group with the seven OS pages as leaves (same 3-deep pattern as `Access Control` → `Posture Checks` → leaf).

## Pre-filled data

The **Go toolchain** table on the NetBird Client launchpad is authoritative — sourced from `go.mod` at each release tag:

| NetBird client version | Go version |
|---|---|
| v0.20.0 – v0.25.3 | 1.20 |
| v0.25.4 – v0.29.1 | 1.21 |
| v0.29.2 – v0.60.2 | 1.23 |
| v0.60.3 – v0.62.3 | 1.24 |
| v0.63.0 – current | 1.25 |

Linux / Windows / macOS pages pre-fill OS version cutoffs **derived** from Go's minimum OS requirements at each release's Go version. Each of those three pages opens with a Warning callout marking the cutoffs as inferences pending team confirmation — NetBird may have stricter requirements than Go. The Windows 7/8 cutoff at `v0.25.3` matches the existing data point.

iOS / Android / Android TV / tvOS pages and the Kubernetes operator / Terraform provider / Self-Hosted pages remain TBD placeholders — Go's reference doesn't map cleanly to gomobile / SDK constraints, and the rest are awaiting team input.

## Design choices

- Launchpads use `<Tiles>` (same as `use-cases/cloud/index.mdx`) for navigation. Version data lives on the detail page only, so a tile description never tries to summarize an arbitrarily large per-distro table.
- Each detail page has 2+ `##` sections so the right-side "On this page" TOC populates.
- New platforms scale: drop a new MDX into the matching directory, append one nav `links` entry.

## Test plan

- [x] `npm run build` passes; all 12 new routes prerender as static HTML.
- [x] Verify sidebar nesting renders (Support Matrix → NetBird Client → OS pages).
- [x] Verify "On this page" right-side TOC populates on each detail page.
- [x] Confirm with the team the derived OS cutoffs on Linux / Windows / macOS, then either remove the Warning callouts or refine the values.
- [x] Fill TBD entries on the mobile/TV pages, Kubernetes operator tables, Terraform provider, and self-hosted page.

## Screenshots

### Support Matrix overview
<img width="900" alt="Support Matrix overview page with Warning callout and 4-component tile grid" src="https://github.com/emrcbrn/docs/releases/download/support-matrix-pr-screenshots/01-overview.png" />

### Sidebar nesting (GET MORE HELP → Support Matrix → NetBird Client)
<img width="320" alt="Sidebar showing 3-deep nesting with Windows active" src="https://github.com/emrcbrn/docs/releases/download/support-matrix-pr-screenshots/06-sidebar-nesting.png" />

### NetBird Client launchpad
<img width="900" alt="NetBird Client landing page with OS tiles and authoritative Go toolchain table" src="https://github.com/emrcbrn/docs/releases/download/support-matrix-pr-screenshots/02-netbird-client.png" />

### Windows — derived data with Warning callout
<img width="900" alt="Windows page showing derived OS versions and Warning callout" src="https://github.com/emrcbrn/docs/releases/download/support-matrix-pr-screenshots/03-windows.png" />

### macOS — derived data with Warning callout
<img width="900" alt="macOS page showing derived OS versions and Warning callout" src="https://github.com/emrcbrn/docs/releases/download/support-matrix-pr-screenshots/05-macos.png" />

### Linux — kernel floor (derived) + distros (TBD)
<img width="900" alt="Linux page showing kernel table and distros TBD" src="https://github.com/emrcbrn/docs/releases/download/support-matrix-pr-screenshots/04-linux.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive Support Matrix documentation hub providing version compatibility information for NetBird Client across all platforms (Linux, Windows, macOS, iOS, Android, Android TV, tvOS), along with detailed support information for Kubernetes Operator, Terraform Provider, and Self-Hosted deployments. Includes guidance on reporting compatibility issues and understanding support status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/docs/pull/764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->