### PR TITLE
Remove Discription from Sizing Routing Peers Nav

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -201,9 +201,8 @@ export const docsNavigation = [
                         href: '/manage/networks/how-routing-peers-work',
                     },
                     {
+                        title: 'Sizing Routing Peers',
                         href: '/manage/networks/sizing-routing-peers',
-                        name: 'Sizing Routing Peers',
-                        description: 'Choose the size and number of routing peers from measured throughput',
                     },
                     {
                         title: 'Masquerade',


### PR DESCRIPTION
<img width="1876" height="913" alt="Screenshot From 2026-07-08 08-18-14" src="https://github.com/user-attachments/assets/79b5e279-e6d6-46e0-a7bc-91de184d63d1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated a documentation navigation entry so the “Sizing Routing Peers” link now uses the correct label format and continues to point to the same page.
  * Removed an outdated extra description from that navigation item, resulting in a cleaner docs menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->