### PR TITLE
docs: remove incorrect posture-check troubleshooting bullet in Zero Trust guide

### DIFF
--- a/src/pages/use-cases/security/implement-zero-trust.mdx
+++ b/src/pages/use-cases/security/implement-zero-trust.mdx
@@ -808,7 +808,6 @@ What to do:
 
 - Check the policy and its posture checks in **Access Control → Policies**.
 - Confirm the peer's group membership in the dashboard under **Peers**.
-- Look at Traffic Events for explicit "blocked due to posture" or "no matching policy" entries.
 
 Useful commands on the peer:
 


### PR DESCRIPTION
Section 9.1 ("Policy exists but connection is still blocked") told readers to look in Traffic Events for explicit `"blocked due to posture"` or `"no matching policy"` entries. Those entries do not exist.

A failed posture check or a group mismatch is resolved on the management server before any traffic flows: the policy stops applying and the two peers never establish a connection, so nothing is written to Traffic Events (which record flows only on connections that were actually established).

This drops the misleading bullet. The remaining two checks (policy and posture checks under **Access Control → Policies**, group membership under **Peers**) are the accurate guidance for this symptom.