### PR TITLE
Add RC Warning to Agent Network

### DIFF
--- a/src/pages/agent-network/index.mdx
+++ b/src/pages/agent-network/index.mdx
@@ -1,4 +1,4 @@
-import { Note } from '@/components/mdx'
+import { Note, Warning } from '@/components/mdx'
 
 export const description =
   'Agent Network is NetBird\'s control layer for AI agents — a keyless gateway to LLM APIs and scoped, identity-based access to your internal resources, all over the tunnel with per-identity policies, limits, and audit.'
@@ -8,6 +8,14 @@ export const description =
 <Note>
     Agent Network is currently in Beta. It is open source and can be self-hosted on your own infrastructure.
 </Note>
+
+<Warning>
+    Agent Network is available only as a **release candidate** ([v0.74.0-rc.2](https://github.com/netbirdio/netbird/releases/tag/v0.74.0-rc.2))
+    and is intended **for evaluation purposes only, not for production use**. You cannot yet enable it on an existing
+    self-hosted instance; the [Quickstart](/agent-network/quickstart) stands up a fresh deployment for evaluation.
+    Upgrading an existing instance will be supported on general availability and will require only a simple variable and
+    minor migration steps. This documentation will be updated on release.
+</Warning>
 
 As AI spreads across organizations, humans, agents, tools, and workflows need access to LLM APIs
 and internal systems. Too often, that access relies on shared API keys and broad network paths, creating credential

--- a/src/pages/agent-network/quickstart.mdx
+++ b/src/pages/agent-network/quickstart.mdx
@@ -1,4 +1,4 @@
-import { Note } from '@/components/mdx'
+import { Note, Warning } from '@/components/mdx'
 
 export const description =
   'Get an LLM request routed through NetBird Agent Network end to end: set up the NetBird server with the proxy, connect a provider, create a policy, and make your first keyless call.'
@@ -11,9 +11,18 @@ Agent Network.
 <Note>
     NetBird Agent Network is open source and self-hosted. This guide sets up a minimal deployment with core functionality;
     you can enable the full platform later.
-
-    It is currently in beta, and the setup process installs release candidate versions of the platform.
 </Note>
+
+<Warning>
+    Agent Network is currently available only as a **release candidate** ([v0.74.0-rc.2](https://github.com/netbirdio/netbird/releases/tag/v0.74.0-rc.2)).
+    The deployment created by this guide is intended **for evaluation purposes only and is not for production use**.
+
+    You **cannot yet enable Agent Network on an existing self-hosted instance**. The setup command below
+    stands up a fresh deployment with the release candidate. Upgrading an existing instance will be supported on
+    general availability and will require only a simple variable and minor migration steps.
+
+    This page will be updated on release with the required variables and full upgrade and migration instructions.
+</Warning>
 
 ## Infrastructure Requirements
 


### PR DESCRIPTION
<img width="1779" height="1191" alt="Screenshot From 2026-06-28 09-44-24" src="https://github.com/user-attachments/assets/fa983bfa-9c44-4373-b691-7195351c3bba" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added prominent warnings to the Agent Network overview and quickstart pages.
  * Clarified that Agent Network is currently available only as a release candidate for evaluation, not production use.
  * Noted that it can’t yet be enabled on existing self-hosted installations and requires a fresh deployment for now.
  * Updated guidance to set expectations about future upgrade support and migration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->