### PR TITLE
Add "Record a HAR file" troubleshooting page

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -1059,9 +1059,22 @@ export const docsNavigation = [
                         title: 'Report a bug',
                         isOpen: false,
                         links: [
-                            { title: 'Overview', href: '/help/report-bug-issues' },
-                            { title: 'Community Support', href: '/help/community-support' },
-                            { title: 'NetBird Support', href: '/help/netbird-support' },
+                            {
+                                title: 'Overview',
+                                href: '/help/report-bug-issues',
+                                isOpen: false,
+                                links: [
+                                    {
+                                        title: 'Community Support',
+                                        href: '/help/community-support',
+                                    },
+                                    {
+                                        title: 'NetBird Support',
+                                        href: '/help/netbird-support',
+                                    },
+                                ],
+                            },
+                            { title: 'Record a HAR file', href: '/help/recording-a-har-file' },
                         ],
                     },
                 ],

--- a/src/pages/help/community-support.mdx
+++ b/src/pages/help/community-support.mdx
@@ -15,7 +15,7 @@ export const description =
   ]}
 />
 
-Whichever channel you choose, include a [debug bundle](/help/troubleshooting-client#debug-bundle), your NetBird version (`netbird version`), and clear steps to reproduce.
+Whichever channel you choose, include a [debug bundle](/help/troubleshooting-client#debug-bundle), your NetBird version (`netbird version`), and clear steps to reproduce. For dashboard, login, or reverse-proxy issues, also [record a HAR file](/help/recording-a-har-file).
 
 ## Community Slack
 

--- a/src/pages/help/netbird-support.mdx
+++ b/src/pages/help/netbird-support.mdx
@@ -43,9 +43,10 @@ export const supportMailto = `mailto:support@netbird.io?subject=${encodeURICompo
   links={[
     { label: "Open a pre-filled support email", href: supportMailto },
     { label: "Attach a debug bundle", href: "/help/troubleshooting-client#debug-bundle" },
+    { label: "Record a HAR file", href: "/help/recording-a-har-file" },
   ]}
 />
 
-Reach the team by opening a <a href={supportMailto}>pre-filled support email</a>. It drops a ready-to-fill report into your mail client, with the fields we need already laid out, so you only fill in the blanks. Prefer to write it yourself? Email [support@netbird.io](mailto:support@netbird.io) and include a [debug bundle](/help/troubleshooting-client#debug-bundle), your NetBird version, and clear steps to reproduce.
+Reach the team by opening a <a href={supportMailto}>pre-filled support email</a>. It drops a ready-to-fill report into your mail client, with the fields we need already laid out, so you only fill in the blanks. Prefer to write it yourself? Email [support@netbird.io](mailto:support@netbird.io) and include a [debug bundle](/help/troubleshooting-client#debug-bundle), your NetBird version, and clear steps to reproduce. For dashboard, login, or reverse-proxy issues, also [record a HAR file](/help/recording-a-har-file).
 
 Not a Cloud or commercial-license customer? [Community Support](/help/community-support), through Slack and GitHub Discussions, is the right place.

--- a/src/pages/help/recording-a-har-file.mdx
+++ b/src/pages/help/recording-a-har-file.mdx
@@ -1,0 +1,46 @@
+import {Note, Warning} from "@/components/mdx"
+
+export const description =
+  "How to record a HAR file in Chrome, Edge, Firefox, or Safari, and share it safely with NetBird Support to debug dashboard, login, and reverse-proxy issues."
+
+# Record a HAR file
+
+When something breaks in the browser, like the dashboard failing to load, an SSO login that never completes, or a reverse proxy returning errors, the problem lives in the traffic between your browser and the server. A [debug bundle](/help/troubleshooting-client#debug-bundle) captures the client and daemon, but it can't see any of that. A HAR file can.
+
+A HAR (HTTP Archive) file is a recording of every network request your browser made, with the timing, headers, and responses for each. Recording one while you reproduce the failing action gives Support the exact exchange your browser had with the server, so we can see what actually went wrong instead of guessing from a description.
+
+<Warning>
+A HAR file contains everything your browser sent and received, including cookies, authorization headers, session tokens, and request and response bodies. Treat it like a live credential: share it **only** with NetBird Support through a private channel, never in a public GitHub Discussion or issue. Where your browser offers a **sanitized** export (Chrome and Edge do), prefer it. If a HAR with live tokens is exposed, sign out to invalidate the session.
+</Warning>
+
+## Before you record
+
+Two things trip people up, so set them first:
+
+- **Open DevTools before you reproduce the problem.** A HAR only contains requests captured while the Network tab was recording. Anything that happened before you opened it is lost.
+- **Turn on "Preserve log" (Chrome, Edge) or "Persist Logs" (Firefox).** Login and SSO flows redirect the page one or more times, and by default each navigation clears the log, wiping the exact requests that failed. Preserving the log keeps everything across redirects.
+
+## Record and export
+
+The flow is the same in every browser:
+
+1. Open **DevTools** (`F12`, or right-click the page and choose **Inspect**) and select the **Network** tab.
+2. Enable **Preserve log** / **Persist Logs**.
+3. Clear the current log so the capture is clean.
+4. Reproduce the problem, following the same steps that fail. Wait for it to fail before stopping.
+5. Export everything as a `.har` file.
+
+The export step, per browser:
+
+- **Google Chrome** — in the Network tab, click the download (export) icon, or right-click any request and choose **Save all as HAR (sanitized)**. See [Save network requests to a HAR file](https://developer.chrome.com/docs/devtools/network/reference/#save-as-har).
+- **Microsoft Edge** — Edge uses the same DevTools as Chrome: right-click a request and choose **Save all as HAR (sanitized)**, or use the export icon. See [Network features reference](https://learn.microsoft.com/en-us/microsoft-edge/devtools/network/reference).
+- **Mozilla Firefox** — in the Network tab, right-click a request (or use the settings menu) and choose **Save All As HAR**. See [Network Monitor toolbar](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/toolbar/index.html).
+- **Safari** — first enable the Develop menu (**Settings → Advanced → Show features for web developers**), then open **Web Inspector** (`⌥⌘I`) and select the **Network** tab. Use the **Export** button to save the recording as a `.har` file. Apple's [Network tab](https://support.apple.com/guide/safari-developer/network-tab-dev1f3525e58/mac) reference covers the tab itself but not the export, which lives in the top-right of the Network tab.
+
+<Note>
+On Chrome and Edge, the plain **Save all as HAR** option includes sensitive headers, while **Save all as HAR (sanitized)** strips them. Use the sanitized version unless Support asks for the full capture.
+</Note>
+
+## Share it with NetBird
+
+Attach the `.har` file to your existing conversation with the team: reply to your [NetBird Support](/help/netbird-support) email, or send it in the channel Support asked you to use. If you were sent here without an open case, start from [Report bugs and issues](/help/report-bug-issues) to reach the right place. Keep it off public channels, for the reasons in the warning above.

--- a/src/pages/help/report-bug-issues.mdx
+++ b/src/pages/help/report-bug-issues.mdx
@@ -5,7 +5,7 @@ export const description =
 
 # Report bugs and issues
 
-NetBird offers two ways to get help, depending on what you are running. Pick the one that fits. Whichever you use, include a [debug bundle](/help/troubleshooting-client#debug-bundle), your NetBird version (`netbird version`), and clear steps to reproduce.
+NetBird offers two ways to get help, depending on what you are running. Pick the one that fits. Whichever you use, include a [debug bundle](/help/troubleshooting-client#debug-bundle), your NetBird version (`netbird version`), and clear steps to reproduce. For dashboard, login, or reverse-proxy issues, also [record a HAR file](/help/recording-a-har-file).
 
 <Tiles
   title="Where to report"


### PR DESCRIPTION
## What

Adds a dedicated **Record a HAR file** how-to at `/help/recording-a-har-file`, under Troubleshooting → Report a bug. Support regularly needs a HAR to debug dashboard, login/SSO, and reverse-proxy issues, and there was no page to point people to.

The page:
- Explains what a HAR is and why Support asks for it: the failure is in browser↔server traffic that a debug bundle can't capture.
- Leads with a security warning: a HAR carries cookies, auth headers, and session tokens, so share it privately and prefer the sanitized export.
- Names the two common mistakes: open DevTools *before* reproducing, and enable "Preserve log" so SSO redirects don't wipe the capture.
- Links each browser's official export docs (Chrome, Edge, Firefox), with inline steps for Safari since Apple doesn't document the export.

## Nav & cross-links

- Nested Community/NetBird Support under the Report a bug **Overview** item, so the new page reads as a sibling of the reporting cluster rather than a fourth flat peer.
- Cross-linked the HAR page from both support pages and the Report bugs overview, next to the existing debug-bundle mention.

## Screenshots

New page, dark and light:

| Dark | Light |
| --- | --- |
| <img src="https://raw.githubusercontent.com/emrcbrn/docs/pr-assets-har/pr-assets/har-page-dark.png" width="400"> | <img src="https://raw.githubusercontent.com/emrcbrn/docs/pr-assets-har/pr-assets/har-page-light.png" width="400"> |

Report a bug submenu (Overview → Community/NetBird, HAR as sibling) and the cross-link in context:

<img src="https://raw.githubusercontent.com/emrcbrn/docs/pr-assets-har/pr-assets/nav-report-bug-dark.png" width="900">

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a help page explaining how to record, export, and securely share HAR files.
  * Added navigation for the new HAR recording guidance.

* **Documentation**
  * Updated bug-reporting and support instructions to request debug bundles, version details, reproduction steps, and HAR files for dashboard, login, or reverse-proxy issues.
  * Added warnings about sensitive information in HAR files and advised sharing them privately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->