### PR TITLE
Add an Updating section to the pfSense install guide

### DIFF
--- a/src/pages/get-started/install/pfsense.mdx
+++ b/src/pages/get-started/install/pfsense.mdx
@@ -159,7 +159,7 @@ To upgrade an existing install, fetch the latest packages and re-run `pkg add -f
 
 2. **Upgrade both packages in place**
 
-   Run `pkg add -f` on both, over the existing install:
+   Using the filenames you downloaded, run `pkg add -f` on both over the existing install:
    ```sh
    pkg add -f netbird-<VERSION>-<ARCH>.pkg
    pkg add -f pfSense-pkg-NetBird-<VERSION>-<ARCH>.pkg

--- a/src/pages/get-started/install/pfsense.mdx
+++ b/src/pages/get-started/install/pfsense.mdx
@@ -145,6 +145,33 @@ By default, pfSense uses automatic outbound NAT which randomizes source ports. T
     -   Run `netbird service restart` on the device.
     -   Run `netbird status -d` to verify the connection.
 
+## Updating
+
+To upgrade an existing install, fetch the latest packages and re-run `pkg add -f` over the current ones. There is no need to `pkg delete` first: the `-f` flag upgrades the packages in place.
+
+1. **Download the latest packages**
+
+   From the [latest pfSense NetBird release](https://github.com/netbirdio/pfsense-netbird/releases/latest), fetch both `.pkg` files for your architecture, replacing the tag, version, and architecture values with those from the release page (as in [Installation](#installation)):
+   ```sh
+   fetch https://github.com/netbirdio/pfsense-netbird/releases/download/<RELEASE_TAG>/netbird-<VERSION>-<ARCH>.pkg
+   fetch https://github.com/netbirdio/pfsense-netbird/releases/download/<RELEASE_TAG>/pfSense-pkg-NetBird-<VERSION>-<ARCH>.pkg
+   ```
+
+2. **Upgrade both packages in place**
+
+   Run `pkg add -f` on both, over the existing install:
+   ```sh
+   pkg add -f netbird-<VERSION>-<ARCH>.pkg
+   pkg add -f pfSense-pkg-NetBird-<VERSION>-<ARCH>.pkg
+   ```
+
+3. **Restart and verify**
+
+   ```sh
+   netbird service restart
+   netbird status -d
+   ```
+
 ## Uninstallation
 
 From a shell on your pfSense system, run:


### PR DESCRIPTION
## What

Adds an **Updating** section to the pfSense install guide, between Configuration and Uninstallation, covering in-place upgrades:

- Re-fetch the latest `netbird-<VERSION>-<ARCH>.pkg` and `pfSense-pkg-NetBird-<VERSION>-<ARCH>.pkg` from the latest GitHub release.
- Re-run `pkg add -f` on both over the existing install. No `pkg delete` first: `-f` upgrades in place.
- `netbird service restart`, then `netbird status -d` to verify.

Matches the Installation section's step style and code blocks, reuses the existing `<RELEASE_TAG>`/`<VERSION>`/`<ARCH>` placeholders, and follows the `Updating`-before-`Uninstallation` layout already used on the Linux and Synology install pages.

## Screenshot

<img src="https://raw.githubusercontent.com/emrcbrn/docs/pr-assets-pfsense-update/pr-assets/pfsense-updating-dark.png" width="620">

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/docs/pr/866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787154024&installation_model_id=427504&pr_number=866&repository=netbirdio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdocs%2Fpull%2F866&signature=cf33dc5034e39c03bfe120d6ea7f7865f07860d91e3948b26213782ddb4e97c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added an “Updating” section to the pfSense installation guide.
  - Included steps to download the latest pfSense NetBird `.pkg` files for the correct architecture, upgrade both packages in place, restart the service, and verify the status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->