### PR TITLE
Reference the config-file bootstrap workflow from install and peer pages

### DIFF
--- a/src/pages/get-started/install/docker.mdx
+++ b/src/pages/get-started/install/docker.mdx
@@ -87,6 +87,8 @@ volumes:
 In case you are activating a server peer, you can use a [setup key](/manage/peers/register-machines-using-setup-keys) as described in the steps below.
 > This is especially helpful when you are running multiple server instances with infrastructure-as-code tools like ansible and terraform.
 
+For unattended deployments across many containers, pre-populate the client config and inject the setup key at runtime. See [Bootstrap peers via config file](/manage/peers/bootstrap-via-config-file).
+
 1. Login to the Management Service. You need to have a `setup key` in hand (see [setup keys](/manage/peers/register-machines-using-setup-keys)).
 
 ```bash

--- a/src/pages/get-started/install/linux.mdx
+++ b/src/pages/get-started/install/linux.mdx
@@ -329,6 +329,8 @@ Check connection status:
 In case you are activating a server peer, you can use a [setup key](/manage/peers/register-machines-using-setup-keys) as described in the steps below.
 > This is especially helpful when you are running multiple server instances with infrastructure-as-code tools like ansible and terraform.
 
+For unattended deployments across many machines, pre-populate the client config so each peer registers on first start. See [Bootstrap peers via config file](/manage/peers/bootstrap-via-config-file).
+
 1. Login to the Management Service. You need to have a `setup key` in hand (see [setup keys](/manage/peers/register-machines-using-setup-keys)).
 
 ```bash

--- a/src/pages/get-started/install/macos.mdx
+++ b/src/pages/get-started/install/macos.mdx
@@ -138,6 +138,8 @@ Check connection status:
 In case you are activating a server peer, you can use a [setup key](/manage/peers/register-machines-using-setup-keys) as described in the steps below.
 > This is especially helpful when you are running multiple server instances with infrastructure-as-code tools like ansible and terraform.
 
+For unattended deployments across many machines, pre-populate the client config so each peer registers on first start. See [Bootstrap peers via config file](/manage/peers/bootstrap-via-config-file).
+
 1. Login to the Management Service. You need to have a `setup key` in hand (see [setup keys](/manage/peers/register-machines-using-setup-keys)).
 
 ```bash

--- a/src/pages/get-started/install/windows.mdx
+++ b/src/pages/get-started/install/windows.mdx
@@ -97,6 +97,8 @@ Check connection status:
 In case you are activating a server peer, you can use a [setup key](/manage/peers/register-machines-using-setup-keys) as described in the steps below.
 > This is especially helpful when you are running multiple server instances with infrastructure-as-code tools like ansible and terraform.
 
+For unattended deployments across many machines, pre-populate the client config so each peer registers on first start. See [Bootstrap peers via config file](/manage/peers/bootstrap-via-config-file).
+
 1. Login to the Management Service. You need to have a `setup key` in hand (see [setup keys](/manage/peers/register-machines-using-setup-keys)).
 
 For all systems:

--- a/src/pages/manage/peers/register-machines-using-setup-keys.mdx
+++ b/src/pages/manage/peers/register-machines-using-setup-keys.mdx
@@ -12,6 +12,8 @@ This unlocks automated, unattended deployments and integrates cleanly with infra
 netbird up --setup-key <SETUP KEY>
 ```
 
+You can also pre-populate the client configuration ahead of first start, so peers come up fully configured and register with no manual steps. See [Bootstrap peers via config file](/manage/peers/bootstrap-via-config-file).
+
 ## Types of Setup Keys
 
 There are two types of setup keys:

--- a/src/pages/use-cases/kubernetes/routing-peers-and-kubernetes.mdx
+++ b/src/pages/use-cases/kubernetes/routing-peers-and-kubernetes.mdx
@@ -70,7 +70,7 @@ Click on Name & Description to give your policy a name and description. Then cli
 ### Step 4: Deploy the NetBird agent
 You can deploy the NetBird agent using a daemon set or a deployment. Below is an example of a deployment configuration with 1 replica.
 
-This mirrors the config-file and setup-key pattern described in [Bootstrap peers via config file](/manage/peers/bootstrap-via-config-file).
+The example below enrolls the agent with a setup key. To also pre-populate the client config so it starts fully configured, see [Bootstrap peers via config file](/manage/peers/bootstrap-via-config-file).
 
 ```yaml
 ---

--- a/src/pages/use-cases/kubernetes/routing-peers-and-kubernetes.mdx
+++ b/src/pages/use-cases/kubernetes/routing-peers-and-kubernetes.mdx
@@ -70,6 +70,8 @@ Click on Name & Description to give your policy a name and description. Then cli
 ### Step 4: Deploy the NetBird agent
 You can deploy the NetBird agent using a daemon set or a deployment. Below is an example of a deployment configuration with 1 replica.
 
+This mirrors the config-file and setup-key pattern described in [Bootstrap peers via config file](/manage/peers/bootstrap-via-config-file).
+
 ```yaml
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
## What

Adds cross-links to [Bootstrap peers via config file](/manage/peers/bootstrap-via-config-file), which was previously reachable only from the sidebar. Each link sits where the page already covers unattended or setup-key enrollment, and each is scoped to at-scale, headless deployment (matching the page's stated purpose):

- **Linux, Windows, macOS** install pages: in "Running NetBird with a Setup Key".
- **Docker** install page: same section, noting the runtime setup-key injection.
- **Setup Keys** page: after the `netbird up --setup-key` example (the reciprocal of the link Bootstrap already makes back to Setup Keys).
- **Kubernetes routing-peers** guide: at the agent deployment step, which mirrors the config-file and setup-key pattern.

No content was moved or duplicated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/docs/pr/868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787223420&installation_model_id=427504&pr_number=868&repository=netbirdio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdocs%2Fpull%2F868&signature=a77efbbdd37fffd3e00a13a2db387776f0b0bdf94cbaaafe1b713bc831f4360c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for unattended deployments by pre-populating client configuration for first-start registration.
  * Clarified how setup key enrollment can work alongside configuration-file bootstrapping across Docker, Linux, macOS, Windows, and Kubernetes.
  * Added cross-links to the “Bootstrap peers via config file” guide from the setup key and Kubernetes instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->