### PR TITLE
docs: add "Choosing a pattern" section to K8s getting started

### DIFF
--- a/src/pages/manage/integrations/kubernetes/index.mdx
+++ b/src/pages/manage/integrations/kubernetes/index.mdx
@@ -46,3 +46,26 @@ All pods should be in a `Running` state before continuing.
 NAME                               READY   STATUS    RESTARTS   AGE
 netbird-operator-b74984867-d68c8   1/1     Running   0          98s
 ```
+
+## Choosing a pattern
+
+The operator supports several ways to connect a cluster, and they answer **different questions** rather than competing with each other. Pick by **what you're exposing** and **whether each workload needs its own identity**.
+
+| Pattern | Exposes | Identity | Reach it via | Best for |
+|---|---|---|---|---|
+| [Routing Peer](/manage/integrations/kubernetes/routing-peer) | a `ClusterIP` Service | a shared routing peer | DNS name (`service.namespace.zone`) | stable internal services (databases, APIs) that many peers reach |
+| [Client Sidecar](/manage/integrations/kubernetes/client-sidecar) | the pod itself | the pod becomes its own peer | the pod's overlay IP | workloads that need their own identity or per-pod access rules (ephemeral CI jobs, per-pod audit) |
+| [API Server Proxy](/manage/integrations/kubernetes/api-server-proxy) | the Kubernetes API | your NetBird user | `netbird kubernetes` + `kubectl` | operating remote clusters with `kubectl` |
+| [Gateway API](/manage/integrations/kubernetes/gateway-api) <Badge status="experimental" text="Beta" /> | Services via Gateway CRDs | a gateway routing peer | route hostname / overlay | teams standardizing on Gateway API CRDs |
+
+### Rules of thumb
+
+- **Default to a routing peer** for "let my peers reach a service in this cluster." One routing peer fronts many services and is the cheapest to operate — see the [Route to a Kubernetes service](/manage/integrations/kubernetes/use-cases/route-to-a-kubernetes-service) how-to, including how to run it highly available.
+- **Reach for a client sidecar** only when per-pod identity matters. The pod becomes a first-class peer: it can be reached directly *and* originate connections out onto the NetBird network as itself. That's why a sidecar — not a routing peer — is the answer when a workload needs to *initiate* traffic onto the overlay. The cost is one peer per pod, so it's more to manage than a shared gateway.
+- **A routing peer exposes in-cluster services to your peers; it does not give other pods in the cluster a path out onto the overlay.** If an in-cluster workload needs to reach the NetBird network, give that pod a sidecar.
+- **The API Server Proxy is orthogonal** — it's about *operating* the cluster, not reaching the apps inside it. Combine it with any of the others.
+- **Gateway API is the future-standard surface but still Beta** — prefer the routing peer or sidecar for anything you depend on today.
+
+<Note>
+NetBird is deny-by-default and the operator does **not** write your access policies. Whichever pattern you choose, put your peers in a dedicated group (never `All`) and create a policy that allows the access you want.
+</Note>

--- a/src/pages/manage/integrations/kubernetes/index.mdx
+++ b/src/pages/manage/integrations/kubernetes/index.mdx
@@ -53,7 +53,7 @@ The operator supports several ways to connect a cluster, and they answer **diffe
 
 | Pattern | Exposes | Identity | Reach it via | Best for |
 |---|---|---|---|---|
-| [Routing Peer](/manage/integrations/kubernetes/routing-peer) | a `ClusterIP` Service | a shared routing peer | DNS name (`service.namespace.zone`) | stable internal services (databases, APIs) that many peers reach |
+| [NetworkRouter](/manage/integrations/kubernetes/routing-peer) | a `ClusterIP` Service | a shared routing peer | a DNS name in the NetworkRouter's zone (`service.namespace.<zone>`) | stable internal services (databases, APIs) that many peers reach |
 | [Client Sidecar](/manage/integrations/kubernetes/client-sidecar) | the pod itself | the pod becomes its own peer | the pod's overlay IP | workloads that need their own identity or per-pod access rules (ephemeral CI jobs, per-pod audit) |
 | [API Server Proxy](/manage/integrations/kubernetes/api-server-proxy) | the Kubernetes API | your NetBird user | `netbird kubernetes` + `kubectl` | operating remote clusters with `kubectl` |
 | [Gateway API](/manage/integrations/kubernetes/gateway-api) <Badge status="experimental" text="Beta" /> | Services via Gateway CRDs | a gateway routing peer | route hostname / overlay | teams standardizing on Gateway API CRDs |


### PR DESCRIPTION
## Summary

Adds a **Choosing a pattern** section to the Kubernetes operator Getting Started page. After installing the operator, readers face several ways to connect a cluster (routing peer, client sidecar, API server proxy, Gateway API) and currently have no guidance on which to pick. This section makes that choice explicit.

It adds:
- A decision table comparing **Routing Peer / Client Sidecar / API Server Proxy / Gateway API (Beta)** across *what they expose, identity, how you reach them, and what they're best for* — each linked to its reference page.
- Rules of thumb, including the common point of confusion: a **sidecar** (not a routing peer) is the answer when a pod needs its own identity or to originate traffic onto the overlay, and a routing peer exposes services to peers rather than giving in-cluster pods a path out.
- A deny-by-default note (the operator does not write your access policies).

## Changes

- `src/pages/manage/integrations/kubernetes/index.mdx` — new `## Choosing a pattern` section (+23 lines).

## Note

The routing-peer row links to the `use-cases/route-to-a-kubernetes-service` how-to, which is added in a separate PR. Merge that one first (or together) so the link resolves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on Kubernetes operator connection patterns, including a comparison table and recommendations for when to use each pattern (Routing Peer, Client Sidecar, API Server Proxy, Gateway API).
  * Clarified that NetBird is deny-by-default and users must create appropriate access policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->