### PR TITLE
Correct Linux desktop app requirements and drop libappindicator

### DIFF
--- a/src/pages/get-started/install/linux.mdx
+++ b/src/pages/get-started/install/linux.mdx
@@ -6,25 +6,41 @@ The NetBird client (agent) allows a peer to join a pre-existing NetBird deployme
 
 ## Desktop App Dependencies
 
-The desktop app introduced in NetBird v0.75.0 renders its interface in a GTK 4 WebKit webview. Supported packages normally install these dependencies automatically. For manual or unsupported deployments, install the corresponding packages before launching the GUI.
+The desktop app introduced in NetBird v0.75.0 renders its interface in a GTK 4 WebKit webview. The `netbird-ui` package does not declare these libraries as dependencies, so install them alongside it.
 
-**Debian 12+ / Ubuntu 22.04+**
+<Warning>
+The desktop app requires **GTK 4.10 or newer** and **WebKitGTK 6.0**. On older GTK 4 releases the app starts but crashes as soon as it opens a file dialog, so install the `netbird` CLI only on those systems.
+</Warning>
+
+Minimum releases that satisfy both requirements:
+
+| Distribution | Desktop app | CLI |
+| --- | --- | --- |
+| Ubuntu | 24.04 LTS and newer | any supported release |
+| Debian | 13 (trixie) and newer | any supported release |
+| Fedora | 43 and newer | any supported release |
+| RHEL / AlmaLinux / Rocky | 10 and newer, with [EPEL](https://docs.fedoraproject.org/en-US/epel/getting-started/) | any supported release |
+| Amazon Linux | not available | 2 and 2023 |
+
+Ubuntu 22.04 (GTK 4.6) and Debian 12 (GTK 4.8) ship WebKitGTK 6.0 but their GTK 4 is below 4.10, so the desktop app is not supported there. RHEL 9 provides neither GTK 4.10 nor WebKitGTK 6.0.
+
+**Debian 13+ / Ubuntu 24.04+**
 
 ```bash
 sudo apt-get install libgtk-4-1 libwebkitgtk-6.0-4 xdg-utils
 ```
 
-**Fedora / RHEL 10+**
+**Fedora 43+ / RHEL 10+**
 
 ```bash
 sudo dnf install gtk4 webkitgtk6.0 xdg-utils
 ```
 
-<Note>
-RHEL 9 includes GTK 4 but does not provide WebKitGTK 6.0, which the desktop app requires. RHEL 10 is supported after enabling [EPEL](https://docs.fedoraproject.org/en-US/epel/getting-started/), which provides the `webkitgtk6.0` package.
-</Note>
+On other distributions, install the equivalent **GTK 4** (4.10+), **WebKitGTK 6.0**, and **xdg-utils** packages from your package manager. Many desktop systems already include some or all of them.
 
-On other distributions, install the equivalent **GTK 4**, **WebKitGTK 6.0**, and **xdg-utils** packages from your package manager, many systems may already include some of all of these packages.
+<Note>
+Linux `netbird-ui` packages are built for **x86_64** only. On arm64 and other architectures, use the `netbird` CLI.
+</Note>
 
 ## Linux Install Script
 
@@ -51,11 +67,15 @@ curl -fsSL https://pkgs.netbird.io/install.sh | sh
 ```bash
  # for CLI only
  sudo apt-get install netbird
- # for GUI package
- sudo apt-get install netbird-ui
+ # for the desktop app (Ubuntu 24.04+ / Debian 13+)
+ sudo apt-get install netbird-ui libgtk-4-1 libwebkitgtk-6.0-4 xdg-utils
 ```
 
-### RHEL/Amazon Linux 2 (RPM)
+### RHEL 9 / Amazon Linux 2 (YUM)
+
+<Note>
+These releases do not provide GTK 4.10 or WebKitGTK 6.0, so the desktop app is not available. Install the CLI and manage NetBird with `netbird` commands.
+</Note>
 
 1. Add the repository:
 ```bash
@@ -71,13 +91,10 @@ EOF
 ```
 2. Install the package
 ```bash
- # for CLI only
  sudo yum install netbird
- # for GUI package
- sudo yum install libappindicator-gtk3 libappindicator netbird-ui
 ```
 
-### Fedora/Amazon Linux 2023 (DNF)
+### Fedora / RHEL 10+ / Amazon Linux 2023 (DNF)
 
 1. Create the repository file:
 ```bash
@@ -102,10 +119,18 @@ EOF
 ```bash
  # for CLI only
  sudo dnf install netbird
- # for GUI package
- sudo dnf install libappindicator-gtk3 libappindicator netbird-ui
+ # for the desktop app (Fedora 43+ / RHEL 10+)
+ sudo dnf install netbird-ui gtk4 webkitgtk6.0 xdg-utils
 ```
-On some recent releases, the default behaviour for `libappindicator` was changed, so we need to install `gnome-shell-extension-appindicator` and enable it:
+
+On RHEL, AlmaLinux and Rocky Linux 10, `webkitgtk6.0` comes from EPEL, so enable it before installing the desktop app:
+```bash
+ sudo dnf install epel-release -y
+```
+
+Amazon Linux 2023 does not provide GTK 4 or WebKitGTK 6.0, so install the CLI only there.
+
+The tray icon uses the D-Bus StatusNotifierItem protocol. GNOME does not support it natively, so on GNOME desktops install `gnome-shell-extension-appindicator` and enable it:
 ```
 sudo dnf install gnome-shell-extension-appindicator
 sudo gnome-extensions enable appindicatorsupport@rgcjonas.gmail.com
@@ -132,8 +157,8 @@ EOF
 ```bash
  # for CLI only
  rpm-ostree install netbird
- # for GUI package
- rpm-ostree install netbird-ui
+ # for the desktop app
+ rpm-ostree install netbird-ui gtk4 webkitgtk6.0 xdg-utils
  # Don't forget to reboot to apply
 ```
 4. Start the service
@@ -238,6 +263,10 @@ reboot
 # Tumbleweed / Leap
 zypper in netbird
 ```
+
+<Note>
+These commands install the CLI. To use the desktop app, install `netbird-ui` together with your distribution's GTK 4.10+ and WebKitGTK 6.0 packages; openSUSE names them differently from Debian and Fedora, so check with `zypper search webkitgtk`.
+</Note>
 
 ### NixOS 22.11+/unstable
 


### PR DESCRIPTION
## Summary

The Wails 3 desktop app links **GTK 4.10+** and **WebKitGTK 6.0**. The page previously advertised a floor of Debian 12 / Ubuntu 22.04, which is below that, and still told RPM users to install `libappindicator`, which the app no longer uses.

Verified against the shipped `netbird-ui` v0.75.0 Linux binary:

```
DT_NEEDED: libgtk-4.so.1, libwebkitgtk-6.0.so.4, libjavascriptcoregtk-6.0.so.1,
           libsoup-3.0.so.0, libX11.so.6, libcairo.so.2,
           libgio/libglib/libgobject-2.0.so.0, libc.so.6
glibc:     max GLIBC_2.34  (not a constraint on any current distribution)
```

The binary imports `gtk_file_dialog_new` / `_open` / `_save` — [`GtkFileDialog`, added in GTK 4.10](https://docs.gtk.org/gtk4/class.FileDialog.html). Nothing sets `BIND_NOW`, so on an older GTK the app launches and then dies the first time it opens a file dialog.

## Distribution floor

| Distribution | GTK 4 | WebKitGTK 6.0 | Desktop app |
| --- | --- | --- | --- |
| Ubuntu 22.04 LTS | 4.6.9 | 2.50.4 | ❌ GTK too old |
| Ubuntu 24.04 LTS | 4.14.5 | 2.52.3 | ✅ |
| Ubuntu 26.04 LTS | 4.22.4 | 2.52.3 | ✅ |
| Debian 12 | 4.8.3 | 2.50.6 | ❌ GTK too old |
| Debian 13 | 4.18.6 | 2.52.5 | ✅ |
| Fedora 43 / 44 | 4.20.4 / 4.22.4 | 2.52.5 | ✅ |
| RHEL / AlmaLinux / Rocky 10 | — | EPEL 10 | ✅ with EPEL |
| RHEL 9 | 4.4.1 | none in EPEL 9 | ❌ CLI only |
| Amazon Linux 2 / 2023 | — | — | ❌ CLI only |

Screenshot
<img width="600" height="800" alt="localhost_3000_get-started_install_linux" src="https://github.com/user-attachments/assets/fe01f614-a4dc-444c-a700-52b8da036f72" />


## Changes

- Document the real per-distribution floor; mark RHEL 9 and Amazon Linux as CLI only.
- Name the GTK 4 / WebKitGTK 6.0 packages in the install commands. `netbird-ui` does **not** declare them (`.goreleaser_ui.yaml` lists only `netbird`), so `apt install netbird-ui` otherwise succeeds and produces an app that cannot start.
- Note that EPEL provides `webkitgtk6.0` on RHEL/AlmaLinux/Rocky 10, and only for the desktop app path.
- Remove `libappindicator-gtk3 libappindicator` from the RPM lines — the Wails 3 tray is a D-Bus StatusNotifierItem with no libappindicator linkage. The `gnome-shell-extension-appindicator` step stays, since GNOME still needs an SNI host.
- Note that Linux `netbird-ui` packages are x86_64 only.
- Correct the claim that packages install these dependencies automatically.

## Notes for the reviewer

- I could not pin RHEL 10's exact `gtk4` version (Red Hat's package manifest 403s, pkgs.org has no el10 data). It's inferred to clear 4.10 from EPEL 10 building `webkitgtk6.0` 2.50 against it — **worth a smoke test before merge.**
- Debian 12 has a second problem beyond GTK: per [DSA-6232-1](https://lists.debian.org/debian-security-announce/2026/msg00142.html), webkit2gtk is no longer security-supported in bookworm.
- Verified: `npm run lint:mdx` clean, page renders at `/get-started/install/linux` with no compile errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3NR7mS9qysiLUWpEjhMPP

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/docs/pr/888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787741742&installation_model_id=427504&pr_number=888&repository=netbirdio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdocs%2Fpull%2F888&signature=47985ba7dff120db99b394af7c2cd0732b387d9845398e8dd4ff752b3869c1c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Linux installation guidance with desktop app compatibility requirements, including GTK 4.10+ and WebKitGTK 6.0.
  * Added a minimum-supported distribution matrix and clarified that desktop app packages are currently x86_64-only.
  * Updated Fedora, RHEL, Amazon Linux, immutable Linux, MicroOS, and openSUSE instructions with accurate dependency and CLI-only guidance.
  * Added GNOME tray/appindicator notes and EPEL setup instructions where required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->