### PR TITLE
Expand Issue 8 (NRPT lingering GPO) with GPO-hunt and source-side fixes

### DIFF
--- a/src/pages/manage/dns/troubleshooting.mdx
+++ b/src/pages/manage/dns/troubleshooting.mdx
@@ -532,7 +532,7 @@ This is a Windows Group Policy state issue, not a NetBird misconfiguration, so t
 
 - **Device-local (off-domain machines):** have local IT clear the stale `DnsPolicyConfig` container from the device's registry, or reconnect the machine to the company network and run `gpupdate /force` so Windows reconciles and drops the lingering container.
 - **At the source, empty lingering list:** edit the offending GPO's NRPT section. If it's empty, add a throwaway rule, update the policy, delete that rule, and update again. This removes the leftover `DnsPolicyConfig` from `registry.pol` that an older Windows version created.
-- **At the source, real rules:** if the section actually contains rules, confirm they're still needed and delete them if not. If they are needed, note that applying that GPO to a device running the NetBird client will override NetBird's rule and break match-domain resolution — the two have to be planned around each other.
+- **At the source, real rules:** if the section actually contains rules, confirm they're still needed and delete them if not. If they are needed, note that applying that GPO to a device running the NetBird client will override NetBird's rule and break match-domain resolution. The two have to be planned around each other.
 
 NetBird cannot remove a Group Policy container from the client side.
 

--- a/src/pages/manage/dns/troubleshooting.mdx
+++ b/src/pages/manage/dns/troubleshooting.mdx
@@ -479,28 +479,60 @@ A domain resource only resolves `A`/`AAAA` records. Active Directory also depend
 
 **Symptoms**:
 - Match-domain names don't resolve on a Windows client, even though `netbird status -d` shows the nameserver as Available and the client log records the NRPT (Name Resolution Policy Table) rule as written.
-- The machine is off-domain (not currently on the company network), often a remote or personal device that was once domain-joined.
+- Resolving the same host by IP still works; only name resolution for the match domain fails.
+- Common on machines that are domain-joined, or were once domain-joined (a remote or personal device that has since gone off-domain).
 
 **Diagnosis**:
 
-NetBird writes its NRPT rule correctly, but a stale Windows Group Policy Object (GPO) `DnsPolicyConfig` container forces the rule into the *policy* store. On an off-domain machine Windows does not apply policy-store NRPT rules, so the rule exists but is never effective. The write succeeds while Windows quietly drops it from resolution.
+To steer match-domain queries to its resolver, the NetBird client writes a *local* NRPT rule on Windows. Windows gives **Group Policy** NRPT rules precedence over local ones: they live in the `DnsPolicyConfig` policy store, and while that store is present it overrides the rule NetBird wrote. Two variants cause this:
 
