### PR TITLE
Document `netbird status --check` health probes

### DIFF
--- a/src/pages/get-started/cli.mdx
+++ b/src/pages/get-started/cli.mdx
@@ -427,6 +427,26 @@ Peers count: 2/3 Connected
     The peer with IP `100.119.85.4` wasn't returned because it was not connected
 </Note>
 
+#### Health checks
+
+Use `netbird status --check` to run a health probe from a script or container orchestrator. These probes do not display the normal status report. A successful probe produces no output and exits with code `0`; a failed probe exits with code `1`.
+
+- `live`: succeeds when the daemon responds to the status request.
+- `ready`: succeeds when the daemon status is `Idle`, `Connecting`, or `Connected`. Authentication-required states (`NeedsLogin`, `LoginFailed`, and `SessionExpired`) and unexpected states fail the check.
+- `startup`: succeeds when management and signal are connected and, if any NetBird relays are configured, at least one relay is available.
+
+For example, the following loop makes each probe result visible:
+
+```shell
+for check in live ready startup; do
+  if netbird status --check "$check"; then
+    echo "$check: PASS"
+  else
+    echo "$check: FAIL ($?)"
+  fi
+done
+```
+
 ### ssh
 Command to connect via SSH to a remote peer in your NetBird network. The `ssh` command has several subcommands for different operations.
 


### PR DESCRIPTION
## Summary

- document that `netbird status --check` runs silent health probes and communicates results through exit codes
- define the success criteria for the `live`, `ready`, and `startup` checks
- add a shell example that displays the result of each health check

## Health checks

The commands produce no output when successful. They exit with code `0` on success and code `1` on failure.

- `netbird status --check live` succeeds when the daemon responds to the status request.
- `netbird status --check ready` succeeds when the daemon is `Idle`, `Connecting`, or `Connected`. Authentication-required and unexpected states fail the check.
- `netbird status --check startup` succeeds when management and signal are connected and, when NetBird relays are configured, at least one relay is available.

Closes #874.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/docs/pr/876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787331130&installation_model_id=427504&pr_number=876&repository=netbirdio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdocs%2Fpull%2F876&signature=cb5204b2ae8ec47f99a162f12ac0b017c8312137e536f39b6a191713d72de3be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using `netbird status --check` health checks.
  * Documented the `live`, `ready`, and `startup` checks, including success and failure exit codes.
  * Added a shell example for running all checks and displaying PASS/FAIL results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->