### PR TITLE
Add note about NB_PPROF_ADDR environment variables

### DIFF
--- a/src/pages/selfhosted/environment-variables.mdx
+++ b/src/pages/selfhosted/environment-variables.mdx
@@ -125,6 +125,7 @@ These variables can override CLI flags at runtime. The naming convention is `NB_
 | `NB_DNS_DOMAIN` | DNS domain for peers |
 | `NB_DISABLE_GEOLITE_UPDATE` | Disable GeoLite database updates |
 | `NB_SETUP_PAT_ENABLED` | Enable optional Personal Access Token creation from `/api/setup` during initial setup. See [Automated Setup](/selfhosted/automated-setup). |
+| `NB_PPROF_ADDR` | The address of the Go pprof HTTP endpoint (e.g. `localhost:6060`). For profiling CPU, memory, and goroutine usage in production. |
 
 ### Advanced Runtime Variables
 
@@ -153,6 +154,7 @@ These variables can override CLI flags at runtime. The naming convention is `NB_
 | `NB_CERT_KEY` | TLS certificate key file |
 | `NB_LOG_LEVEL` | Log level |
 | `NB_LOG_FILE` | Log file path |
+| `NB_PPROF_ADDR` | The address of the Go pprof HTTP endpoint (e.g. `localhost:6060`). For profiling CPU, memory, and goroutine usage in production. |
 
 ## Relay Server Variables
 


### PR DESCRIPTION
Adds a note about the environment variables for overridding the default pprof listen addresses.

See: https://github.com/netbirdio/netbird/pull/6448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new runtime environment variable for configuring the Go pprof HTTP endpoint address in Management Server and Signal Server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->