### PR TITLE
 Update Enterprise getting started

### DIFF
--- a/src/pages/selfhosted/enterprise/getting-started.mdx
+++ b/src/pages/selfhosted/enterprise/getting-started.mdx
@@ -1,21 +1,21 @@
-export const description = 'Deploy or migrate a self-hosted NetBird Enterprise Commercial stack with the built-in embedded identity provider using the getting-started.sh and migrate-to-commercial.sh scripts — no external OIDC provider required.'
+export const description = 'Deploy or migrate a self-hosted NetBird Enterprise Commercial stack with the built-in embedded identity provider using the getting-started-enterprise.sh and migrate-to-enterprise.sh scripts — no external OIDC provider required.'
 
 # Getting Started with NetBird Enterprise Commercial License
 
 Two scripts deploy enterprise self-hosted NetBird:
 
-- **Fresh installation** with `getting-started.sh`.
-- **Migration** from an existing community combined-server deployment with `migrate-to-commercial.sh`.
+- **Fresh installation** with `getting-started-enterprise.sh`.
+- **Migration** from an existing community combined-server deployment with `migrate-to-enterprise.sh`.
 
 The scripts generate the Compose files, configuration, secrets, and Postgres setup — plus optional traffic-flow services — so there's no manual YAML to write.
 
 Both run the **embedded identity provider**, so no external OIDC provider is required. On a fresh install, you create the owner account from the dashboard on first login; you can connect an external provider later.
 
