### PR TITLE
docs: add Commercial License Overview nav entry

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -550,9 +550,12 @@ export const docsNavigation = [
             { title: 'Automated Setup', href: '/selfhosted/automated-setup' },
             {
                 title: 'Commercial License',
-                href: '/selfhosted/enterprise',
                 isOpen: false,
                 links: [
+                    {
+                        title: 'Overview',
+                        href: '/selfhosted/enterprise',
+                    },
                     {
                         title: 'Getting Started',
                         href: '/selfhosted/enterprise/getting-started',


### PR DESCRIPTION
## What

`/selfhosted/enterprise` is now reachable from the sidebar as its own **Overview** entry, placed above **Getting Started**.

Previously the page was only linked from the **Commercial License** group label itself, so it was easy to miss and inconsistent with the rest of the sidebar.

## Before / After

```
Commercial License  →  Commercial License
  Getting Started         Overview
  High Availability       Getting Started
                          High Availability
```

## Why this shape

Every other section that has an index page uses a plain group with `Overview` as its first child — Networks, Cloud Marketplaces, Observability, Troubleshooting, Use Cases. This brings Commercial License in line with them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an **Overview** entry to the Commercial License section of the self-hosted documentation navigation.
  * Improved access to enterprise self-hosting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->