### PR TITLE
Link Reverse Proxy troubleshooting under Connectivity

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -1031,6 +1031,10 @@ export const docsNavigation = [
                                 href: '/help/troubleshooting-resource-connectivity',
                             },
                             {
+                                title: 'Reverse Proxy',
+                                href: '/manage/reverse-proxy/troubleshooting',
+                            },
+                            {
                                 title: 'NAT & Connectivity',
                                 href: '/about-netbird/understanding-nat-and-connectivity',
                             },

--- a/src/pages/help/troubleshooting.mdx
+++ b/src/pages/help/troubleshooting.mdx
@@ -39,7 +39,6 @@ next to the feature they cover, so nothing here is a copy.
         { label: "Signal service", href: "/about-netbird/how-netbird-works#signal-service" },
         { label: "Relay / TURN", href: "/selfhosted/troubleshooting/connectivity#debugging-turn-connections" },
         { label: "Dashboard", href: "/selfhosted/troubleshooting/dashboard" },
-        { label: "Reverse proxy", href: "/manage/reverse-proxy/troubleshooting" },
       ],
     },
     {
@@ -65,6 +64,7 @@ next to the feature they cover, so nothing here is a copy.
       chips: [
         { label: "Relayed connections", href: "/help/troubleshooting-relayed-connections" },
         { label: "Resource connectivity", href: "/help/troubleshooting-resource-connectivity" },
+        { label: "Reverse proxy", href: "/manage/reverse-proxy/troubleshooting" },
         { label: "NAT & firewall ports", href: "/about-netbird/ports-and-firewalls" },
         { label: "DNS", href: "/manage/dns/troubleshooting" },
         { label: "Network routes", href: "/manage/network-routes" },


### PR DESCRIPTION
## What

Surfaces the existing **Reverse Proxy troubleshooting** page (`/manage/reverse-proxy/troubleshooting`) in the Troubleshooting section. That page is about reaching services exposed through routing peers (502s, target type Peer vs Host/Subnet, service binding) — a connectivity concern, not self-hosted control-plane infrastructure — but it wasn't referenced from Troubleshooting at all.

- **Sidebar:** added **Reverse Proxy** to Troubleshooting → Connectivity, right after Resource Connectivity.
- **Hub:** moved the **Reverse proxy** chip from the Self-hosted card to Connectivity & networking, so the hub and sidebar agree on where it lives.

No new page and no duplicated content — both are links to the one existing page, consistent with how the Troubleshooting section indexes troubleshooting docs that live next to their feature.

## Screenshots

Sidebar — Connectivity now lists Reverse Proxy:

<img src="https://raw.githubusercontent.com/emrcbrn/docs/pr-assets-reverse-proxy/pr-assets/nav-connectivity-dark.png" width="900">

Hub — Reverse proxy moved from Self-hosted to Connectivity & networking:

<img src="https://raw.githubusercontent.com/emrcbrn/docs/pr-assets-reverse-proxy/pr-assets/hub-cards-dark.png" width="440">

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Reverse Proxy” troubleshooting link under Connectivity → Resource Connectivity.
  * Reorganized the “Reverse proxy” troubleshooting link from the Self-hosted section to Connectivity & networking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->