### PR TITLE
Update reverse proxy docs for Rosenpass support

### DIFF
--- a/src/pages/manage/reverse-proxy/index.mdx
+++ b/src/pages/manage/reverse-proxy/index.mdx
@@ -13,9 +13,9 @@ NetBird Reverse Proxy lets you expose internal services running on peers or behi
 <Note>
     **Self-hosted requirement:** Self-hosted deployments **must** use [Traefik](/selfhosted/external-reverse-proxy) as their external reverse proxy. Traefik is the only supported reverse proxy that provides TLS passthrough, which is required for the Reverse Proxy feature to function correctly.
 </Note>
-<Warning>
-    The Reverse Proxy feature does not currently support Rosenpass. If your network relies on this feature, reverse proxy services will not function as expected.
-</Warning>
+<Note>
+    **Rosenpass:** The Reverse Proxy works with [Rosenpass](/client/post-quantum-cryptography)-enabled peers. The proxy runs Rosenpass in permissive mode, establishing a post-quantum-secured tunnel with peers that have Rosenpass enabled and falling back to standard WireGuard for peers that do not. Self-hosted deployments can turn this off with `NB_PROXY_ROSENPASS=false` on the proxy, but then Rosenpass-enabled peers cannot be reached through the proxy.
+</Note>
 
 ## How it works
 


### PR DESCRIPTION
## Summary

Update the Reverse Proxy page now that the embedded proxy supports Rosenpass-enabled peers.

- Replace the warning that the Reverse Proxy does not support Rosenpass with a note explaining it now works: the proxy runs Rosenpass in permissive mode, establishing post-quantum-secured tunnels with Rosenpass-enabled peers and falling back to standard WireGuard for peers without it.
- Document the `NB_PROXY_ROSENPASS=false` opt-out for self-hosted proxies.

Draft until the embedded proxy Rosenpass support ships (netbirdio/netbird#6763).

## Screenshots

`/manage/reverse-proxy` (Rosenpass note):

<img width="1920" height="1080" alt="reverse-proxy-rosenpass-note-clean-2026-07-14T12-54-05-744Z" src="https://github.com/user-attachments/assets/81a474d3-24d6-40dd-9176-f1950b271f50" />
