### PR TITLE
Note that reverse proxy access rules combine with AND by default

### DIFF
--- a/src/pages/manage/reverse-proxy/index.mdx
+++ b/src/pages/manage/reverse-proxy/index.mdx
@@ -286,6 +286,8 @@ Switch to the **Access Control** tab to restrict access by IP address, country, 
 - Add **allowed countries** or **blocked countries** to restrict by geographic location.
 - Set **CrowdSec IP Reputation** to **enforce** or **observe** to block or monitor known malicious IPs (when available on the proxy cluster).
 
+By default, restrictions of different types are combined with a logical **AND**: a connection must satisfy all of them (for example, come from an allowed CIDR *and* an allowed country) to be allowed through.
+
 Access restrictions are evaluated before authentication: if a connection is blocked by an access restriction rule, it is rejected before any authentication check.
 
 <Note>


### PR DESCRIPTION
## What

Adds a one-line clarification to **Step 3b: Configure access control** on the Reverse Proxy page: access restrictions of different types (IP CIDR, country, CrowdSec IP reputation) are combined with a logical **AND** by default, so a connection must satisfy all of them to be allowed through.

Scoped to restrictions of different *types*; it doesn't claim anything about how multiple entries within a single type combine.

## Screenshot

<img src="https://raw.githubusercontent.com/emrcbrn/docs/pr-assets-rp-ac-operator/pr-assets/rp-step3b-dark.png" width="620">

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/docs/pr/863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787131150&installation_id=146802194&pr_number=863&repository=netbirdio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdocs%2Fpull%2F863&signature=cab8fab8d08bcd632064545105be7d9306a60282b63aa768cefe090071a87a02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified access control behavior when multiple restriction types are configured.
  * Documented that all configured restrictions must be satisfied for a connection to be allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->