### PR TITLE
add optional logout URL step to self-hosted IdP setup guides

### DIFF
--- a/src/pages/selfhosted/identity-providers/adfs.mdx
+++ b/src/pages/selfhosted/identity-providers/adfs.mdx
@@ -128,6 +128,8 @@ Write-Host "Client Secret: $($serverApp.ClientSecret)"
 
 Record both the **Client ID** and **Client Secret**. You will paste them into the NetBird dashboard in Step 2.
 
+*(Optional)* To let logout redirect back to NetBird, register NetBird's logout callback as an additional redirect URI — include `"https://<NETBIRD_FQDN>/oauth2/logout/callback"` in the `-RedirectUri` array above. ADFS validates the `post_logout_redirect_uri` against the registered redirect URIs.
+
 ### 1.3 Add a Web API
 
 The Web API resource shares the same identifier as the Server Application so the permission grant in Step 1.4 binds them together.

--- a/src/pages/selfhosted/identity-providers/authentik.mdx
+++ b/src/pages/selfhosted/identity-providers/authentik.mdx
@@ -94,6 +94,7 @@ Add Authentik as an external IdP directly in the NetBird Management Dashboard. T
 </p>
 
 3. Under **Redirect URIs/Origins**, add the redirect URL you copied from NetBird
+   - *(Optional)* Add a second **Strict** entry, `https://netbird.example.com/oauth2/logout/callback` (replace `netbird.example.com` with your NetBird dashboard domain), so logout redirects back to NetBird cleanly. Authentik validates post-logout redirects against this same allowlist.
 4. Select **Strict** (not Regex) to match the exact URL from NetBird
 
 <p>

--- a/src/pages/selfhosted/identity-providers/generic-oidc.mdx
+++ b/src/pages/selfhosted/identity-providers/generic-oidc.mdx
@@ -143,6 +143,11 @@ The redirect URL format is typically:
 https://your-netbird-domain.com/oauth2/callback/{connector-id}
 ```
 
+**(Optional) Logout redirect URI** — if your provider supports a post-logout (sign-out) redirect URI, also register NetBird's logout callback so logout redirects back to NetBird cleanly:
+```
+https://your-netbird-domain.com/oauth2/logout/callback
+```
+
 <Note>
 **Common issues:** Ensure the redirect URI matches exactly - no trailing slashes, correct protocol (https), and proper case sensitivity depending on your provider.
 </Note>

--- a/src/pages/selfhosted/identity-providers/keycloak.mdx
+++ b/src/pages/selfhosted/identity-providers/keycloak.mdx
@@ -110,6 +110,7 @@ Add Keycloak as an external IdP directly in the NetBird Management Dashboard. Th
 1. Return to the Keycloak Admin Console tab
 2. On the Login settings page:
    - Under **Valid redirect URIs**, paste the redirect URL you copied from NetBird
+   - *(Optional)* Under **Valid post logout redirect URIs**, add `https://netbird.example.com/oauth2/logout/callback` (replace `netbird.example.com` with your NetBird dashboard domain) so logout redirects back to NetBird cleanly
 3. Click **Save**
 4. Go to the **Credentials** tab and copy the **Client secret** — you'll need this for Step 6
 

--- a/src/pages/selfhosted/identity-providers/managed/auth0.mdx
+++ b/src/pages/selfhosted/identity-providers/managed/auth0.mdx
@@ -55,6 +55,7 @@ Add Auth0 as an external IdP directly in the NetBird Management Dashboard. This 
 1. Return to the Auth0 tab
 2. Go to **Settings** tab
 3. Under **Allowed Callback URLs**, add the redirect URL you copied from NetBird
+   - *(Optional)* Under **Allowed Logout URLs**, add `https://netbird.example.com/oauth2/logout/callback` (replace `netbird.example.com` with your NetBird dashboard domain) so logout redirects back to NetBird cleanly
 4. Click **Save Changes**
 
 <p>

--- a/src/pages/selfhosted/identity-providers/managed/duo.mdx
+++ b/src/pages/selfhosted/identity-providers/managed/duo.mdx
@@ -78,6 +78,10 @@ Add Duo as an external IdP directly in the NetBird Management Dashboard. This is
     <img src="/docs-static/img/selfhosted/identity-providers/managed/duo/5_redirect-urls.png" alt="Configure Redirect URLs" className="imagewrapper-big"/>
 </p>
 
