### PR TITLE
docs: use euros for plan pricing on billing page

### DIFF
--- a/src/pages/manage/settings/plans-and-billing.mdx
+++ b/src/pages/manage/settings/plans-and-billing.mdx
@@ -7,9 +7,9 @@ NetBird offers diverse plans to accommodate various networking needs, ensuring s
 - **Free Plan:** The Free plan provides secure connectivity for up to 5 users and 100 machines suitable for individuals or small teams.
 It features peer-to-peer connections and encryption, access control, routing, and private DNS. This plan includes Single Sign-On (SSO) integration with identity providers like Google Workspace, Azure, and Okta.
 
-- **Team Plan:** Priced at **$6 per user per month**, the Team Plan offers unlimited admin and regular users, multi-factor authentication (MFA), access and connection logging, user and group provisioning and sync from your identity provider (IdP), and custom SSO login options, making it ideal for larger teams seeking scalable and secure connectivity.
+- **Team Plan:** Priced at **€6 per user per month**, the Team Plan offers unlimited admin and regular users, multi-factor authentication (MFA), access and connection logging, user and group provisioning and sync from your identity provider (IdP), and custom SSO login options, making it ideal for larger teams seeking scalable and secure connectivity.
 
-- **Business Plan:** At  **$12 per user per month**, the Business Plan offers enhanced network security with a Zero Trust approach. It supports unlimited users and includes features like device approvals and integrations (MDM and EDR) for comprehensive control, device posture checks and activity events streaming, making it an excellent choice for organizations seeking advanced security solutions.
+- **Business Plan:** At **€12 per user per month**, the Business Plan offers enhanced network security with a Zero Trust approach. It supports unlimited users and includes features like device approvals and integrations (MDM and EDR) for comprehensive control, device posture checks and activity events streaming, making it an excellent choice for organizations seeking advanced security solutions.
 
 
 <p>


### PR DESCRIPTION
## Summary

The Plans and billing page priced the Team and Business plans in USD at the top, while the "Machine-based Usage" section further down already priced Team at `€6/user`. This aligns the plan descriptions with euros so the page is internally consistent.

- Team Plan: `$6` → `€6 per user per month`
- Business Plan: `$12` → `€12 per user per month`

Amounts are unchanged — only the currency symbol. Also removed a stray double space before the Business price.

Agent Network `USD` references (LLM spend caps, cost-per-token, API fields like `group_cap_usd`) are intentionally untouched: they measure spend against external LLM providers billed in USD and are literal API field names, not NetBird pricing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/docs/pr/882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787473619&installation_model_id=427504&pr_number=882&repository=netbirdio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdocs%2Fpull%2F882&signature=7bd5ff273e3357646d8b2522fbfc61df7ec52996a58f624dd5a86d251fc2fbe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Team and Business plan pricing to display Euros instead of Dollars.
  * Team plan: €6 per user/month.
  * Business plan: €12 per user/month.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->