### PR TITLE
Ask for the JumpCloud console region in the SSO setup step

### DIFF
--- a/src/pages/manage/team/single-sign-on/jumpcloud.mdx
+++ b/src/pages/manage/team/single-sign-on/jumpcloud.mdx
@@ -38,7 +38,7 @@ You can use JumpCloud as your Identity Provider with NetBird, but it will requir
 
 9. Record the Client ID and Client Secret that JumpCloud generates for your application.
 
-10. Share your Client ID, and Client Secret with our team. Please use a secure method for sharing this information.
+10. Share your Client ID and Client Secret with our team, along with the region your JumpCloud console is in (US, EU, or India). Please use a secure method for sharing this information.
 
 <Note>
 We recommend using a secure channel to share the Client’s secret. You can send a separate email and use a secret sharing service like: <br/>


### PR DESCRIPTION
## What

Step 10 of the JumpCloud SSO setup now asks the customer to tell us which region their JumpCloud console is in (US, EU, or India), along with the Client ID and Client Secret. That lets us configure the connector against the correct JumpCloud endpoint.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/docs/pr/871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787236866&installation_model_id=427504&pr_number=871&repository=netbirdio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdocs%2Fpull%2F871&signature=e31b6bd2e2ec6697b4da03a7a2fec32e958fa3cf2d227f782e530cbb8d96162c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated JumpCloud single sign-on setup instructions to include the JumpCloud console region alongside the Client ID and Client Secret.
  * Clarified that these details should be shared securely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->