### PR TITLE
Add Windows GPO deployment guide

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -182,7 +182,6 @@
       "version": "5.46.0",
       "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.46.0.tgz",
       "integrity": "sha512-0emZTaYOeI9WzJi0TcNd2k3SxiN6DZfdWc2x2gHt855Jl9jPUOzfVTL6gTvCCrOlT4McvpDGg5nGO+9doEjjig==",
-      "peer": true,
       "engines": {
         "node": ">= 14.0.0"
       }
@@ -291,7 +290,6 @@
       "version": "5.46.0",
       "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.46.0.tgz",
       "integrity": "sha512-eW6xyHCyYrJD0Kjk9Mz33gQ40LfWiEA51JJTVfJy3yeoRSw/NXhAL81Pljpa0qslTs6+LO/5DYPZddct6HvISQ==",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.46.0"
       },
@@ -308,7 +306,6 @@
       "version": "5.46.0",
       "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.46.0.tgz",
       "integrity": "sha512-Vn2+TukMGHy4PIxmdvP667tN/MhS7MPT8EEvEhS6JyFLPx3weLcxSa1F9gVvrfHWCUJhLWoMVJVB2PT8YfRGcw==",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.46.0"
       },
@@ -320,7 +317,6 @@
       "version": "5.46.0",
       "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.46.0.tgz",
       "integrity": "sha512-xaqXyna5yBZ+r1SJ9my/DM6vfTqJg9FJgVydRJ0lnO+D5NhqGW/qaRG/iBGKr/d4fho34el6WakV7BqJvrl/HQ==",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.46.0"
       },
@@ -390,6 +386,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -840,6 +837,7 @@
       "version": "6.7.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },
@@ -1438,7 +1436,6 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -1462,6 +1459,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-2.3.0.tgz",
       "integrity": "sha512-IqsscXh7Q3Rzb+f5DXYk0HU71PK+WuFsEhf+mSV3fOhpLcEpgsHvTQ2h0T6TlZ5gHOaBeFjkXwB52by7ypMyNg==",
