### PR TITLE
Document the iOS debug bundle and surface it in the client guide

### DIFF
--- a/src/pages/help/troubleshooting-client.mdx
+++ b/src/pages/help/troubleshooting-client.mdx
@@ -72,7 +72,7 @@ experience. The steps here are cross-platform; for OS-specific details, use the 
       title: "iOS",
       href: "/help/troubleshooting-client/ios",
       icon: "mobile",
-      description: "Capturing logs from the app. On-device debugging is limited.",
+      description: "Collect a debug bundle from the app. On-device debugging is limited.",
     },
   ]}
 />
@@ -225,6 +225,8 @@ netbird debug bundle --anonymize --system-info
 This will output the path of the generated file. The output file is owned by and can only be accessed by the user
 NetBird is running as, by default it is: `Administrator` on Windows, `root` on MacOS/Linux or the operating system\'s
 equivalent.
+
+On iOS, the `netbird` CLI is not available. Collect the bundle from the app instead, under **Settings → Troubleshoot**. See [NetBird client on iOS](/help/troubleshooting-client/ios).
 
 #### What's inside the bundle
 

--- a/src/pages/help/troubleshooting-client/ios.mdx
+++ b/src/pages/help/troubleshooting-client/ios.mdx
@@ -1,14 +1,14 @@
 import {Note} from "@/components/mdx"
 
 export const description =
-  "iOS-specific NetBird client troubleshooting and how to capture logs from the app."
+  "iOS-specific NetBird client troubleshooting and how to collect a debug bundle from the app."
 
 # NetBird client on iOS
 
 iOS-specific steps for the NetBird client. Most troubleshooting is cross-platform, so start from [Troubleshooting client issues](/help/troubleshooting-client).
 
-On-device debugging on iOS is more limited than on desktop platforms. To share diagnostics, capture logs from the NetBird iOS app and attach them to your report.
+On-device debugging on iOS is more limited than on desktop platforms, but the NetBird app can collect a debug bundle you can attach to a report.
 
 <Note>
-There are no iOS-specific debug commands yet. For status, connectivity, and DNS issues, follow the cross-platform [Troubleshooting client issues](/help/troubleshooting-client) and [DNS Troubleshooting](/manage/dns/troubleshooting) guides. If you can reproduce a problem, report it through [Community Support](/help/community-support).
+To collect a debug bundle on iOS, open the NetBird app and go to **Settings → Troubleshoot**. For status, connectivity, and DNS issues, also follow the cross-platform [Troubleshooting client issues](/help/troubleshooting-client) and [DNS Troubleshooting](/manage/dns/troubleshooting) guides. When you can reproduce a problem, report it with the debug bundle attached through [Community Support](/help/community-support), or through [NetBird Support](/help/netbird-support) if you are a paying customer.
 </Note>


### PR DESCRIPTION
## What

The NetBird iOS app can now collect a debug bundle from **Settings → Troubleshoot**. This documents it and references it where debug bundles are already discussed.

- **iOS troubleshooting page**: replaced the outdated "there are no iOS-specific debug commands yet" note. It now explains collecting the bundle via Settings → Troubleshoot, and routes reports to [Community Support](/help/community-support), or [NetBird Support](/help/netbird-support) for paying customers.
- **Client troubleshooting guide**: in the canonical Debug bundle section, noted that the CLI is not available on iOS and the bundle is collected from the app, linking to the iOS page. Also updated the iOS card on the hub grid from "Capturing logs" to "Collect a debug bundle from the app".

The many generic "attach a debug bundle" mentions on other pages link to that canonical section, so they are covered without further edits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/docs/pr/880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787408622&installation_model_id=427504&pr_number=880&repository=netbirdio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdocs%2Fpull%2F880&signature=c2a6c1ba9a05cc9d5fb1d8984f6b5a21f97e32a51976e2ed98cb262329911959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated iOS troubleshooting guidance to explain how to collect a debug bundle from **Settings → Troubleshoot** in the app.
  * Clarified that the `netbird` CLI is unavailable on iOS.
  * Added instructions to attach debug bundles when reporting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->