### PR TITLE
Add self-hosted Environment Variables page to sidebar nav

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -542,6 +542,10 @@ export const docsNavigation = [
             href: '/selfhosted/maintenance/configuration-files',
           },
           {
+            title: 'Environment Variables',
+            href: '/selfhosted/environment-variables',
+          },
+          {
             title: 'Scaling Your Deployment',
             href: '/selfhosted/maintenance/scaling/scaling-your-self-hosted-deployment',
             isOpen: false,
@@ -994,7 +998,11 @@ function NavigationGroup({ group, className, hasChildren }) {
           }
           setIsOpen(!isOpen)
           if (!isOpen) {
-            if (!isActiveGroup && !isInsideMobileNavigation && group.links[0]?.href)
+            if (
+              !isActiveGroup &&
+              !isInsideMobileNavigation &&
+              group.links[0]?.href
+            )
               router.push(group.links[0].href)
             setActiveHighlight()
           } else {


### PR DESCRIPTION
## Summary

The self-hosted Environment Variables reference page (`src/pages/selfhosted/environment-variables.mdx`, served at `/selfhosted/environment-variables`) had **zero inbound links** — it wasn't in either sidebar, no page linked to it, and there was no redirect. It was only reachable by typing the URL directly or via search, despite existing since #553.

This adds it to the **Maintenance** group in the docs sidebar, immediately after "Configuration Files", grouping the two configuration-reference pages together.

Note: the existing "Environment Variables" entry under the client section (`/client/environment-variables`) is a different page about the client daemon; this one covers self-hosted Management/Signal/Relay/Dashboard variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Environment Variables" link to the self-hosted NetBird documentation under the Maintenance section, positioned between Configuration Files and Scaling Your Deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->