+<Note>
+Duo SSO's generic OIDC relying party only exposes **Sign-In Redirect URLs** — there is no separate logout/sign-out redirect field, so no logout URL needs to be configured here.
+</Note>
+
 4. Under **Scopes**, ensure the following are enabled:
     - **openid** (required, cannot be disabled)
     - **profile** (check the box)

--- a/src/pages/selfhosted/identity-providers/managed/google-workspace.mdx
+++ b/src/pages/selfhosted/identity-providers/managed/google-workspace.mdx
@@ -67,6 +67,11 @@ Add Google as an external IdP directly in the NetBird Management Dashboard. This
 </p>
 
 4. Click **Create**
+
+<Note>
+Google's OAuth 2.0 client only supports **Authorized redirect URIs** — it has no separate logout/sign-out redirect field, so there is no logout URL to configure here.
+</Note>
+
 5. Note the **Client ID** and **Client Secret** — you'll need these for Step 4
 
 <p>

--- a/src/pages/selfhosted/identity-providers/managed/jumpcloud.mdx
+++ b/src/pages/selfhosted/identity-providers/managed/jumpcloud.mdx
@@ -83,6 +83,7 @@ Sometimes, the JumpCloud application configuration will add duplicate attributes
 1. Return to the JumpCloud tab
 2. Click the **SSO** tab
 3. Under **Redirect URIs**, verify the redirect URL matches the exact URL you copied from NetBird (e.g., `https://netbird.hopkins.sh/oauth2/callback`). If it doesn't match exactly, update it to match.
+   - *(Optional)* In the **Post Logout Redirect URIs** field, add `https://<your-netbird-domain>/oauth2/logout/callback` (using the same domain as the redirect URL) so logout redirects back to NetBird cleanly
 4. Click **Save** (if you made any changes)
 
 <p>

--- a/src/pages/selfhosted/identity-providers/managed/microsoft-entra-id.mdx
+++ b/src/pages/selfhosted/identity-providers/managed/microsoft-entra-id.mdx
@@ -87,6 +87,7 @@ Add Microsoft as an external IdP directly in the NetBird Management Dashboard. C
 2. Click **Add a platform** → **Web**
 3. In the dropdown next to the redirect URI field, select **Web**
 4. Paste the redirect URL you copied from NetBird in the **Redirect URI** field
+   - *(Optional)* Add NetBird's logout callback as an additional **Web** redirect URI: `https://netbird.example.com/oauth2/logout/callback` (replace `netbird.example.com` with your NetBird dashboard domain). Entra validates the post-logout redirect against the registered redirect URIs, so this lets logout return to NetBird cleanly.
 
 <p>
     <img src="/docs-static/img/selfhosted/identity-providers/managed/microsoft-entra-id/3_select-web-paste-uri-microsoft-entra.png" alt="Select web and paste URI" className="imagewrapper-big"/>

--- a/src/pages/selfhosted/identity-providers/managed/okta.mdx
+++ b/src/pages/selfhosted/identity-providers/managed/okta.mdx
@@ -72,6 +72,7 @@ Add Okta as an external IdP directly in the NetBird Management Dashboard. This i
 
 1. Return to the Okta tab
 2. In the **Sign-in redirect URIs** field, paste the redirect URL you copied from NetBird
+   - *(Optional)* In the **Sign-out redirect URIs** field, add `https://netbird.example.com/oauth2/logout/callback` (replace `netbird.example.com` with your NetBird dashboard domain) so logout redirects back to NetBird cleanly
 
 <p>
     <img src="/docs-static/img/selfhosted/identity-providers/managed/okta/5_sign-in-uri-okta.png" alt="Sign-in redirect URIs" className="imagewrapper-big"/>

--- a/src/pages/selfhosted/identity-providers/pocketid.mdx
+++ b/src/pages/selfhosted/identity-providers/pocketid.mdx
@@ -80,6 +80,7 @@ After saving, NetBird displays the **Redirect URL**. Copy this URL and add it to
 1. Return to PocketID console → **OIDC Clients**
 2. Edit your NetBird client
 3. Add the redirect URL to **Callback URLs**