+      "peer": true,
       "dependencies": {
         "@mdx-js/mdx": "^2.0.0",
         "source-map": "^0.7.0"
@@ -1506,6 +1504,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.3.0.tgz",
       "integrity": "sha512-zQH//gdOmuu7nt2oJR29vFhDv88oGPmVw6BggmrHeMI+xgEkp1B2dX9/bMBSYtK0dyLX/aOmesKS09g222K1/g==",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0",
         "@types/react": ">=16"
@@ -2230,7 +2229,6 @@
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2240,7 +2238,6 @@
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -2306,7 +2303,6 @@
       "version": "25.0.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2373,6 +2369,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.55.0.tgz",
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -2850,7 +2847,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -2859,26 +2855,22 @@
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
-      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "peer": true
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA=="
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
-      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "peer": true
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ=="
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
-      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "peer": true
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA=="
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -2888,14 +2880,12 @@
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
-      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "peer": true
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA=="
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2907,7 +2897,6 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
-      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -2916,7 +2905,6 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
-      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -2924,14 +2912,12 @@
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
-      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "peer": true
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ=="
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2947,7 +2933,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -2960,7 +2945,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2972,7 +2956,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -2986,7 +2969,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -2995,19 +2977,18 @@
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "peer": true
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "peer": true
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3019,7 +3000,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -3055,7 +3035,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -3072,7 +3051,6 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3087,13 +3065,13 @@
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "peer": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/algoliasearch": {
       "version": "4.25.3",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.25.3.tgz",
       "integrity": "sha512-kgeIixgDiB+FbH1cHDFUtTNkxdJadHryF8lSPIHHQkEeUrzZA1Hi3PLL+EgNubO0dch4ALNb5G4rw+FDCv3Vbw==",
+      "peer": true,
       "dependencies": {
         "@algolia/cache-browser-local-storage": "4.25.3",
         "@algolia/cache-common": "4.25.3",
@@ -3531,6 +3509,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3548,8 +3527,7 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "peer": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -3733,7 +3711,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -3847,6 +3824,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -4256,6 +4234,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4577,7 +4556,6 @@
       "version": "5.18.4",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
       "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -4702,8 +4680,7 @@
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "peer": true
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4795,6 +4772,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4972,6 +4950,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5343,7 +5322,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -5409,8 +5387,7 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -5716,8 +5693,7 @@
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "peer": true
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "node_modules/globals": {
       "version": "14.0.0",
@@ -5762,8 +5738,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "peer": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
@@ -6536,7 +6511,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -6550,7 +6524,6 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -6565,6 +6538,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6614,8 +6588,7 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "peer": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -6765,7 +6738,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
       "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
-      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -7160,8 +7132,7 @@
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "peer": true
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -7898,7 +7869,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -7907,7 +7877,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -8013,8 +7982,7 @@
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "peer": true
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/next": {
       "version": "16.1.6",
@@ -8457,6 +8425,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8632,6 +8601,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -8763,7 +8733,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -8772,6 +8741,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8780,6 +8750,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8975,7 +8946,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9119,8 +9089,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -9170,7 +9139,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -9205,7 +9173,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -9216,8 +9183,7 @@
     "node_modules/schema-utils/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "peer": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/search-insights": {
       "version": "2.17.3",
@@ -9241,7 +9207,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -9460,7 +9425,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -9470,7 +9434,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9733,6 +9696,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -9781,7 +9745,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -9794,7 +9757,6 @@
       "version": "5.44.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -9812,7 +9774,6 @@
       "version": "5.3.16",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
       "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
@@ -9845,8 +9806,7 @@
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "peer": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -9911,6 +9871,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10134,8 +10095,7 @@
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "peer": true
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
     },
     "node_modules/unified": {
       "version": "10.1.2",
@@ -10409,7 +10369,6 @@
       "version": "5.104.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.0.tgz",
       "integrity": "sha512-5DeICTX8BVgNp6afSPYXAFjskIgWGlygQH58bcozPOXgo2r/6xx39Y1+cULZ3gTxUYQP88jmwLj2anu4Xaq84g==",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -10457,7 +10416,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
       "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -10466,7 +10424,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -10479,7 +10436,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -10488,7 +10444,6 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
       "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
-      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -10629,6 +10584,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -427,6 +427,10 @@ export const docsNavigation = [
                         isOpen: true,
                         links: [
                             {
+                                title: 'Deploy with Group Policy (GPO)',
+                                href: '/manage/integrations/mdm-deployment/windows-gpo-deployment',
+                            },
+                            {
                                 title: 'macOS CLI-Only .pkg',
                                 href: '/manage/integrations/mdm-deployment/macos-cli-pkg-deployment',
                             },

--- a/src/pages/manage/integrations/mdm-deployment/windows-gpo-deployment.mdx
+++ b/src/pages/manage/integrations/mdm-deployment/windows-gpo-deployment.mdx
@@ -40,7 +40,7 @@ Create a GPO named `NetBird Policy`, link it to the OU that holds the target com
 | Disable Profiles | Enabled | Users cannot switch to another NetBird account |
 | Disable Update Settings | Enabled | Client settings become read-only for the user |
 
-These five are just this guide's example posture, not the full catalog: the templates cover every supported setting, from kill switches to Rosenpass and the WireGuard port. See the [complete key reference](/client/mdm-integration#policy-keys-reference) on the MDM Integration page and enforce the set your posture requires.
+**These five are just this guide's example posture, not the full catalog:** the templates cover every supported setting, from kill switches to Rosenpass and the WireGuard port. See the [complete key reference](/client/mdm-integration#policy-keys-reference) on the MDM Integration page and enforce the set your posture requires.
 
 Always write the Management URL with its explicit port (`https://api.example.com:443`, not `https://api.example.com`).
 

--- a/src/pages/manage/integrations/mdm-deployment/windows-gpo-deployment.mdx
+++ b/src/pages/manage/integrations/mdm-deployment/windows-gpo-deployment.mdx
@@ -88,7 +88,11 @@ For devices without direct internet access, stage the MSI on an internal share o
 
 Create a second GPO named `NetBird Install` (or reuse the first), and add the script under **Computer Configuration > Policies > Windows Settings > Scripts (Startup/Shutdown) > Startup**, on the **PowerShell Scripts** tab. Link it to the same OU.
 
-By default, the MSI registers the NetBird tray application to launch when users sign in. If you do not want that, append `AUTOSTART=0` to the `msiexec` argument list. Note that this is an installer property; the Disable Autostart policy in the ADMX only governs the client's own launch-on-login setting and does not remove the installer's entry.
+By default, the installer makes the NetBird tray application start every time a user signs in, by writing a `Run` entry under `HKLM\Software\Microsoft\Windows\CurrentVersion\Run`. If you do not want the tray application to appear at sign-in, add `AUTOSTART=0` to the `msiexec` argument list in the script above.
+
+<Note>
+The **Disable Autostart** policy in the ADMX does not do this, and it is easy to reach for by mistake. That policy controls a different mechanism: the launch-on-login setting inside the NetBird client itself. The installer's `Run` entry is created before any policy is read and is removed by neither. `AUTOSTART=0` at install time is the only switch that keeps the tray application from launching at sign-in.
+</Note>
 
 ## 4. Scope the GPOs
 

--- a/src/pages/manage/integrations/mdm-deployment/windows-gpo-deployment.mdx
+++ b/src/pages/manage/integrations/mdm-deployment/windows-gpo-deployment.mdx
@@ -26,6 +26,8 @@ Copy-Item netbird.admx '\\ad.example.com\SYSVOL\ad.example.com\Policies\PolicyDe
 Copy-Item netbird.adml '\\ad.example.com\SYSVOL\ad.example.com\Policies\PolicyDefinitions\en-US\'
 ```
 
+The links above track the latest development version; to pin the templates to the release you deploy, browse the same files under that release's tag (replace `main` in the URL with the tag, for example `v0.75.0`).
+
 Reopen the Group Policy Management Editor. The policies appear under **Computer Configuration > Policies > Administrative Templates > NetBird**.
 
 ## 2. Create the policy GPO
@@ -71,11 +73,17 @@ if ($installed) { Write-Log "NetBird $($installed.DisplayVersion) already instal
 # Download the MSI (or copy it from an internal share instead).
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $msi = "$env:TEMP\netbird.msi"
-Invoke-WebRequest 'https://pkgs.netbird.io/windows/msi/x64' -OutFile $msi -UseBasicParsing
+try {
+    Invoke-WebRequest 'https://pkgs.netbird.io/windows/msi/x64' -OutFile $msi -UseBasicParsing -TimeoutSec 300
+} catch {
+    Write-Log "MSI download failed: $($_.Exception.Message)"; exit 1
+}
 
-# Refuse to execute an installer that is not signed by NetBird.
+# Refuse to execute an installer that is not validly signed by NetBird.
 $sig = Get-AuthenticodeSignature $msi
-if ($sig.Status -ne 'Valid') { Write-Log "Invalid MSI signature: $($sig.Status)"; exit 1 }
+if ($sig.Status -ne 'Valid' -or $sig.SignerCertificate.Subject -notlike 'CN=NetBird*') {
+    Write-Log "MSI signature rejected (status: $($sig.Status), signer: $($sig.SignerCertificate.Subject))"; exit 1
+}
 
 $p = Start-Process msiexec.exe -ArgumentList @('/i', "`"$msi`"", '/qn', '/norestart',
      '/l*v', "`"$env:ProgramData\NetBird\netbird-install.log`"") -Wait -PassThru
@@ -84,7 +92,9 @@ Write-Log "Install finished with exit code $($p.ExitCode)."
 exit $p.ExitCode
 ```
 
-For devices without direct internet access, stage the MSI on an internal share once and replace the download line with `Copy-Item '\\fileserver.ad.example.com\software\netbird.msi' $msi`. Keep the signature check either way.
+For devices without direct internet access, stage the MSI on an internal share once and replace the download block with `Copy-Item '\\fileserver.ad.example.com\software\netbird.msi' $msi`. Keep the signature check either way.
+
+The script deliberately never touches an existing installation, so machines that already run NetBird **older than v0.73.0** keep ignoring managed policy after this rollout. If your fleet may contain such installs, upgrade them to a current version first; the policy values themselves can safely be in place before, during, and after that upgrade.
 
 Create a second GPO named `NetBird Install` (or reuse the first), and add the script under **Computer Configuration > Policies > Windows Settings > Scripts (Startup/Shutdown) > Startup**, on the **PowerShell Scripts** tab. Link it to the same OU.
 

--- a/src/pages/manage/integrations/mdm-deployment/windows-gpo-deployment.mdx
+++ b/src/pages/manage/integrations/mdm-deployment/windows-gpo-deployment.mdx
@@ -5,21 +5,21 @@ export const description =
 
 # Deploying NetBird with Group Policy (GPO)
 
-Rolling NetBird out to a fleet of domain-joined Windows devices by hand means two problems: installing the client on every machine without touching each one, and making sure users cannot point it at the wrong server or loosen settings your security posture depends on. In an Active Directory environment, Group Policy solves both in one pass. A policy GPO writes managed values to the registry, which the NetBird client enforces as its highest-priority configuration layer, and a computer startup script performs the silent MSI install. Writing policy never starts a connection: users authenticate through your identity provider the first time they connect.
+Rolling NetBird out to a fleet of domain-joined Windows devices poses two problems: installing the client on every machine without touching each one, and making sure users cannot point it at the wrong server or loosen settings your security posture depends on. In an Active Directory environment, Group Policy solves both in one pass. A policy GPO writes managed values to the registry, which the NetBird client enforces as its highest-priority configuration layer, and a computer startup script performs the silent MSI install. Writing policy never starts a connection: users authenticate through your identity provider the first time they connect.
 
-This guide walks through one deployment end to end. How the client merges and locks MDM-managed settings is covered on the [MDM Integration](/client/mdm-integration) page; here we only apply it.
+This guide walks through one deployment end to end. How the client merges and locks MDM-managed settings is covered on the [MDM Integration](/client/mdm-integration) page; this guide focuses on delivering those settings with Group Policy.
 
 We use one running example throughout: the Active Directory domain `ad.example.com` and a self-hosted management server at `https://api.example.com:443`. If you use NetBird Cloud, skip the Management URL policy and keep everything else.
 
 ## Prerequisites
 
-- An Active Directory domain and permissions to create and link GPOs (Group Policy Management Console).
+- An Active Directory domain and access to the Group Policy Management Console (GPMC) with permissions to create and link GPOs.
 - NetBird client **v0.73.0 or later**. Earlier versions ignore managed policy entirely, so pin your installer source accordingly.
-- A [NetBird account](https://app.netbird.io) with the settings you plan to enforce already decided. Start from least privilege: enforce what your posture requires and leave the rest unmanaged.
+- A [NetBird account](https://app.netbird.io), and a decision on which settings to enforce. Start from least privilege: enforce what your posture requires and leave the rest unmanaged.
 
 ## 1. Import the ADMX templates
 
-NetBird ships Group Policy administrative templates in the client repository. Download [`netbird.admx`](https://github.com/netbirdio/netbird/blob/main/docs/netbird.admx) and [`netbird.adml`](https://github.com/netbirdio/netbird/blob/main/docs/netbird.adml), matching the client version you deploy, and copy them to the domain Central Store:
+NetBird ships Group Policy administrative templates in the client repository. Download the [`netbird.admx`](https://github.com/netbirdio/netbird/blob/main/docs/netbird.admx) and [`netbird.adml`](https://github.com/netbirdio/netbird/blob/main/docs/netbird.adml) pair that matches the client version you deploy, and copy the files to the domain Central Store:
 
 ```powershell
 Copy-Item netbird.admx '\\ad.example.com\SYSVOL\ad.example.com\Policies\PolicyDefinitions\'
@@ -44,7 +44,7 @@ Create a GPO named `NetBird Policy`, link it to the OU that holds the target com
 
 Always write the Management URL with its explicit port (`https://api.example.com:443`, not `https://api.example.com`).
 
-Every value lands in `HKLM\Software\Policies\NetBird`. If you prefer Group Policy Preferences Registry items or `reg import` over ADMX, write the same values there; the client does not care which tool wrote them. A commented sample with every supported key ships alongside the templates as [`netbird-policy.reg`](https://github.com/netbirdio/netbird/blob/main/docs/netbird-policy.reg).
+Every value lands in `HKLM\Software\Policies\NetBird`. If you prefer Group Policy Preferences Registry items or `reg import` over ADMX, write the same values with those tools instead; the client does not care which tool wrote them. A commented sample with every supported key ships alongside the templates as [`netbird-policy.reg`](https://github.com/netbirdio/netbird/blob/main/docs/netbird-policy.reg).
 
 <Note>
 Order matters once, at rollout: get the Management URL right **before** you enforce Disable Update Settings. That policy locks configuration changes from the GUI and the CLI alike, so after it applies, the policy channel you are building here is the only way to correct the URL. Corrections still propagate: managed values are re-read about once a minute.
@@ -84,13 +84,13 @@ Write-Log "Install finished with exit code $($p.ExitCode)."
 exit $p.ExitCode
 ```
 
-Devices without direct internet access: stage the MSI on an internal share once, and replace the download with `Copy-Item '\\fileserver.ad.example.com\software\netbird.msi' $msi`. Keep the signature check either way.
+For devices without direct internet access, stage the MSI on an internal share once and replace the download line with `Copy-Item '\\fileserver.ad.example.com\software\netbird.msi' $msi`. Keep the signature check either way.
 
 Create a second GPO named `NetBird Install` (or reuse the first), and add the script under **Computer Configuration > Policies > Windows Settings > Scripts (Startup/Shutdown) > Startup**, on the **PowerShell Scripts** tab. Link it to the same OU.
 
-By default the MSI registers the NetBird tray application to launch when users sign in. If you do not want that, append `AUTOSTART=0` to the `msiexec` argument list. Note this is a property of the installer; the Disable Autostart policy in the ADMX only governs the client's own launch-on-login setting and does not remove the installer's entry.
+By default, the MSI registers the NetBird tray application to launch when users sign in. If you do not want that, append `AUTOSTART=0` to the `msiexec` argument list. Note that this is an installer property; the Disable Autostart policy in the ADMX only governs the client's own launch-on-login setting and does not remove the installer's entry.
 
-## 4. Scope it
+## 4. Scope the GPOs
 
 - Link both GPOs to the OU containing the workstation computer objects rather than the domain root.
 - Different postures for different device classes (developer workstations that need server routes, kiosks that need a full lockdown) are just separate policy GPOs on separate OUs, or one GPO with a WMI filter.
@@ -98,17 +98,17 @@ By default the MSI registers the NetBird tray application to launch when users s
 
 ## 5. First sign-in
 
-After the next reboot the machine has NetBird installed and every managed value enforced, but no tunnel yet:
+After the next reboot, the machine has NetBird installed and every managed value enforced, but no tunnel yet:
 
 1. The user clicks **Connect** in the NetBird tray application.
 2. The daemon loads its configuration with the managed values on top and connects to `https://api.example.com:443`.
 3. A browser window opens for single sign-on; the user signs in with their identity provider account and the device becomes a peer.
 
-Settings you enforced are locked and marked as managed in the client UI from the first start, so there is no window in which a user can misconfigure the client. Unattended machines (servers, kiosks) can skip the interactive step by registering with a [setup key](/manage/peers/register-machines-using-setup-keys) instead; setup keys are an enrollment credential passed to `netbird up --setup-key`, not a policy value.
+Settings you enforced are locked and marked as managed in the client UI from the first start, so there is no window in which a user can misconfigure the client. Unattended machines (servers, kiosks) can skip the interactive step by registering with a [setup key](/manage/peers/register-machines-using-setup-keys) instead; a setup key is an enrollment credential passed to `netbird up --setup-key`, not a policy value.
 
 ## Verify
 
-On a deployed device, in an elevated PowerShell:
+On a deployed device, in an elevated PowerShell session:
 
 ```powershell
 reg query HKLM\Software\Policies\NetBird   # the values from step 2

--- a/src/pages/manage/integrations/mdm-deployment/windows-gpo-deployment.mdx
+++ b/src/pages/manage/integrations/mdm-deployment/windows-gpo-deployment.mdx
@@ -40,6 +40,8 @@ Create a GPO named `NetBird Policy`, link it to the OU that holds the target com
 | Disable Profiles | Enabled | Users cannot switch to another NetBird account |
 | Disable Update Settings | Enabled | Client settings become read-only for the user |
 
+These five are just this guide's example posture, not the full catalog: the templates cover every supported setting, from kill switches to Rosenpass and the WireGuard port. See the [complete key reference](/client/mdm-integration#policy-keys-reference) on the MDM Integration page and enforce the set your posture requires.
+
 Always write the Management URL with its explicit port (`https://api.example.com:443`, not `https://api.example.com`).
 
 Every value lands in `HKLM\Software\Policies\NetBird`. If you prefer Group Policy Preferences Registry items or `reg import` over ADMX, write the same values there; the client does not care which tool wrote them. A commented sample with every supported key ships alongside the templates as [`netbird-policy.reg`](https://github.com/netbirdio/netbird/blob/main/docs/netbird-policy.reg).

--- a/src/pages/manage/integrations/mdm-deployment/windows-gpo-deployment.mdx
+++ b/src/pages/manage/integrations/mdm-deployment/windows-gpo-deployment.mdx
@@ -1,0 +1,132 @@
+import { Note, Warning } from "@/components/mdx";
+
+export const description =
+  "Deploy NetBird to a fleet of domain-joined Windows devices with Group Policy: enforce client settings through the NetBird ADMX templates and install the MSI silently with a computer startup script.";
+
+# Deploying NetBird with Group Policy (GPO)
+
+Rolling NetBird out to a fleet of domain-joined Windows devices by hand means two problems: installing the client on every machine without touching each one, and making sure users cannot point it at the wrong server or loosen settings your security posture depends on. In an Active Directory environment, Group Policy solves both in one pass. A policy GPO writes managed values to the registry, which the NetBird client enforces as its highest-priority configuration layer, and a computer startup script performs the silent MSI install. Writing policy never starts a connection: users authenticate through your identity provider the first time they connect.
+
+This guide walks through one deployment end to end. How the client merges and locks MDM-managed settings is covered on the [MDM Integration](/client/mdm-integration) page; here we only apply it.
+
+We use one running example throughout: the Active Directory domain `ad.example.com` and a self-hosted management server at `https://api.example.com:443`. If you use NetBird Cloud, skip the Management URL policy and keep everything else.
+
+## Prerequisites
+
+- An Active Directory domain and permissions to create and link GPOs (Group Policy Management Console).
+- NetBird client **v0.73.0 or later**. Earlier versions ignore managed policy entirely, so pin your installer source accordingly.
+- A [NetBird account](https://app.netbird.io) with the settings you plan to enforce already decided. Start from least privilege: enforce what your posture requires and leave the rest unmanaged.
+
+## 1. Import the ADMX templates
+
+NetBird ships Group Policy administrative templates in the client repository. Download [`netbird.admx`](https://github.com/netbirdio/netbird/blob/main/docs/netbird.admx) and [`netbird.adml`](https://github.com/netbirdio/netbird/blob/main/docs/netbird.adml), matching the client version you deploy, and copy them to the domain Central Store:
+
+```powershell
+Copy-Item netbird.admx '\\ad.example.com\SYSVOL\ad.example.com\Policies\PolicyDefinitions\'
+Copy-Item netbird.adml '\\ad.example.com\SYSVOL\ad.example.com\Policies\PolicyDefinitions\en-US\'
+```
+
+Reopen the Group Policy Management Editor. The policies appear under **Computer Configuration > Policies > Administrative Templates > NetBird**.
+
+## 2. Create the policy GPO
+
+Create a GPO named `NetBird Policy`, link it to the OU that holds the target computer objects, and enable the settings you want to enforce. For our example fleet of user workstations:
+
+| Policy | Value | Effect |
+| --- | --- | --- |
+| Management URL | `https://api.example.com:443` | Devices only talk to your server |
+| Block Inbound | Enabled | The device accepts no inbound connections from other peers |
+| Disable Server Routes | Enabled | The device cannot act as a routing peer |
+| Disable Profiles | Enabled | Users cannot switch to another NetBird account |
+| Disable Update Settings | Enabled | Client settings become read-only for the user |
+
+Always write the Management URL with its explicit port (`https://api.example.com:443`, not `https://api.example.com`).
+
+Every value lands in `HKLM\Software\Policies\NetBird`. If you prefer Group Policy Preferences Registry items or `reg import` over ADMX, write the same values there; the client does not care which tool wrote them. A commented sample with every supported key ships alongside the templates as [`netbird-policy.reg`](https://github.com/netbirdio/netbird/blob/main/docs/netbird-policy.reg).
+
+<Note>
+Order matters once, at rollout: get the Management URL right **before** you enforce Disable Update Settings. That policy locks configuration changes from the GUI and the CLI alike, so after it applies, the policy channel you are building here is the only way to correct the URL. Corrections still propagate: managed values are re-read about once a minute.
+</Note>
+
+## 3. Create the install GPO
+
+Policy alone configures NetBird but installs nothing; a machine that only receives the policy GPO simply holds inert registry values until the client arrives. The one job left for a script is the MSI install, so keep the script to exactly that.
+
+Save the following as `Install-NetBird.ps1` in a share readable by domain computers, for example `\\ad.example.com\SYSVOL\ad.example.com\scripts\`:
+
+```powershell
+# Silent NetBird MSI install for GPO computer startup. Logs to file, no console output.
+$ErrorActionPreference = 'Stop'
+$log = "$env:ProgramData\NetBird\netbird-deploy.log"
+New-Item -ItemType Directory -Path (Split-Path $log) -Force | Out-Null
+function Write-Log($m) { "$(Get-Date -Format s) $m" | Out-File $log -Append -Encoding UTF8 }
+
+# Idempotent: never touch an existing install.
+$installed = Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*' -ErrorAction SilentlyContinue |
+             Where-Object { $_.DisplayName -like 'NetBird*' }
+if ($installed) { Write-Log "NetBird $($installed.DisplayVersion) already installed."; exit 0 }
+
+# Download the MSI (or copy it from an internal share instead).
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$msi = "$env:TEMP\netbird.msi"
+Invoke-WebRequest 'https://pkgs.netbird.io/windows/msi/x64' -OutFile $msi -UseBasicParsing
+
+# Refuse to execute an installer that is not signed by NetBird.
+$sig = Get-AuthenticodeSignature $msi
+if ($sig.Status -ne 'Valid') { Write-Log "Invalid MSI signature: $($sig.Status)"; exit 1 }
+
+$p = Start-Process msiexec.exe -ArgumentList @('/i', "`"$msi`"", '/qn', '/norestart',
+     '/l*v', "`"$env:ProgramData\NetBird\netbird-install.log`"") -Wait -PassThru
+Remove-Item $msi -Force -ErrorAction SilentlyContinue
+Write-Log "Install finished with exit code $($p.ExitCode)."
+exit $p.ExitCode
+```
+
+Devices without direct internet access: stage the MSI on an internal share once, and replace the download with `Copy-Item '\\fileserver.ad.example.com\software\netbird.msi' $msi`. Keep the signature check either way.
+
+Create a second GPO named `NetBird Install` (or reuse the first), and add the script under **Computer Configuration > Policies > Windows Settings > Scripts (Startup/Shutdown) > Startup**, on the **PowerShell Scripts** tab. Link it to the same OU.
+
+By default the MSI registers the NetBird tray application to launch when users sign in. If you do not want that, append `AUTOSTART=0` to the `msiexec` argument list. Note this is a property of the installer; the Disable Autostart policy in the ADMX only governs the client's own launch-on-login setting and does not remove the installer's entry.
+
+## 4. Scope it
+
+- Link both GPOs to the OU containing the workstation computer objects rather than the domain root.
+- Different postures for different device classes (developer workstations that need server routes, kiosks that need a full lockdown) are just separate policy GPOs on separate OUs, or one GPO with a WMI filter.
+- Expect one extra boot on brand-new machines: startup scripts only run once the device has already downloaded the scripts policy, so a freshly joined machine typically installs NetBird on its second boot. This is standard Group Policy foreground processing, not a NetBird property.
+
+## 5. First sign-in
+
+After the next reboot the machine has NetBird installed and every managed value enforced, but no tunnel yet:
+
+1. The user clicks **Connect** in the NetBird tray application.
+2. The daemon loads its configuration with the managed values on top and connects to `https://api.example.com:443`.
+3. A browser window opens for single sign-on; the user signs in with their identity provider account and the device becomes a peer.
+
+Settings you enforced are locked and marked as managed in the client UI from the first start, so there is no window in which a user can misconfigure the client. Unattended machines (servers, kiosks) can skip the interactive step by registering with a [setup key](/manage/peers/register-machines-using-setup-keys) instead; setup keys are an enrollment credential passed to `netbird up --setup-key`, not a policy value.
+
+## Verify
+
+On a deployed device, in an elevated PowerShell:
+
+```powershell
+reg query HKLM\Software\Policies\NetBird   # the values from step 2
+netbird status -d                          # daemon state and management URL
+```
+
+The client log (`C:\ProgramData\netbird\client.log`) records the policy overlay at every load, one line per enforced key:
+
+```
+MDM enrolled with 5 managed key(s): [blockInbound disableProfiles disableServerRoutes disableUpdateSettings managementURL]
+MDM override managementURL = https://api.example.com:443
+MDM override blockInbound = true
+```
+
+The install script's own log is at `%ProgramData%\NetBird\netbird-deploy.log`, and the verbose MSI log at `%ProgramData%\NetBird\netbird-install.log`. Policy changes you make later in GPMC reach running clients within a Group Policy refresh plus about one minute, with no reboot or service restart.
+
+## When not to use GPO
+
+Group Policy only reaches domain-joined Windows machines. For Windows devices managed by Intune, use [Deploy with Intune](/manage/integrations/mdm-deployment/intune-netbird-integration) with the same ADMX or an OMA-URI profile. For macOS fleets, see [Jamf Pro](/manage/integrations/mdm-deployment/jamf-pro-netbird-integration) or [Kandji](/manage/integrations/mdm-deployment/kandji-netbird-integration). The registry values themselves are tool-agnostic, so anything that can write `HKLM\Software\Policies\NetBird` (SCCM, an RMM, a provisioning image) gives you the same enforcement without GPO.
+
+## Recap
+
+For `ad.example.com` pointing at `https://api.example.com:443`: the ADMX pair in the Central Store, one GPO enforcing the Management URL and the lockdown set, one startup script installing the signed MSI, both linked to the workstation OU. Policy is pure GPO state, the install is one small script, and the only thing left for users is single sign-on the first time they connect.


### PR DESCRIPTION
## What

New how-to page under **Manage > Integrations > MDM for Deployment**: deploying NetBird to domain-joined Windows fleets with Group Policy.

- `manage/integrations/mdm-deployment/windows-gpo-deployment.mdx`
- Sidebar entry "Deploy with Group Policy (GPO)" at the top of the MDM for Deployment group (the only Windows-native entry there)

## Why

The MDM Integration page documents what the client enforces and lists Group Policy as a delivery channel, but there was no walkthrough for the on-prem AD path, while Intune, Jamf, and Kandji each have one. This fills that gap.

## Content

One worked example (domain `ad.example.com`, self-hosted server `https://api.example.com:443`, NetBird Cloud variant noted): ADMX import to the Central Store, policy GPO with a hardened-workstation posture, a minimal computer-startup install script (idempotent, TLS 1.2, Authenticode check, silent msiexec, file-only logging), scoping, first sign-in, and verification via registry, `netbird status -d`, and the client log's MDM lines.

Known pitfalls are called out in place: explicit port on the management URL, setting the URL before enforcing Disable Update Settings, the ~1 minute policy propagation, the extra boot before startup scripts first run, and the installer's `AUTOSTART` property vs the Disable Autostart policy.

Links to the MDM Integration key reference instead of duplicating the key list; points to the Intune/Jamf/Kandji pages for non-GPO fleets.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/docs/pr/879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787405741&installation_model_id=427504&pr_number=879&repository=netbirdio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdocs%2Fpull%2F879&signature=dd26a3764ed7d1bf1d1e11dd591d922e19afd23b791e900a4529f9f9e24b871f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for deploying NetBird on domain-joined Windows devices using Group Policy Objects (GPO).
  * Documented policy configuration, MSI installation, validation, troubleshooting, enrollment, and verification steps.
  * Added the new **Deploy with Group Policy (GPO)** page to the MDM for Deployment documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->