### PR TITLE
Adds doc for NB_SOCKS5_LISTENER_ADDRESS

### DIFF
--- a/src/pages/client/environment-variables.mdx
+++ b/src/pages/client/environment-variables.mdx
@@ -46,6 +46,7 @@ To clear all saved service parameters (including env vars), run `sudo netbird se
 | `NB_USE_NETSTACK_MODE` | All | Run WireGuard on top of a userspace TCP/IP stack (gVisor netstack) instead of a TUN device. Required for environments without TUN support (e.g. unprivileged containers). |
 | `NB_NETSTACK_SKIP_PROXY` | All | When using netstack mode, do not start the built-in SOCKS5 proxy that exposes the WireGuard network to local applications. |
 | `NB_SOCKS5_LISTENER_PORT` | All | Override the port the netstack SOCKS5 proxy listens on (default: `1080`). Only relevant when netstack mode is active. |
+| `NB_SOCKS5_LISTENER_ADDRESS` | All | Override the host/IP the netstack SOCKS5 proxy binds to (default: `127.0.0.1`). The proxy is unauthenticated and meant for local applications only, so it listens on loopback. Set this (e.g. to `0.0.0.0`) only when the proxy must be reachable from other hosts, such as a container gateway — this exposes an unauthenticated proxy on that address. Only relevant when netstack mode is active. |
 
 ## Firewall
 

--- a/src/pages/use-cases/cloud/netbird-on-faas.mdx
+++ b/src/pages/use-cases/cloud/netbird-on-faas.mdx
@@ -36,6 +36,14 @@ docker run --rm --name PEER_NAME --hostname PEER_NAME -d \
 ```
 This is useful when you want to configure a simple routing peer without adding privileged permissions or linux capabilities.
 
+<Note>
+The SOCKS5 proxy binds to `127.0.0.1` by default, so it is reachable only from
+within the same container. If your application runs in a **separate** container
+and connects to the agent's proxy over the Docker network, set
+`NB_SOCKS5_LISTENER_ADDRESS=0.0.0.0` on the agent so the proxy accepts those
+connections. The proxy is unauthenticated, so only do this on trusted networks.
+</Note>
+
 ## How to use the SOCKS5 proxy?
 Once you have the agent running in netstack mode, you need to configure your application to use the SOCKS5 proxy. The following is an example of a python 3 application:
 ```python


### PR DESCRIPTION
<img width="1082" height="287" alt="image" src="https://github.com/user-attachments/assets/939c6bc4-0ba0-4a9e-95e7-d4fe1d7de1b3" />

<img width="1079" height="207" alt="image" src="https://github.com/user-attachments/assets/0cb6cb2b-8df3-4ee9-a3fc-ff27a0258548" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/docs/pr/860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786871859&installation_id=146802194&pr_number=860&repository=netbirdio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdocs%2Fpull%2F860&signature=891f1bd4254de501891995f4c6bdfdb6163acdc30a056884b4a6f7fdd311cbfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the `NB_SOCKS5_LISTENER_ADDRESS` environment variable for configuring the netstack SOCKS5 proxy bind address.
  * Added Docker guidance for enabling cross-container access when needed.
  * Clarified that the proxy is unauthenticated and should only be exposed on trusted networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->