### PR TITLE
Organize Agent Network Navigation

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -556,10 +556,16 @@ export const docsNavigation = [
   {
     title: 'AGENT NETWORK',
     links: [
-      { title: 'What is Agent Network?', href: '/agent-network' },
-      { title: 'How It Works', href: '/agent-network/how-it-works' },
-      { title: 'Quickstart', href: '/agent-network/quickstart' },
-      { title: 'Providers', href: '/agent-network/providers' },
+      {
+        title: 'Getting Started',
+        href: '/agent-network',
+        links: [
+          { title: 'What is Agent Network?', href: '/agent-network' },
+          { title: 'How It Works', href: '/agent-network/how-it-works' },
+          { title: 'Quickstart', href: '/agent-network/quickstart' },
+          { title: 'Providers', href: '/agent-network/providers' },
+        ],
+      },
       {
         title: 'Policies',
         href: '/agent-network/policies',
@@ -587,9 +593,9 @@ export const docsNavigation = [
             title: 'Log Collection & Retention',
             href: '/agent-network/usage-and-logs/log-collection',
           },
+          { title: 'Global Limits', href: '/agent-network/global-limits' },
         ],
       },
-      { title: 'Global Limits', href: '/agent-network/global-limits' },
       {
         title: 'Integrations',
         href: '/agent-network/integrations',


### PR DESCRIPTION
## Summary

Agent Network as it's own parent item in the sidebar navigation pushes self-hosting and client further down. Condensing this a bit helps.

### Before

<img width="1048" height="468" alt="Screenshot From 2026-07-07 09-20-19" src="https://github.com/user-attachments/assets/c434547c-5753-43c9-8fb2-2e2e8ebae034" />

### After Condensed

<img width="942" height="401" alt="Screenshot From 2026-07-07 09-10-39" src="https://github.com/user-attachments/assets/ee552e42-0bef-4813-8212-59887a43d623" />

### After Expanded

<img width="942" height="734" alt="Screenshot From 2026-07-07 09-11-11" src="https://github.com/user-attachments/assets/35d8eef4-67cc-44ab-a143-06d88e374f0f" />
