### PR TITLE
build: use npm ci for clean, reproducible installs

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -22,9 +22,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Lint MDX heading hierarchy
         run: npm run lint:mdx

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,8 +10,8 @@ RUN npm install --global pm2
 # Utilise Docker cache to save re-installing dependencies if unchanged
 COPY ./package*.json ./
 
-# Install dependencies
-RUN npm install --production
+# Install dependencies (npm ci = clean, reproducible install from the lockfile)
+RUN npm ci --omit=dev
 
 # Copy all files
 COPY ./ ./


### PR DESCRIPTION
## Why

Now that the lockfile is tracked (#838), switch installs to `npm ci` for clean, deterministic, lockfile-pinned installs. Third of the docs build/deploy speed series.

## What

- `pr-build.yml`: `npm install` → `npm ci`, and enable `setup-node`'s `cache: 'npm'` (caches `~/.npm` keyed on the lockfile).
- `docker/Dockerfile`: `npm install --production` → `npm ci --omit=dev`.

## Impact

- Deterministic installs from the lockfile (no more re-resolving `^` ranges).
- Faster, cache-assisted installs on PR CI.
- CI now **fails fast on an out-of-sync lockfile** — the intended safety net (documented in CLAUDE.md via #838).

## Testing

Ran both install paths in an isolated dir (did not touch the repo's `node_modules`):
- `npm ci --omit=dev` (Docker path): exit 0; `next` 16.1.6, react, shiki present; eslint/prettier correctly omitted.
- full `npm ci` (pr-build path): exit 0; devDeps present.

## Depends on

- #838 (lockfile tracked) — merged. ✅

## Test plan

- [x] `npm ci` in sync with committed lockfile (both `--omit=dev` and full)
- [x] `pr-build` CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and container dependency installation to use cleaner, lockfile-based installs.
  * Enabled dependency caching in the build workflow to help speed up repeated runs.
  * Improved install consistency by omitting development-only packages in production image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->