### PR TITLE
Surface the DC WireGuard port conflict in the troubleshooting flow

### DIFF
--- a/src/pages/help/troubleshooting-client/windows.mdx
+++ b/src/pages/help/troubleshooting-client/windows.mdx
@@ -41,6 +41,7 @@ DNS on Windows has a few platform-specific failure modes worth checking separate
 
 - **Match-domain names don't resolve, even though the NRPT (Name Resolution Policy Table) rule was written.** A lingering Group Policy `DnsPolicyConfig` container can stop NetBird's rule from taking effect on an off-domain machine. See [DNS Troubleshooting: Issue 8 (lingering GPO)](/manage/dns/troubleshooting#issue-8-windows-nrpt-rule-is-written-but-never-takes-effect-lingering-gpo).
 - **Active Directory login, mapped drives, or DFS fail** while a file share by IP works. This is usually a DC-locator (`SRV` record) problem. See [Domain Controllers as routing peers](/manage/dns/internal-dns-servers#domain-controllers-as-routing-peers).
+- **NetBird won't start on a Domain Controller** and the peer shows disconnected. The Windows DNS Server service can claim WireGuard's UDP port 51820 before NetBird does, so the tunnel never comes up. See [WireGuard port conflict on Domain Controllers](/manage/dns/internal-dns-servers#wire-guard-port-conflict-on-domain-controllers).
 
 <Note>
 For the full DNS diagnostic flow on any platform, see [DNS Troubleshooting](/manage/dns/troubleshooting).

--- a/src/pages/manage/dns/troubleshooting.mdx
+++ b/src/pages/manage/dns/troubleshooting.mdx
@@ -473,6 +473,10 @@ A domain resource only resolves `A`/`AAAA` records. Active Directory also depend
 - Add a **DNS nameserver** with match domain `corp.example.com` pointing at the DC's IP, distributed to your remote-users group — see [Active Directory & Windows File Shares → Give clients corp DNS](/use-cases/remote-access/active-directory#step-5-give-clients-corp-dns).
 - Confirm the DC itself is reachable through the routing peer on the AD ports — see [Reaching a Domain Controller through a routing peer](/manage/dns/internal-dns-servers#reaching-a-domain-controller-through-a-routing-peer).
 
+<Note>
+Running the NetBird client directly **on** a Domain Controller is a separate case: it can fail to start when the Windows DNS Server service has already claimed WireGuard's UDP port 51820. See [WireGuard port conflict on Domain Controllers](/manage/dns/internal-dns-servers#wire-guard-port-conflict-on-domain-controllers).
+</Note>
+
 ---
 
 ### Issue 8: Windows NRPT rule is written but never takes effect (lingering GPO)


### PR DESCRIPTION
## What

The "WireGuard port conflict on Domain Controllers" guidance (on [/manage/dns/internal-dns-servers](https://docs.netbird.io/manage/dns/internal-dns-servers#wire-guard-port-conflict-on-domain-controllers)) wasn't reachable from the Troubleshooting section at all — the only direct link to it lived on the Active Directory use-case page. This adds two cross-links so a troubleshooting-hub user can get to it:

- **Windows client troubleshooting** ([`windows.mdx`](../blob/docs/link-dc-port-conflict/src/pages/help/troubleshooting-client/windows.mdx)) — a bullet under *Windows DNS scenarios* for the "NetBird won't start on a DC" symptom (Windows DNS Server holding UDP 51820).
- **DNS troubleshooting** ([`troubleshooting.mdx`](../blob/docs/link-dc-port-conflict/src/pages/manage/dns/troubleshooting.mdx)) — a note after the AD/DC issue (Issue 7), disambiguating the "client running *on* the DC" case.

No content duplicated — both are pointers to the one existing section.

## Screenshots

Windows client page — new bullet under Windows DNS scenarios:

<img src="https://raw.githubusercontent.com/emrcbrn/docs/pr-assets-dc-port-conflict/pr-assets/dc-port-windows-dark.png" width="900">

DNS troubleshooting page — note after Issue 7:

<img src="https://raw.githubusercontent.com/emrcbrn/docs/pr-assets-dc-port-conflict/pr-assets/dc-port-dns-dark.png" width="900">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
