### PR TITLE
docs(cli): document --use-device-auth flag for up and login

### DIFF
--- a/src/pages/get-started/cli.mdx
+++ b/src/pages/get-started/cli.mdx
@@ -119,6 +119,7 @@ The command will check if the peer is logged in and connect to the management se
       --profile string                      Profile name to use for the login. If not specified, the last used profile will be used.
       --rosenpass-permissive                [Experimental] Enable Rosenpass in permissive mode to allow this peer to accept WireGuard connections without requiring Rosenpass functionality from peers that do not have Rosenpass enabled.
       --ssh-jwt-cache-ttl int               SSH JWT token cache TTL in seconds (default 0, disabled). When enabled, the client caches the JWT so repeated SSH connections skip the OIDC login flow. The receiving SSH server rejects tokens older than 10 minutes, so values above 600 will result in authentication failures for cached tokens.
+      --use-device-auth                     force the OAuth 2.0 Device Authorization Grant instead of the PKCE/browser flow
       --wireguard-port uint16               WireGuard interface listening port (default 51820)
 ```
 #### Usage
@@ -153,8 +154,9 @@ netbird up --setup-key AAAA-BBB-CCC-DDDDDD --extra-dns-labels vpc1,mgmt1
 Command to authenticate the NetBird client to a management service. If the peer is not logged in, by default, it will attempt to initiate an SSO login flow.
 #### Flags
 ```shell
-      --no-browser       Do not open the browser for SSO login
-      --profile string   Profile name to use for the login. If not specified, the last used profile will be used.
+      --no-browser         Do not open the browser for SSO login
+      --profile string     Profile name to use for the login. If not specified, the last used profile will be used.
+      --use-device-auth    force the OAuth 2.0 Device Authorization Grant instead of the PKCE/browser flow
 ```
 #### Usage
 The minimal form of running the command is:


### PR DESCRIPTION
Documents the new CLI command flag to force device code flow

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/docs/pr/883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787490541&installation_model_id=427504&pr_number=883&repository=netbirdio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdocs%2Fpull%2F883&signature=ab374465aef20520e1d2600e6527772f87d73be06eddb056401f00f75f2937d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CLI reference documentation for the `--use-device-auth` flag in the `netbird up` and `netbird login` commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->