### PR TITLE
docs: add performance expectations section to exit nodes page

### DIFF
--- a/src/pages/use-cases/remote-access/exit-nodes.mdx
+++ b/src/pages/use-cases/remote-access/exit-nodes.mdx
@@ -101,12 +101,12 @@ See [Manage DNS in your network](/manage/dns) for details.
 
 ## Performance Expectations
 
-An exit node carries each device's entire internet traffic through a single WireGuard tunnel, and a single tunnel is processed largely on one CPU core of the exit node. This puts an absolute ceiling on each device's throughput: a few Gbps on a modern server CPU running Linux kernel WireGuard, no matter how many downloads or parallel streams the device runs.
+An exit node carries each device's entire internet traffic through a single WireGuard tunnel, and a single tunnel is processed largely on one CPU core of the exit node. This caps each device's throughput at single-tunnel speed: typically a few Gbps on a modern server CPU running Linux kernel WireGuard. The exact figure depends on the exit node's per-core speed, the tunnel MTU, and traffic direction (see the [benchmark assumptions](/manage/networks/sizing-routing-peers#per-peer-capacity-reference)), but it does not grow with parallel streams.
 
-Because the ceiling is absolute rather than proportional, what you observe depends on your internet line rate:
+Because this is a fixed cap rather than a percentage cost, what you observe depends on your internet line rate:
 
 - On links up to about 1 Gbps, an exit node typically adds little to no throughput loss.
-- On multi-gigabit links, full-tunnel throughput tops out at the ceiling. Measuring a 40 to 70 percent drop against a 5 or 10 Gbps line is expected behavior, not a misconfiguration.
+- On multi-gigabit links, full-tunnel throughput tops out at the tunnel cap, so a large relative drop against a 5 or 10 Gbps line is expected behavior, not a misconfiguration.
 
 A common mistake is scaling the wrong dimension: adding CPU cores to the exit node or running more parallel streams on a device does not raise that device's ceiling, because the tunnel still serializes on one core. Per-core CPU speed does raise it, so for fast individual clients pick the exit node hardware with the fastest single-core performance available. More cores raise the aggregate capacity across many devices; see [Sizing Routing Peers](/manage/networks/sizing-routing-peers#per-peer-capacity-reference) for measured per-size numbers.
 
@@ -114,6 +114,7 @@ If throughput lands well below a few Gbps, check these before resizing hardware:
 
 - **Relayed connection.** Run `netbird status -d` on the device and confirm the connection to the exit node shows type P2P. Relayed traffic is significantly slower than a direct connection.
 - **Userspace WireGuard.** Devices on Windows and macOS, and peers running in [userspace mode](/manage/networks/sizing-routing-peers#userspace-mode), reach well below kernel-mode numbers.
+- **Exit node limits.** If the connection is P2P and both ends run kernel WireGuard, check the exit node's CPU load, the tunnel MTU, and the traffic direction against [Tuning for more throughput](/manage/networks/sizing-routing-peers#tuning-for-more-throughput).
 
 ## IPv6 Support
 

--- a/src/pages/use-cases/remote-access/exit-nodes.mdx
+++ b/src/pages/use-cases/remote-access/exit-nodes.mdx
@@ -99,6 +99,22 @@ Add a DNS server with the match domain set to `ALL`. Local DNS servers may not b
 
 See [Manage DNS in your network](/manage/dns) for details.
 
+## Performance Expectations
+
+An exit node carries each device's entire internet traffic through a single WireGuard tunnel, and a single tunnel is processed largely on one CPU core of the exit node. This puts an absolute ceiling on each device's throughput: a few Gbps on a modern server CPU running Linux kernel WireGuard, no matter how many downloads or parallel streams the device runs.
+
+Because the ceiling is absolute rather than proportional, what you observe depends on your internet line rate:
+
+- On links up to about 1 Gbps, an exit node typically adds little to no throughput loss.
+- On multi-gigabit links, full-tunnel throughput tops out at the ceiling. Measuring a 40 to 70 percent drop against a 5 or 10 Gbps line is expected behavior, not a misconfiguration.
+
+A common mistake is scaling the wrong dimension: adding CPU cores to the exit node or running more parallel streams on a device does not raise that device's ceiling, because the tunnel still serializes on one core. Per-core CPU speed does raise it, so for fast individual clients pick the exit node hardware with the fastest single-core performance available. More cores raise the aggregate capacity across many devices; see [Sizing Routing Peers](/manage/networks/sizing-routing-peers#per-peer-capacity-reference) for measured per-size numbers.
+
+If throughput lands well below a few Gbps, check these before resizing hardware:
+
+- **Relayed connection.** Run `netbird status -d` on the device and confirm the connection to the exit node shows type P2P. Relayed traffic is significantly slower than a direct connection.
+- **Userspace WireGuard.** Devices on Windows and macOS, and peers running in [userspace mode](/manage/networks/sizing-routing-peers#userspace-mode), reach well below kernel-mode numbers.
+
 ## IPv6 Support
 
 <Note>


### PR DESCRIPTION
## What

Adds a **Performance Expectations** section to the exit nodes page (between Configuration Steps and IPv6 Support).

## Why

Users testing full tunnel on multi-gigabit links report 40-50% throughput degradation and read it as a defect. The page currently says nothing about performance, so there is no documented answer.

The section explains:

- Each device's full-tunnel traffic rides a single WireGuard tunnel, processed largely on one core of the exit node, so per-device throughput has an absolute ceiling (a few Gbps on modern hardware) rather than a percentage cost.
- What that means per line rate: little to no loss up to ~1 Gbps; hitting the ceiling on multi-gigabit links is expected behavior.
- The common sizing mistake: more cores or more parallel streams do not raise a single device's ceiling; per-core speed does.
- What to check when throughput is far below the ceiling: relayed connection, userspace WireGuard.

Cross-links to the sizing guide's capacity table and userspace mode sections; no numbers are duplicated from that page.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/docs/pr/873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787302639&installation_model_id=427504&pr_number=873&repository=netbirdio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdocs%2Fpull%2F873&signature=34e7466f7b67fbf2bdcfff6a47d2ffa03f8f5c40ba8ecc348c0fc1e3102eb10c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added performance expectations for exit nodes, including throughput limitations and scaling considerations.
  * Added troubleshooting guidance for diagnosing unexpectedly low throughput, including relayed connections and userspace WireGuard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->