-NetBird issues `getting-started.sh`, the GHCR credentials, and the license key with your [Enterprise Commercial License](https://netbird.io/pricing#on-prem). `migrate-to-commercial.sh` is available on request — contact your account team.
+NetBird issues `getting-started-enterprise.sh`, the GHCR token, and the license key with your [Enterprise Commercial License](https://netbird.io/pricing#on-prem). `migrate-to-enterprise.sh` is available on request — contact your account team.
 
 ## 1. Fresh Installation
 
-`getting-started.sh` deploys a single-node self-hosted NetBird stack with the embedded IdP. Management, signal, relay, and STUN run in one `netbird-server` container alongside Caddy, the dashboard, and Postgres.
+`getting-started-enterprise.sh` deploys a single-node self-hosted NetBird stack with the embedded IdP. Management, signal, relay, and STUN run in one `netbird-server` container alongside Caddy, the dashboard, and Postgres.
 
 ### 1.1 Prerequisites
 
@@ -24,7 +24,7 @@ NetBird issues `getting-started.sh`, the GHCR credentials, and the license key w
 - `bash`, `curl`, `jq`, and `openssl` available on the host.
 - A real DNS-resolvable FQDN with an A record pointing at the host. Bare IP addresses are not supported.
 - Open inbound ports: `80/tcp`, `443/tcp`, and `3478/udp`.
-- GHCR username and token associated with the enterprise license.
+- GHCR token (PAT) associated with the enterprise license.
 - An enterprise license key authorized for the products you want to enable.
 
 ### 1.2 Run the script
@@ -34,7 +34,7 @@ Create an empty directory and run the script from inside it:
 ```bash
 mkdir -p netbird-enterprise
 cd netbird-enterprise
-bash getting-started.sh
+curl -fsSL https://github.com/netbirdio/netbird/releases/latest/download/getting-started-enterprise.sh | bash
 ```
 
 The script prompts for:
@@ -42,7 +42,7 @@ The script prompts for:
 - Whether to enable traffic flow — required for traffic event logging and streaming.
 - The public NetBird domain.
 - A single license key (used for all enabled products and features).
-- GHCR username and token.
+- GHCR token (PAT).
 
 It then generates the deployment files, logs in to GHCR, pulls the required images, starts Postgres, waits for it to become ready, and starts the remaining services.
 
@@ -115,7 +115,7 @@ We recommend using SCIM provisioning where possible. In the following setup guid
 
 ## 3. Migrate an Existing Community Combined Deployment
 
-Use `migrate-to-commercial.sh` to convert an existing community combined-server deployment to the enterprise images. The same script also migrates SQLite data to Postgres and enables traffic flow, so no manual Compose or `config.yaml` edits are required for the supported migration path.
+Use `migrate-to-enterprise.sh` to convert an existing community combined-server deployment to the enterprise images. The same script also migrates SQLite data to Postgres and enables traffic flow, so no manual Compose or `config.yaml` edits are required for the supported migration path.
 
 <Note>
 The migration script is available on request — contact your account team to obtain it.
@@ -130,7 +130,7 @@ The script targets an existing combined-server deployment that has a `docker-com
 - `bash`, `openssl`, Docker, and Docker Compose are available on the host.
 - At least 5 GB of free disk space — the enterprise images (~2.2 GB) are pulled while the community images are still present (~1.5 GB extra), plus a SQLite backup and Postgres data.
 - `yq` is installed using the [Mike Farah implementation](https://github.com/mikefarah/yq); the Python wrapper is not supported.
-- GHCR username and token associated with the enterprise license.
+- GHCR token (PAT) associated with the enterprise license.
 - An enterprise license key authorized for the products you want to enable.
 - Access to the deployment directory that contains `docker-compose.yml`.
 
@@ -141,7 +141,7 @@ The script asks which steps to apply:
 | Step | What it does |
 | --- | --- |
 | Image swap | Replaces the community server and dashboard images with the enterprise images and adds the enterprise license key. |
-| Postgres migration | Adds Postgres, generates `config.yaml.commercial`, backs up the SQLite data volume, and runs `migrate-store --verify`. |
+| Postgres migration | Adds Postgres, generates `config.yaml.enterprise`, backs up the SQLite data volume, and runs `migrate-store --verify`. |
 | Traffic flow | Adds NATS, a flow receiver, and a flow enricher. Requires Postgres and traffic-flow licenses. |
 
 For SQLite deployments, the Postgres migration is handled by the script through the built-in `migrate-store` command. It copies the legacy SQLite stores (`store.db`, `integrations.db`, `events.db`, and `idp.db` when present) into Postgres and verifies row counts after the copy.
@@ -152,10 +152,10 @@ Run the script from the directory that contains the existing `docker-compose.yml
 
 ```bash
 cd /path/to/existing/netbird/deployment
-bash migrate-to-commercial.sh
+curl -fsSL https://github.com/netbirdio/netbird/releases/latest/download/migrate-to-enterprise.sh | bash
 ```
 
-The script detects the combined-server service name, the dashboard service name, the host path for `config.yaml`, the data volume mounted at `/var/lib/netbird`, and the Compose network. It then prompts for the license key, GHCR credentials, whether to migrate to Postgres, and whether to enable traffic flow.
+The script detects the combined-server service name, the dashboard service name, the host path for `config.yaml`, the data volume mounted at `/var/lib/netbird`, and the Compose network. It then prompts for the license key, GHCR token, whether to migrate to Postgres, and whether to enable traffic flow.
 
 ### 3.4 Files created by the migration script
 
@@ -164,9 +164,9 @@ The script does not modify the existing `docker-compose.yml` or original `config
 | File or directory | Purpose |
 | --- | --- |
 | `docker-compose.override.yml` | Compose override with the enterprise images and optional Postgres or traffic-flow services. |
-| `config.yaml.commercial` | Generated only when Postgres migration is selected. Points the enterprise server at Postgres. |
+| `config.yaml.enterprise` | Generated only when Postgres migration is selected. Points the enterprise server at Postgres. |
 | `.env` additions | License key and generated secrets used by the override file. |
-| `backups/sqlite-pre-commercial-*` | SQLite data backup created before the Postgres migration. |
+| `backups/sqlite-pre-enterprise-*` | SQLite data backup created before the Postgres migration. |
 
 Docker Compose automatically merges `docker-compose.override.yml` with the existing `docker-compose.yml`.
 
@@ -189,7 +189,7 @@ Rollback generally means:
 
 - Stop the stack with Docker Compose.
 - If Postgres migration was selected, remove the generated Postgres volume and restore the SQLite backup created by the script.
-- Remove `docker-compose.override.yml` and `config.yaml.commercial`.
+- Remove `docker-compose.override.yml` and `config.yaml.enterprise`.
 - Remove the migration entries added to `.env`.
 - Start the original stack again.
 
@@ -214,7 +214,7 @@ Each entry follows the same structure: **Symptom → Cause → Resolution → Ve
 
 - **Symptom:** The server boots, but the warning above appears and no flow events are written.
 - **Cause:** `server.trafficFlow.enabled: true` while running on SQLite.
-- **Resolution:** Run `migrate-to-commercial.sh`, select the Postgres migration step, and enable traffic flow when prompted. The warning disappears once the server runs with Postgres-backed stores and traffic flow enabled.
+- **Resolution:** Run `migrate-to-enterprise.sh`, select the Postgres migration step, and enable traffic flow when prompted. The warning disappears once the server runs with Postgres-backed stores and traffic flow enabled.
 - **Verification:** `psql -c '\dt' netbird` shows `network_traffic_events` (and related) tables; events appear in the dashboard's flow view.
 
 ### 4.3 Licensed features unavailable: `license is not valid`
@@ -256,13 +256,13 @@ Each entry follows the same structure: **Symptom → Cause → Resolution → Ve
   ```bash
   docker compose down --volumes   # removes containers and the postgres/embedded-IdP data
   rm -f .env docker-compose.yml Caddyfile config.yaml
-  bash getting-started.sh
+  curl -fsSL https://github.com/netbirdio/netbird/releases/latest/download/getting-started-enterprise.sh | bash
   ```
 - **Verification:** `curl -s https://<your-domain>/api/instance | jq .` returns `setupRequired: true`; the dashboard now shows the owner-setup flow on first visit.
 
 ### 4.8 `docker login ghcr.io` fails during the script
 
-- **Symptom:** `getting-started.sh` aborts at the GHCR login step with an authentication error.
+- **Symptom:** `getting-started-enterprise.sh` aborts at the GHCR login step with an authentication error.
 - **Cause:** The token lacks the `read:packages` scope, or the username does not match the one issued alongside the enterprise license.
 - **Resolution:** Confirm the token at [github.com/settings/tokens](https://github.com/settings/tokens) has `read:packages` scope, and that the username matches the one NetBird issued with the license.
 - **Verification:** `echo "$TOKEN" | docker login ghcr.io -u "<username>" --password-stdin` returns `Login Succeeded`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated getting-started and migration guides for Enterprise Commercial deployments
  * Installation and migration script references now use enterprise-specific versions
  * Configuration file naming conventions and generated artifacts updated for Enterprise
  * GHCR login instructions clarified to specify Personal Access Token (PAT) authentication
  * Backup file naming, rollback procedures, and troubleshooting steps updated to reflect Enterprise conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->