### PR TITLE
Update ports-and-firewalls.mdx

### DIFF
--- a/src/pages/about-netbird/ports-and-firewalls.mdx
+++ b/src/pages/about-netbird/ports-and-firewalls.mdx
@@ -57,7 +57,7 @@ NetBird usually won't need open ports, but sometimes you or your IT team needs t
     * In more restricted environments, `netbird status` will show `keepalive ping failed` errors without a firewall rule for TURN
         * Example `nftables` outbound firewall rule: `ip daddr turn.netbird.io tcp dport 443-65535 accept`
 * Relay service:
-  * **Endpoint**: *.relay.netbird.io
+  * **Endpoints**: *.relay.netbird.io and relay.netbird.io
   * **Port**: TCP/443
   * **IPv4**: The list is dynamic and geo-distributed; When looking at the `netbird status -d` output, you can see which relay you are connecting to.
   * It is advised to wildcard `*.relay.netbird.io` when possible, to avoid interrupts.


### PR DESCRIPTION
adding relay.netbird.io as required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated relay service endpoint documentation to clarify that both the wildcard domain `*.relay.netbird.io` and specific hostname `relay.netbird.io` should be allowed through firewalls for proper relay service connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->