### PR TITLE
update management env vars with NB_PPROF_ADDR

### DIFF
--- a/src/pages/selfhosted/environment-variables.mdx
+++ b/src/pages/selfhosted/environment-variables.mdx
@@ -149,7 +149,7 @@ These variables can override CLI flags at runtime. The naming convention is `NB_
 | `NB_PORT` | Signal server port |
 | `NB_METRICS_PORT` | Prometheus metrics port |
 | `NB_SSL_DIR` | SSL certificates directory |
-| `NB_LETSENCRYPT_DOMAIN` | Let's Encrypt dom remove pprofain |
+| `NB_LETSENCRYPT_DOMAIN` | Let's Encrypt domain |
 | `NB_CERT_FILE` | TLS certificate file |
 | `NB_CERT_KEY` | TLS certificate key file |
 | `NB_LOG_LEVEL` | Log level |

--- a/src/pages/selfhosted/environment-variables.mdx
+++ b/src/pages/selfhosted/environment-variables.mdx
@@ -130,6 +130,7 @@ These variables can override CLI flags at runtime. The naming convention is `NB_
 
 | Variable | Description |
 |----------|-------------|
+| `NB_PPROF_ADDR` | Enable pprof on a given address |
 | `NB_EVENT_ACTIVITY_LOG_ENABLED` | Enable activity log events |
 | `NB_GET_ACCOUNT_BUFFER_INTERVAL` | Account buffer interval duration |
 | `NB_SQL_MAX_OPEN_CONNS` | Maximum SQL database connections |
@@ -148,7 +149,7 @@ These variables can override CLI flags at runtime. The naming convention is `NB_
 | `NB_PORT` | Signal server port |
 | `NB_METRICS_PORT` | Prometheus metrics port |
 | `NB_SSL_DIR` | SSL certificates directory |
-| `NB_LETSENCRYPT_DOMAIN` | Let's Encrypt domain |
+| `NB_LETSENCRYPT_DOMAIN` | Let's Encrypt dom remove pprofain |
 | `NB_CERT_FILE` | TLS certificate file |
 | `NB_CERT_KEY` | TLS certificate key file |
 | `NB_LOG_LEVEL` | Log level |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `NB_PPROF_ADDR` runtime environment variable, including its use for enabling pprof on a specified address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->