### PR TITLE
docs: add Networks site-to-site use-case guide

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -215,6 +215,10 @@ export const docsNavigation = [
                 title: 'Site-to-VPN',
                 href: '/manage/networks/use-cases/site-to-vpn',
               },
+              {
+                title: 'Site-to-Site',
+                href: '/manage/networks/use-cases/site-to-site',
+              },
             ],
           },
         ],
@@ -464,15 +468,15 @@ export const docsNavigation = [
             links: [
               {
                 title: 'Getting Started',
-                href: '/manage/integrations/kubernetes'
+                href: '/manage/integrations/kubernetes',
               },
               {
                 title: 'Routing Peer',
-                href: '/manage/integrations/kubernetes/routing-peer'
+                href: '/manage/integrations/kubernetes/routing-peer',
               },
               {
                 title: 'Client Sidecar',
-                href: '/manage/integrations/kubernetes/client-sidecar'
+                href: '/manage/integrations/kubernetes/client-sidecar',
               },
               {
                 title: 'Gateway API',

--- a/src/pages/manage/network-routes/use-cases/site-to-site.mdx
+++ b/src/pages/manage/network-routes/use-cases/site-to-site.mdx
@@ -12,7 +12,9 @@ Site A device ──► Routing Peer ──► NetBird Tunnel ──► Routing 
 ```
 
 <Note>
-For one-way access from a NetBird peer to clientless devices behind a routing peer (VPN-to-Site), prefer [Networks](/manage/networks) — it has per-resource access control and simpler setup. Network Routes is required when you need Site-to-Site, source-IP preservation (masquerade disabled), or ACL Groups.
+For most site-to-site setups, prefer [Networks Site-to-Site](/manage/networks/use-cases/site-to-site) — it has per-Resource access control and is the actively developed system.
+
+Network Routes is still the right choice when you need site-to-site without any Policy gating traffic — the legacy "wide open" mode with empty Access Control Groups. Networks requires at least one Policy per Resource and has no equivalent.
 
 For the reverse — clientless devices at a site initiating connections to NetBird peers — see [Site-to-VPN](/manage/networks/use-cases/site-to-vpn).
 </Note>

--- a/src/pages/manage/networks/use-cases/site-to-site.mdx
+++ b/src/pages/manage/networks/use-cases/site-to-site.mdx
@@ -21,8 +21,7 @@ For the reverse — clientless devices at a site initiating connections to NetBi
 
 ## Prerequisites
 
-- A NetBird account ([cloud](https://app.netbird.io/) or [self-hosted](/selfhosted/selfhosted-quickstart))
-- An always-on device at each site to act as the routing peer (server, VM, Raspberry Pi, NAS with Docker)
+- An always-on device at each site to act as the routing peer
 - Different subnets at each site. If both sites use the same range (e.g. `192.168.1.0/24`), see [Overlapping Routes](/manage/network-routes/overlapping-routes)
 
 ## Example
@@ -60,15 +59,14 @@ Each site becomes its own Network: a Resource for that site's subnet, served by 
 
 1. Go to **Networks** → **Add Network**, name it `site-a`, and click **Create Network**
 2. Inside the network, click **Add Resource**:
-   - **Name:** `site-a-subnet`
-   - **Address:** `10.0.0.0/24`
-   - **Type:** Subnet
-   - **Groups:** create and add `site-a-cidr` (this group represents the subnet for use in policies)
+   - Enter a name like `site-a-subnet`
+   - Enter the address `10.0.0.0/24` (a subnet, or a single host like `10.0.0.50/32`)
+   - Expand **Additional Options** and under **Resource Groups**, create a group called `site-a-cidr` (this group represents the subnet for use in policies)
 3. Click **Add Routing Peer**, select the `site-a-routers` group, and leave **Masquerade** enabled (the default)
 
 **Network B:** repeat the steps — name `site-b`, Resource address `10.1.0.0/24` with group `site-b-cidr`, and routing peer group `site-b-routers`.
 
-## Step 4: Create policies
+## Step 4: Create access control policies
 
 Networks requires a Policy on every Resource — without one, the dashboard will not allow access to it. Add one Policy per Network:
 

--- a/src/pages/manage/networks/use-cases/site-to-site.mdx
+++ b/src/pages/manage/networks/use-cases/site-to-site.mdx
@@ -1,0 +1,134 @@
+import { Note } from '@/components/mdx'
+
+# Site-to-Site
+
+Site-to-Site connects two networks through routing peers at each end. Neither end-device needs NetBird installed — the routing peers forward traffic across the NetBird tunnel. This guide builds it with [Networks](/manage/networks), where each site is a Resource gated by its own Policy.
+
+## Architecture
+
+```
+Site A device ──► Routing Peer ──► NetBird Tunnel ──► Routing Peer ──► Site B device
+ (no NetBird)       (peer)                              (peer)         (no NetBird)
+```
+
+<Note>
+Networks is the recommended way to build site-to-site. It has per-Resource access control, is Zero Trust by default, and is the actively developed system.
+
+Use [Network Routes](/manage/network-routes/use-cases/site-to-site) instead only when you need site-to-site without any Policy gating traffic — the legacy "wide open" mode with empty Access Control Groups. Networks requires at least one Policy per Resource and has no equivalent.
+
+For the reverse — clientless devices at a site initiating connections to NetBird peers — see [Site-to-VPN](/manage/networks/use-cases/site-to-vpn).
+</Note>
+
+## Prerequisites
+
+- A NetBird account ([cloud](https://app.netbird.io/) or [self-hosted](/selfhosted/selfhosted-quickstart))
+- An always-on device at each site to act as the routing peer (server, VM, Raspberry Pi, NAS with Docker)
+- Different subnets at each site. If both sites use the same range (e.g. `192.168.1.0/24`), see [Overlapping Routes](/manage/network-routes/overlapping-routes)
+
+## Example
+
+Two sites, A and B:
+- Site A: `10.0.0.0/24`, routing peer group `site-a-routers`
+- Site B: `10.1.0.0/24`, routing peer group `site-b-routers`
+
+## Step 1: Create setup keys for each site
+
+Create one setup key per site with an auto-assigned group for that site's routing peers.
+
+1. Go to **Setup Keys** → **Create Setup Key**
+2. For Site A: name "Site A Routing Peer", auto-assign group `site-a-routers`
+3. Repeat for Site B with group `site-b-routers`
+
+<Note>
+You can also assign groups manually after the peer connects, under **Peers** → select peer → **Assigned Groups**.
+</Note>
+
+## Step 2: Install NetBird on the routing peers
+
+On each site's routing peer:
+
+```bash
+curl -fsSL https://pkgs.netbird.io/install.sh | sh
+sudo netbird up --setup-key YOUR_SETUP_KEY
+```
+
+## Step 3: Create a Network for each site
+
+Each site becomes its own Network: a Resource for that site's subnet, served by that site's routing peers.
+
+**Network A:**
+
+1. Go to **Networks** → **Add Network**, name it `site-a`, and click **Create Network**
+2. Inside the network, click **Add Resource**:
+   - **Name:** `site-a-subnet`
+   - **Address:** `10.0.0.0/24`
+   - **Type:** Subnet
+   - **Groups:** create and add `site-a-cidr` (this group represents the subnet for use in policies)
+3. Click **Add Routing Peer**, select the `site-a-routers` group, and leave **Masquerade** enabled (the default)
+
+**Network B:** repeat the steps — name `site-b`, Resource address `10.1.0.0/24` with group `site-b-cidr`, and routing peer group `site-b-routers`.
+
+## Step 4: Create policies
+
+Networks requires a Policy on every Resource — without one, the dashboard will not allow access to it. Add one Policy per Network:
+
+- **Network A's Resource:** Source Groups = `site-b-routers` → destination = the `site-a-subnet` Resource
+- **Network B's Resource:** Source Groups = `site-a-routers` → destination = the `site-b-subnet` Resource
+
+Tighten by protocol/port if needed; use **All** to allow any.
+
+## Step 5: Tell clientless devices about the remote subnet
+
+Devices without NetBird need a static route pointing to the local routing peer.
+
+**Router-level (recommended)** — add a static route on the site's router so all devices inherit it:
+
+```
+Destination: 10.1.0.0/24       # remote network
+Gateway:     10.0.0.50         # local routing peer
+```
+
+**Per-device fallback** — Linux:
+
+```bash
+sudo ip route add 10.1.0.0/24 via 10.0.0.50
+```
+
+Windows (PowerShell, persistent):
+
+```powershell
+route -p add 10.1.0.0 mask 255.255.255.0 10.0.0.50
+```
+
+<Note>
+The Linux `ip route add` form above applies only until the next reboot. For persistent Linux routes (Netplan or systemd-networkd), follow the same pattern shown in [Persistent configuration](/manage/networks/masquerade#persistent-configuration), substituting your remote site's CIDR (`10.1.0.0/24` in this example) for the destination shown there. The Windows `route -p add` form is already persistent.
+</Note>
+
+Repeat this on the other site with the values swapped, so Site B's router or devices know to reach `10.0.0.0/24` via the local Site B routing peer. Bidirectional site-to-site needs the static routes on both sides.
+
+This step assumes Masquerade is enabled on both routing peers (the default in Step 3), so reply traffic is handled by the destination's local LAN. If you disable Masquerade to preserve source IPs end to end, you'll also need return-direction static routes on the destination side so reply traffic can find its way home.
+
+## Step 6: Verify
+
+From Site A, ping a device at Site B:
+
+```bash
+ping 10.1.0.100
+```
+
+Reverse from Site B to confirm both directions work. The destination sees the connection coming from its local routing peer's LAN IP — source IPs are masqueraded at both routing peers.
+
+## Cloud routing peers
+
+When the routing peer is a cloud instance, the VPC needs to allow it to forward traffic on behalf of other addresses:
+
+- **AWS**: Disable the source/destination check on the routing peer's ENI. Add a VPC route table entry with the remote CIDR as the destination and the routing peer's ENI as the target. Security groups must allow traffic from the routing peer.
+- **GCP**: Enable IP forwarding on the instance. Add a custom route in the VPC with the remote CIDR as the destination and the routing peer instance as the next hop. Firewall rules must allow traffic from the routing peer's internal IP.
+- **Azure**: Enable IP forwarding on the routing peer's NIC. Add a route table entry with the remote CIDR pointing at the routing peer. Network security groups must allow the traffic.
+
+## Next steps
+
+- [Masquerade](/manage/networks/masquerade) — how source NAT works on routing peers
+- [Site-to-VPN](/manage/networks/use-cases/site-to-vpn) — clientless devices initiating connections to NetBird peers
+- [Access Home Devices](/manage/networks/use-cases/access-home-devices) — reach a single site from your NetBird peers
+- [Network Routes Site-to-Site](/manage/network-routes/use-cases/site-to-site) — the legacy approach, for wide-open no-policy setups

--- a/src/pages/manage/networks/use-cases/site-to-site.mdx
+++ b/src/pages/manage/networks/use-cases/site-to-site.mdx
@@ -64,6 +64,12 @@ Each site becomes its own Network: a Resource for that site's subnet, served by 
    - Expand **Additional Options** and under **Resource Groups**, create a group called `site-a-cidr` (this group represents the subnet for use in policies)
 3. Click **Add Routing Peer**, select the `site-a-routers` group, and leave **Masquerade** enabled (the default)
 
+<Note>
+Leave Masquerade enabled on both routing peers. NetBird's tunnel drops traffic whose source isn't the peer's NetBird IP, so Masquerade is what makes site-to-site work — disabling it on a routing peer breaks the flow. Masquerade is enabled by default everywhere, and the toggle to turn it off only exists on Linux.
+
+NetBird only performs the required outbound SNAT itself on Linux routing peers. Other platforms (OPNsense and pfSense are common examples) don't do this SNAT unless you configure it manually, so use a Linux routing peer for site-to-site.
+</Note>
+
 **Network B:** repeat the steps — name `site-b`, Resource address `10.1.0.0/24` with group `site-b-cidr`, and routing peer group `site-b-routers`.
 
 ## Step 4: Create access control policies
@@ -104,7 +110,7 @@ The Linux `ip route add` form above applies only until the next reboot. For pers
 
 Repeat this on the other site with the values swapped, so Site B's router or devices know to reach `10.0.0.0/24` via the local Site B routing peer. Bidirectional site-to-site needs the static routes on both sides.
 
-This step assumes Masquerade is enabled on both routing peers (the default in Step 3), so reply traffic is handled by the destination's local LAN. If you disable Masquerade to preserve source IPs end to end, you'll also need return-direction static routes on the destination side so reply traffic can find its way home.
+This step assumes Masquerade is enabled on both routing peers (the default in Step 3). Site-to-site over Networks requires Masquerade to be on — disabling it on a routing peer causes the WireGuard tunnel to drop traffic whose source isn't the peer's NetBird IP, so source-IP preservation isn't currently supported for site-to-site. If you need to preserve source IPs end to end, use the [Network Routes site-to-site setup](/manage/network-routes/use-cases/site-to-site) instead, which supports running with Masquerade disabled.
 
 ## Step 6: Verify
 


### PR DESCRIPTION
## Summary

Adds a canonical **Site-to-Site** use-case guide built on the Networks / Resources / Policies system, and repositions the legacy Network Routes guide as a narrow fallback.

NetBird's docs previously implied Networks couldn't do site-to-site (the legacy doc even stated "Network Routes is required when you need Site-to-Site"). That's incorrect — Networks fully supports two-routing-peer site-to-site, verified end-to-end in a lab. This guide documents the recommended pattern so customers migrating off legacy routes don't have to rediscover it.

## Changes

- **New page** `src/pages/manage/networks/use-cases/site-to-site.mdx` — full guide: architecture, prerequisites, example topology, setup keys, install, one Network per site (Resource + Routing Peer with Masquerade), policies, static routes (with persistence + bidirectional/return-route notes), verify, cloud routing peers, next steps.
- **Edit** `src/pages/manage/network-routes/use-cases/site-to-site.mdx` — replaced the top `<Note>` to make Networks the default recommendation; Network Routes is now scoped to the **wide-open, no-policy** case only (empty Access Control Groups). Source-IP/Masquerade is no longer cited as a differentiator since Masquerade toggles per Routing Peer in both systems.
- **Edit** `src/components/NavigationDocs.jsx` — added the new page to the sidebar under Networks → Use Cases.

## Notes

- Positioning is deliberate: Networks is the recommended, actively developed system; Network Routes remains only for wide-open site-to-site with no policy gating.
- `NavigationAPI.jsx` needs no change (page isn't under `ipa/`); no `next.config.mjs` redirect needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Site-to-Site connectivity setup guide covering architecture, prerequisites, and step-by-step configuration using NetBird's Networks system with policy-based access control.
  * Updated guidance clarifying when to use Networks versus Network Routes for site-to-site scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->