-From a [debug bundle](/help/troubleshooting-client#debug-bundle), `client.log` and the matching entry in `state.json` show whether the NetBird client detected a GPO in place.
+- **A GPO defines NRPT rules.** The policy-store rules win over NetBird's local rule, so match-domain queries never reach NetBird's resolver.
+- **A lingering empty NRPT list.** NRPT rules created and then deleted under older Windows versions leave an empty list behind in the GPO's `registry.pol`. Applied to a device, that empty policy store still takes precedence and leaves no working rule.
 
-Then compare the rule NetBird wrote against what Windows is actually applying (PowerShell):
+1. Confirm NetBird's rule is written but not effective (PowerShell):
 
 ```powershell
 Get-DnsClientNrptRule                # the rule NetBird wrote
 Get-DnsClientNrptPolicy -Effective   # what Windows is actually applying
 ```
 
-If the rule appears in `Get-DnsClientNrptRule` but not in the `-Effective` output, a lingering GPO container is blocking it.
+If the rule shows in `Get-DnsClientNrptRule` but not in the `-Effective` output, a Group Policy container is overriding it. A [debug bundle](/help/troubleshooting-client#debug-bundle)'s `client.log` and `state.json` also record whether the client detected a GPO.
+
+2. Confirm a GPO is responsible by checking for the policy-store container on the device:
+
+```
+HKLM\Software\Policies\Microsoft\Windows NT\DNSClient\DnsPolicyConfig
+```
+
+If that key exists, Group Policy NRPT rules are being applied.
+
+3. Find which GPO. On the device, generate a policy report and look for an NRPT section:
+
+```powershell
+gpresult /h GPReport.html
+```
+
+To locate the source across the domain, scan the `SYSVOL` share for `registry.pol` files that carry NRPT (`DnsPolicyConfig`) entries:
+
+```powershell
+# Set this to your domain's SYSVOL Policies path, for example:
+# \\dc1.corp.example.com\sysvol\corp.example.com\Policies
+$sysvolPath = "\\<DC FQDN>\sysvol\<domain FQDN>\Policies"
+
+$matches = Get-ChildItem -Path $sysvolPath -Recurse -Filter "registry.pol" -File |
+  Where-Object { (Get-Content -Path $_.FullName -Encoding Unicode) -like "*dnspolicyconfig*" }
+
+if ($matches) { "GPOs with NRPT rules:"; $matches.FullName }
+else          { "No GPOs with NRPT rules found." }
+```
 
 **Solutions**:
 
-This is a Windows Group Policy state issue, not a NetBird misconfiguration, and the fix has to happen locally:
-- Have local IT clear the stale `DnsPolicyConfig` GPO container from the machine's registry, or
-- Connect the machine to the company network and run `gpupdate /force` so Windows reconciles and removes the lingering container.
+This is a Windows Group Policy state issue, not a NetBird misconfiguration, so the fix is on the Windows side. Pick by situation:
+
+- **Device-local (off-domain machines):** have local IT clear the stale `DnsPolicyConfig` container from the device's registry, or reconnect the machine to the company network and run `gpupdate /force` so Windows reconciles and drops the lingering container.
+- **At the source, empty lingering list:** edit the offending GPO's NRPT section. If it's empty, add a throwaway rule, update the policy, delete that rule, and update again. This removes the leftover `DnsPolicyConfig` from `registry.pol` that an older Windows version created.
+- **At the source, real rules:** if the section actually contains rules, confirm they're still needed and delete them if not. If they are needed, note that applying that GPO to a device running the NetBird client will override NetBird's rule and break match-domain resolution — the two have to be planned around each other.
 
 NetBird cannot remove a Group Policy container from the client side.
 


### PR DESCRIPTION
## What

Expands **Issue 8** on the DNS troubleshooting page (Windows NRPT rule written but never effective, lingering GPO). We already covered the off-domain, empty-GPO case, but not how to actually find and fix the responsible Group Policy. This adds that depth:

- **Two variants** spelled out: a GPO that defines NRPT rules (overrides NetBird's local rule), and a legacy empty NRPT list left in `registry.pol` (still takes precedence, leaves no working rule).
- **Diagnosis:** check the `DnsPolicyConfig` registry container, then find the responsible GPO with `gpresult /h` and a `SYSVOL` `registry.pol` scan.
- **Source-side fixes:** the dummy-rule trick to clear an empty lingering container, plus guidance for when a GPO carries real NRPT rules.

Everything already in the section is preserved, and the **heading/anchor is unchanged** so existing links (the Windows client page and the Active Directory use-case page) keep resolving.

Adapted from the same Windows NRPT/GPO behavior documented for other clients; rewritten in NetBird's voice and framed around the NetBird client, not copied.

## Screenshot

<img src="https://raw.githubusercontent.com/emrcbrn/docs/pr-assets-nrpt-gpo/pr-assets/issue8-expanded-dark.png" width="620">

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/docs/pr/862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786893690&installation_id=146802194&pr_number=862&repository=netbirdio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdocs%2Fpull%2F862&signature=aa1a38239e5709278d11063ce59a5f889e1d02ac93729ecc936c100355c263cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Windows NRPT troubleshooting guidance for scenarios where resolving by IP works but match-domain name resolution fails.
  * Added a structured diagnostic flow to compare written vs. effective NRPT policy, verify local DNS policy state, and pinpoint conflicting Group Policy.
  * Included targeted remediation steps for stale entries, correcting an empty lingering list, and addressing cases where real conflicting rules override NetBird behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->