### PR TITLE
Change secure sharing link from onetimesecret to 1time

### DIFF
--- a/src/pages/manage/team/single-sign-on/authentik.mdx
+++ b/src/pages/manage/team/single-sign-on/authentik.mdx
@@ -74,6 +74,6 @@ You can use Authentik as your Identity Provider with NetBird, but it will requir
 
 <Note>
 We recommend using a secure channel to share the Client’s secret. You can send a separate email and use a secret sharing service like: <br/>
-https://onetimesecret.com/en/ <br/>
+https://1time.io/ <br/>
 https://password.link/en
 </Note>


### PR DESCRIPTION
Updated the recommended secure channel for sharing the client’s secret. onetimesecret.com is not secure enough, while 1time.io is a true zero-knowledge service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the recommended service for sharing Client Secrets in the Single Sign-On configuration guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->