+   - *(Optional)* In **Logout Callback URLs**, add `https://netbird.example.com/oauth2/logout/callback` (replace `netbird.example.com` with your NetBird dashboard domain) so logout redirects back to NetBird cleanly
 
 <p>
     <img src="/docs-static/img/selfhosted/identity-providers/self-hosted/pocketid/6_add-callback-url-pocketid.png" alt="Add callback URL" className="imagewrapper-big"/>

--- a/src/pages/selfhosted/identity-providers/zitadel.mdx
+++ b/src/pages/selfhosted/identity-providers/zitadel.mdx
@@ -87,6 +87,7 @@ Add Zitadel as an external IdP directly in the NetBird Management Dashboard. Thi
 
 1. Return to the Zitadel Console tab
 2. In the redirect URIs field, paste the redirect URL you copied from NetBird
+   - *(Optional)* In the **Post Logout URIs** field, add `https://netbird.example.com/oauth2/logout/callback` (replace `netbird.example.com` with your NetBird dashboard domain) so logout redirects back to NetBird cleanly
 
 <p>
     <img src="/docs-static/img/selfhosted/identity-providers/self-hosted/zitadel/07_add_redirect-uri-zitadel.png" alt="Add redirect URI" className="imagewrapper-big"/>


### PR DESCRIPTION
## Summary

Adds an optional step to the self-hosted Identity Provider setup guides showing how to register NetBird's logout callback URL (`https://netbird.example.com/oauth2/logout/callback`) so that signing out of NetBird redirects back cleanly through the IdP. The step is placed inline at the point where each guide configures the OIDC redirect URI, and names the correct field for each provider (the field label differs per IdP). Providers that don't expose a logout/sign-out redirect field get a short clarifying note instead of a step. `advanced/*` guides are intentionally untouched.

## Description

### What changed

Each guide gets the logout URL added as an **optional in-flow step** next to the existing redirect-URI step, using the same domain placeholder convention already used in that file (`netbird.example.com`, `<NETBIRD_FQDN>` for ADFS, `<your-netbird-domain>` for JumpCloud / Generic OIDC).

The logout URL is constant — `…/oauth2/logout/callback` — but where it goes differs per provider:

| Provider | Field referenced |
|----------|------------------|
| Keycloak | Valid post logout redirect URIs |
| Zitadel | Post Logout URIs |
| Auth0 | Allowed Logout URLs |
| Okta | Sign-out redirect URIs |
| Pocket ID | Logout Callback URLs |
| JumpCloud | Post Logout Redirect URIs |
| Authentik | Redirect URIs/Origins (Authentik validates post-logout against the same allowlist — added as a second Strict entry) |
| Microsoft Entra ID | Added as an additional Web redirect URI (Entra validates `post_logout_redirect_uri` against registered redirect URIs) |
| ADFS | Included in the `-RedirectUri` array (same reason) |
| Generic OIDC | Optional block: register it if your provider exposes a post-logout/sign-out redirect URI |

### Providers without a logout field

Duo (generic OIDC relying party exposes only *Sign-In Redirect URLs*) and Google Workspace (OAuth 2.0 client has only *Authorized redirect URIs*) have no logout/sign-out redirect field. Rather than document a step against a field that doesn't exist, these two pages get a short `<Note>` stating no logout URL needs to be configured.

### Note

The logout mechanism was inferred from the `/oauth2/logout/callback` path (treated as a post-logout *redirect* the IdP returns the browser to).

### Files changed

12 files under `src/pages/selfhosted/identity-providers/` (adfs, authentik, generic-oidc, keycloak, pocketid, zitadel, and managed/{auth0, duo, google-workspace, jumpcloud, microsoft-entra-id, okta}).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated identity provider configuration guides (ADFS, Authentik, Generic OIDC, Keycloak, Auth0, Duo, Google Workspace, JumpCloud, Microsoft Entra ID, Okta, PocketID, Zitadel) with optional instructions for configuring logout redirect URLs, enabling clean post-logout redirects back to NetBird.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->