### PR TITLE
Add commercial license links

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -548,7 +548,21 @@ export const docsNavigation = [
         links: [
             { title: 'Quickstart Guide', href: '/selfhosted/selfhosted-quickstart' },
             { title: 'Automated Setup', href: '/selfhosted/automated-setup' },
-            { title: 'Commercial License', href: '/selfhosted/enterprise' },
+            {
+                title: 'Commercial License',
+                href: '/selfhosted/enterprise',
+                isOpen: false,
+                links: [
+                    {
+                        title: 'Getting Started',
+                        href: '/selfhosted/enterprise/getting-started',
+                    },
+                    {
+                        title: 'High Availability',
+                        href: '/selfhosted/maintenance/scaling/high-availability',
+                    },
+                ],
+            },
             {
                 title: 'Infrastructure as Code',
                 isOpen: false,

--- a/src/pages/get-started/cli.mdx
+++ b/src/pages/get-started/cli.mdx
@@ -522,7 +522,7 @@ For SFTP and SCP, use native clients (`sftp` and `scp` commands) which work with
 - Verify your IdP is properly configured
 - To disable JWT authentication: `netbird up --allow-server-ssh --disable-ssh-auth`
 
-**Port forwarding not working:**
+**Port forwarding not workihng:**
 
 - Ensure the server has the appropriate flags:
   ```shell

--- a/src/pages/get-started/cli.mdx
+++ b/src/pages/get-started/cli.mdx
@@ -522,7 +522,7 @@ For SFTP and SCP, use native clients (`sftp` and `scp` commands) which work with
 - Verify your IdP is properly configured
 - To disable JWT authentication: `netbird up --allow-server-ssh --disable-ssh-auth`
 
-**Port forwarding not workihng:**
+**Port forwarding not working:**
 
 - Ensure the server has the appropriate flags:
   ```shell


### PR DESCRIPTION
<img width="338" height="319" alt="Screenshot 2026-07-25 at 20 50 23" src="https://github.com/user-attachments/assets/86ba0475-9b3e-4339-91b7-e2e4ece0e23d" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/docs/pr/885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787597431&installation_model_id=427504&pr_number=885&repository=netbirdio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdocs%2Fpull%2F885&signature=50446ec018cd7187c3a8f656f9faeb84bd867fd80e4e77e6e6346097522f0be2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the Commercial License section under Self-Host NetBird navigation with dedicated “Getting Started” and “High Availability” pages.
  - Added collapsible navigation for easier access to related documentation.

- **Documentation**
  - Updated the SSH troubleshooting section’s port-forwarding heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->