### PR TITLE
docs: document posture check evaluation timing and policy distribution

### DIFF
--- a/src/pages/manage/access-control/index.mdx
+++ b/src/pages/manage/access-control/index.mdx
@@ -349,6 +349,14 @@ Protocol: ALL
 
 This creates an unclear mesh where laptops, servers, and everything else can all access each other bidirectionally. It's impossible to tell from this policy what's actually happening, and you've likely granted more access than needed.
 
+## How Policy Changes Are Distributed
+
+When you create or change a policy, group, posture check, DNS setting, route, or network resource, NetBird distributes the updated configuration to all connected peers immediately. Peers receive the change without reconnecting.
+
+Distribution is event-driven. There is no periodic redistribution interval; updates are sent in response to configuration changes, not on a timer. When many changes happen in quick succession, NetBird coalesces them so connected peers receive a single consolidated update rather than one update per change.
+
+Posture checks follow the same distribution model. For how and when a posture check is evaluated for a peer, see [When Posture Checks Are Evaluated](/manage/access-control/posture-checks#when-posture-checks-are-evaluated).
+
 ## Advanced Patterns and Use Cases
 
 ### Pattern 1: Port Ranges for Application Suites

--- a/src/pages/manage/access-control/posture-checks/index.mdx
+++ b/src/pages/manage/access-control/posture-checks/index.mdx
@@ -117,6 +117,16 @@ If you revisit the `Posture Checks` dashboard, you'll notice a green dot next to
 
 Following these steps, you can effectively implement and manage NetBird's Posture Checks, significantly enhancing your network's security posture.
 
+## When Posture Checks Are Evaluated
+
+NetBird evaluates posture checks when a peer connects or logs in. The check result is computed at connection time and is not re-evaluated continuously for the duration of an active session.
+
+When you add or change a posture check on a policy, the updated configuration is distributed to connected peers immediately. A peer that is already connected is evaluated against the new check on its next connection. There is no periodic redistribution interval; distribution is driven by configuration changes, not a timer. For more on how changes reach peers, see [How Policy Changes Are Distributed](/manage/access-control#how-policy-changes-are-distributed).
+
+<Note>
+Because evaluation happens at connection time, a peer that passes a posture check and later changes state during a long-lived session (for example an operating system downgrade or a required process being stopped) is not re-evaluated until it reconnects. If you require enforcement to react to a peer changing state mid-session, account for this connection-time evaluation model in your design.
+</Note>
+
 ## Known Limitations
 
 ### Peer Network Range Check on Mobile Platforms


### PR DESCRIPTION
## Summary

Closes two documentation gaps that customers have asked about:

1. When are posture checks evaluated, and does a check apply to an already-connected peer?
2. Is there a redistribution interval for policy/check changes reaching connected peers?

### Changes

- **`manage/access-control/posture-checks`** — new **When Posture Checks Are Evaluated** section: checks are evaluated at peer connect/login; changes distribute to connected peers immediately and apply on the peer's next connection; no periodic redistribution interval. Includes a `<Note>` on the connection-time evaluation model (mid-session state changes such as an OS downgrade or a stopped process are not re-evaluated until reconnect).
- **`manage/access-control`** — new **How Policy Changes Are Distributed** section: distribution is event-driven, has no fixed interval, and coalesces rapid successive changes into a single update.

The two sections cross-link.

Both are same-page sections, so no navigation changes are required. Content is stated in NetBird's own voice with no external references.