### PR TITLE
Add Agent Network access log session view

### DIFF
--- a/src/pages/agent-network/usage-and-logs/access-logs.mdx
+++ b/src/pages/agent-network/usage-and-logs/access-logs.mdx
@@ -1,5 +1,5 @@
 export const description =
-  'The per-request Agent Network access log: caller identity, provider, model, tokens, cost, decision, and reason, with server-side filtering.'
+  'The per-request Agent Network access log: caller identity, provider, model, tokens, cost, decision, and reason, with server-side filtering and a grouped-by-session view.'
 
 # Access Logs
 
@@ -22,6 +22,41 @@ and the reason a request was allowed or denied.
 - **Status** and **Reason** — for denials, the mapped policy reason; for
   allowed requests, a link to the policy that authorized it.
 
+## Sessions
+
+Use the **Requests / Sessions** switch above the log to change the view. The
+**Sessions** view groups related requests into a single session and shows one
+row per session, most recent activity first — so you can see the latest sessions
+at a glance.
+
+<p>
+    <img src="/docs-static/img/agent-network/usage-and-logs/agent-network-access-log-sessions.png" alt="agent network access logs grouped by session" className="imagewrapper-big" />
+</p>
+
+Some agents keep a session across many separate calls — for example,
+[Claude Code](/agent-network/integrations/claude-code) tags every request in a
+coding session with the same session id. Agent Network groups those requests
+together, so a whole session shows up as one row with its totals instead of
+dozens of individual entries.
+
+Each session row summarizes:
+
+- **Activity** — the session's time span, from its first request to its last.
+- **User / Agent** and **Auth Group** — the caller and the authorizing groups.
+- **Provider** — the provider and the model(s) used (e.g. `2 models`; hover to
+  see the full list).
+- **Requests** — how many requests the session made, and over what duration.
+- **Tokens** and **Cost** — summed across the whole session.
+- **Reason** — the session's policy decision; a denial if any request in the
+  session was blocked.
+
+Expand a session to see its individual requests — each with its timestamp, path,
+status, duration, model, tokens, and cost — and expand a request for its full
+detail (including the prompt and response when prompt capture is on).
+
+Requests from agents that don't set a session id each appear as their own
+single-request row.
+
 ## Filtering
 
 <p>
@@ -37,7 +72,8 @@ Filter the log by:
 - **Model**
 - **Path** — match requests whose path starts with a given prefix (e.g. `/v1/messages`).
 
-All filtering is applied server-side.
+All filtering is applied server-side and works in both the Requests and Sessions
+views.
 
 ## Availability
 


### PR DESCRIPTION
<img width="1354" height="948" alt="Screenshot 2026-07-01 at 16 01 16" src="https://github.com/user-attachments/assets/c4fe1dcb-b5e5-451b-ae4a-d8b69b14441e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated access log help content to cover both request-based and session-based views.
  * Added guidance on switching between Requests and Sessions, including what appears in each row and how to expand entries for more detail.
  * Clarified that server-side filtering works consistently in both views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->