### PR TITLE
OPNsense checkbox "Show community plugins"

### DIFF
--- a/src/pages/get-started/install/opnsense.mdx
+++ b/src/pages/get-started/install/opnsense.mdx
@@ -23,7 +23,7 @@ there are both managed and [self-hosted](https://docs.netbird.io/selfhosted/self
 
 2. **Install the NetBird package**
 
-    In the OPNsense Web UI, navigate to `System` > `Firmware` > `Plugins`, Make sure `Show community plugins` is checked and search for the `os-netbird` package. Click the install button next to it.
+    In the OPNsense Web UI, navigate to `System` > `Firmware` > `Plugins`. Make sure `Show community plugins` is checked, then search for the `os-netbird` package and click the install button next to it.
 
 3. **Verify the installation**
 

--- a/src/pages/get-started/install/opnsense.mdx
+++ b/src/pages/get-started/install/opnsense.mdx
@@ -23,7 +23,7 @@ there are both managed and [self-hosted](https://docs.netbird.io/selfhosted/self
 
 2. **Install the NetBird package**
 
-    In the OPNsense Web UI, navigate to `System` > `Firmware` > `Plugins`, and search for the `os-netbird` package. Click the install button next to it.
+    In the OPNsense Web UI, navigate to `System` > `Firmware` > `Plugins`, Make sure `Show community plugins` is checked and search for the `os-netbird` package. Click the install button next to it.
 
 3. **Verify the installation**
 


### PR DESCRIPTION
OPNsense requires a new checkbox "Show community plugins" to be checked, before you can find the netbird plugin.

Tested on OPNsense 26.1.8_5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OPNsense installation instructions to clarify that you must enable "Show community plugins" before searching for and installing the NetBird plugin.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/docs/pull/765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->