### PR TITLE
Document Agent Network focused dashboard view

### DIFF
--- a/src/pages/agent-network/index.mdx
+++ b/src/pages/agent-network/index.mdx
@@ -77,6 +77,16 @@ That makes agent access a natural responsibility for IT.
 Because NetBird connects seamlessly with existing identity providers, IT teams can integrate NetBird Agent Network into
 their enterprise stack with minimal changes.
 
+## Focused dashboard view
+
+Some accounts open directly into the Agent Network view, with the rest of the
+NetBird dashboard (Peers, Networks, DNS, and so on) hidden to keep the
+experience focused on agents. This is the default for accounts onboarded
+specifically for Agent Network.
+
+To use the full NetBird platform, go to **Settings** and turn off **Agent
+Network focused view**. You can re-enable it at any time from the same place.
+
 ## Next steps
 
 - [Quickstart](/agent-network/quickstart). Deploy NetBird Agent Network and make your first routed LLM call.


### PR DESCRIPTION
Documents the Agent Network focused dashboard view and how to switch to the full NetBird dashboard.

Some accounts (those onboarded specifically for Agent Network, e.g. netbird.ai signups) open directly into the Agent Network view with the rest of the dashboard hidden. This adds a short "Focused dashboard view" section to the Agent Network overview explaining the behavior and the **Settings → Agent Network focused view** toggle to turn it off.

Framed by behavior + the toggle rather than tied to a specific signup source, so it stays accurate for self-hosted readers.

Pairs with the dashboard implementation (netbirdio/dashboard#708) and the backend setting (netbirdio/netbird#6736). The API reference is generated automatically, so only this narrative note is added by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance about the Agent Network focused dashboard view.
  * Explained that Agent Network accounts open directly to the Agent Network view.
  * Documented how to disable focused view in Settings to access the full platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->