### PR TITLE
Document daemon IPC privilege requirements and the Windows named pipe

### DIFF
--- a/src/pages/client/desktop-app.mdx
+++ b/src/pages/client/desktop-app.mdx
@@ -81,10 +81,11 @@ The settings page uses a tabbed layout that groups options by what they control.
   Server**, **Enable Root Login** and SSH authentication, can only be changed by a
   privileged caller, because the background service runs as root on Linux and macOS
   and as LocalSystem on Windows while the app runs as you. The app shows those
-  switches as unavailable and puts the equivalent command next to them: run it in a
-  terminal with `sudo` on Linux and macOS, or from an elevated prompt on Windows,
-  where you can also start the app as administrator. A switch that is already on
-  stays operable, since turning these settings off never requires privileges.
+  switches as unavailable and puts the equivalent command next to them: run it with
+  `sudo` on Linux and macOS, or from an elevated prompt on Windows. Without those
+  rights, an administrator has to run it, or push the setting through
+  [MDM](#mdm-driven-ui), which the client applies itself. A switch that is already
+  on stays operable, since turning these settings off never requires privileges.
 </Note>
 
 **Connect on Startup** controls whether the background service reconnects when it starts. **Launch NetBird UI at Login** controls only whether the graphical interface opens when you sign in to the operating system. On a fresh desktop installation, launch at login is enabled once by default. Upgrades preserve the user's existing preference. Administrators can manage this behavior with [`disableAutostart`](/client/mdm-integration#disableAutostart).

--- a/src/pages/client/desktop-app.mdx
+++ b/src/pages/client/desktop-app.mdx
@@ -66,7 +66,8 @@ The settings page uses a tabbed layout that groups options by what they control.
 * **Network** for connectivity, DNS, routes, and IPv6 settings.
 * **Security** for inbound traffic, LAN access, and quantum-resistant encryption settings.
 * **Profiles** for managing the accounts the app knows about. See [Profiles](/client/profiles).
-* **SSH** for the native SSH server and its optional features.
+* **SSH** for the native SSH server and its optional features. Some of these
+  require privileges: see the note below.
 * **Advanced** for log-level and custom configuration options.
 * **Troubleshoot** for [capturing a debug bundle](#capturing-a-debug-bundle).
 * **About** for version information, useful links, and updating the app.
@@ -74,6 +75,17 @@ The settings page uses a tabbed layout that groups options by what they control.
 <p>
     <img src="/docs-static/img/client/desktop-app/settings-language.png" alt="Settings page with the General tab and Display Language picker" className="imagewrapper"/>
 </p>
+
+<Note>
+  The switches that decide who may obtain a shell on the machine, **Enable SSH
+  Server**, **Enable Root Login** and SSH authentication, can only be changed by a
+  privileged caller, because the background service runs as root on Linux and macOS
+  and as LocalSystem on Windows while the app runs as you. The app shows those
+  switches as unavailable and puts the equivalent command next to them: run it in a
+  terminal with `sudo` on Linux and macOS, or from an elevated prompt on Windows,
+  where you can also start the app as administrator. A switch that is already on
+  stays operable, since turning these settings off never requires privileges.
+</Note>
 
 **Connect on Startup** controls whether the background service reconnects when it starts. **Launch NetBird UI at Login** controls only whether the graphical interface opens when you sign in to the operating system. On a fresh desktop installation, launch at login is enabled once by default. Upgrades preserve the user's existing preference. Administrators can manage this behavior with [`disableAutostart`](/client/mdm-integration#disableAutostart).
 

--- a/src/pages/client/desktop-app.mdx
+++ b/src/pages/client/desktop-app.mdx
@@ -77,9 +77,9 @@ The settings page uses a tabbed layout that groups options by what they control.
 </p>
 
 <Note>
-  The switches that decide who may obtain a shell on the machine, **Enable SSH
-  Server**, **Enable Root Login** and SSH authentication, can only be changed by a
-  privileged caller, because the background service runs as root on Linux and macOS
+  The changes that decide who may obtain a shell on the machine, **Enable SSH
+  Server**, **Enable Root Login** and turning SSH authentication off, can only be
+  made by a privileged caller, because the background service runs as root on Linux and macOS
   and as LocalSystem on Windows while the app runs as you. The app shows those
   switches as unavailable and puts the equivalent command next to them: run it with
   `sudo` on Linux and macOS, or from an elevated prompt on Windows. Without those

--- a/src/pages/client/grpc-socket.mdx
+++ b/src/pages/client/grpc-socket.mdx
@@ -225,10 +225,10 @@ grpcurl \
 
 ### Query Status Through a TCP Socket
 
-For a custom loopback TCP listener. Note that `grpcurl` cannot dial a Windows named
-pipe, so the Windows default is not reachable this way; use a client that can open
-the pipe, or configure a TCP listener for testing and accept that [privileged
-operations](#privileged-operations) are refused on it:
+This applies to a custom loopback TCP listener, since `grpcurl` cannot dial a
+Windows named pipe and the Windows default is therefore not reachable this way. Use
+a client that can open the pipe, or configure a TCP listener for testing and accept
+that [privileged operations](#privileged-operations) are refused on it:
 
 ```shell
 grpcurl \

--- a/src/pages/client/grpc-socket.mdx
+++ b/src/pages/client/grpc-socket.mdx
@@ -21,14 +21,25 @@ The HTTP/JSON gateway is optional. The gRPC socket is available whenever the Net
 | Platform        | Default address                |
 | --------------- | ------------------------------ |
 | Linux and macOS | `unix:///var/run/netbird.sock` |
-| Windows         | `tcp://127.0.0.1:41731`        |
+| Windows         | `npipe://netbird`              |
+
+On Windows the daemon serves a named pipe. Which path that is depends on what the
+daemon may create: running as a service or elevated it serves
+`\\.\pipe\ProtectedPrefix\Administrators\netbird`, a namespace only administrators
+can create in, and otherwise it falls back to `\\.\pipe\netbird`. Clients try both
+and check who owns the pipe before using the plain name, so passing
+`npipe://netbird` is enough. Windows installations that predate the named pipe are
+migrated from `tcp://127.0.0.1:41731` automatically.
 
 <Warning>
-  **Security warning:** On supported Linux installations, the default Unix
-  socket allows read and write access for local users. The API exposes control
-  operations as well as status. If you require local-user isolation, place a
-  custom socket inside a restricted directory and ensure that the directory is
-  recreated securely at boot.
+  **Security warning:** The default Unix socket allows read and write access for
+  local users, so any local user can read status and configuration and perform
+  operations that do not require privileges. Operations that decide who may
+  obtain a shell on the machine are refused unless the caller is root, or an
+  administrator on Windows: see [Privileged
+  operations](#privileged-operations). If you require local-user isolation
+  beyond that, place a custom socket inside a restricted directory and ensure
+  that the directory is recreated securely at boot.
 </Warning>
 
 On Linux installations that use an instance-specific systemd service, the socket can instead be under `/var/run/netbird/<instance>.sock`. The NetBird CLI automatically uses the only socket in that directory when the default socket does not exist. If multiple instance sockets exist, pass the intended address explicitly with `--daemon-addr`.
@@ -46,6 +57,7 @@ Use the global `--daemon-addr` option when installing or reconfiguring the servi
 ```text
 unix:///path/to/netbird.sock
 tcp://host:port
+npipe://name
 ```
 
 <Warning>
@@ -92,7 +104,55 @@ netbird --daemon-addr tcp://127.0.0.1:41731 status
   TLS. Keep TCP listeners bound to a trusted interface such as `127.0.0.1` and
   do not expose them to an untrusted network. The API includes operations that
   can read or change the local NetBird daemon's state.
+
+  A TCP connection also carries no caller identity, so the daemon cannot tell
+  who is calling and refuses every [privileged
+  operation](#privileged-operations) on that socket, whoever runs the client.
+  Use a Unix socket, or `npipe://` on Windows, if your integration needs them.
 </Warning>
+
+## Privileged Operations
+
+Any local user can reach the socket, so the daemon authorizes individual operations
+by the identity of whoever calls it, read from the kernel rather than supplied by
+the client: `SO_PEERCRED` on Linux, `LOCAL_PEERCRED` on macOS, and the named-pipe
+client token on Windows. A caller whose identity cannot be established is refused.
+
+Since 0.76.0 the following require root, or an administrator on Windows, because
+they decide who may obtain a shell on the machine:
+
+| Change | Refused when |
+| --- | --- |
+| Enable the NetBird SSH server | the caller is not privileged |
+| Enable SSH root login | the caller is not privileged |
+| Disable SSH authentication | the caller is not privileged |
+| Change the management URL | the caller is not privileged and that profile has the SSH server enabled |
+| Deregister the peer (logout, profile removal) | the caller is not privileged and that profile has the SSH server enabled |
+
+Only the direction that creates the capability is guarded. Turning any of them off
+is always allowed, and restating a value that is already set is not a change, so an
+integration that submits a whole settings form does not start failing once an
+administrator enables SSH.
+
+A refusal comes back as gRPC `PermissionDenied` carrying a `google.rpc.ErrorInfo`
+detail, so an integration can recognise it without parsing the message:
+
+```text
+reason:   PRIVILEGE_REQUIRED
+domain:   daemon.netbird.io
+metadata: summary = "Enabling the NetBird SSH server requires root."
+          command = "sudo netbird down; sudo netbird up --allow-server-ssh"
+```
+
+Render `summary` and `command` rather than the raw error: `command` is the same
+operation with the privileges it needs, ready to run.
+
+<Note>
+  When the daemon itself runs unprivileged, as in a rootless container or on
+  Windows in netstack mode, a caller running as the daemon's own user is treated
+  as privileged. Such a caller can already rewrite the configuration the daemon
+  reads, so refusing it would protect nothing.
+</Note>
 
 ## Service Definition
 
@@ -165,7 +225,10 @@ grpcurl \
 
 ### Query Status Through a TCP Socket
 
-For the default Windows listener or a custom loopback TCP listener:
+For a custom loopback TCP listener. Note that `grpcurl` cannot dial a Windows named
+pipe, so the Windows default is not reachable this way; use a client that can open
+the pipe, or configure a TCP listener for testing and accept that [privileged
+operations](#privileged-operations) are refused on it:
 
 ```shell
 grpcurl \
@@ -229,6 +292,15 @@ This is expected. Supply `daemon.proto` with your tool's equivalent of the `grpc
 ### A Client Receives an Unavailable or Connection-Refused Error
 
 Confirm that the daemon is running and that the integration uses the same socket address as the service. For a Unix socket, also verify access to the socket and each parent directory. For TCP, verify the host and port and ensure the listener remains bound to a trusted interface.
+
+### A Call Is Refused With PermissionDenied
+
+The operation is one of the [privileged operations](#privileged-operations) and the
+caller is not root, or not an administrator on Windows. Check the `ErrorInfo` detail
+on the error: `PRIVILEGE_REQUIRED` in domain `daemon.netbird.io` means the daemon
+identified the caller and refused the change, rather than failing to reach it. On a
+TCP socket every such operation is refused, because the transport carries no caller
+identity.
 
 ### A Method or Field Is Unimplemented
 

--- a/src/pages/client/json-socket.mdx
+++ b/src/pages/client/json-socket.mdx
@@ -35,12 +35,19 @@ unix:///var/run/netbird-http.sock
 ```
 
 <Warning>
-  **Security warning:** On supported Linux installations, the default Unix
-  socket allows read and write access for local users. The API exposes control
-  operations as well as status. If you require local-user isolation, place a
-  custom socket inside a restricted directory and ensure that the directory is
-  recreated securely at boot.
+  **Security warning:** The default Unix socket allows read and write access for
+  local users. The API exposes control operations as well as status. If you
+  require local-user isolation, place a custom socket inside a restricted
+  directory and ensure that the directory is recreated securely at boot.
 </Warning>
+
+The gateway runs inside the daemon and re-dials it locally, so it reads the identity
+of its own HTTP client and forwards it, which is what lets the daemon authorize the
+request as that user rather than as the daemon itself. The
+[privileged operations](/client/grpc-socket#privileged-operations) therefore behave
+the same over HTTP as over gRPC, and a refusal comes back as HTTP 403 with the same
+`PRIVILEGE_REQUIRED` detail. Metadata headers reserved for that forwarding are
+dropped when a client supplies them.
 
 To enable it on an existing installation, reconfigure the service:
 
@@ -95,6 +102,11 @@ sudo netbird service reconfigure \
   listeners bound to a trusted interface such as `127.0.0.1` and do not expose
   them to an untrusted network. The API includes operations that can read or
   change the local NetBird daemon's state.
+
+  A TCP connection carries no caller identity, so the gateway cannot tell who is
+  calling and every
+  [privileged operation](/client/grpc-socket#privileged-operations) is refused on
+  such a socket, whoever runs the client.
 </Warning>
 
 To disable the gateway again, run:
@@ -240,6 +252,15 @@ If you supplied `--json-socket` without `--enable-json-socket`, NetBird rejects 
 ### Curl Reports Permission Denied
 
 Verify that the process running the integration can access the socket and every parent directory in its path. A custom restricted directory can prevent access even when the socket itself allows it.
+
+### A Request Is Refused With 403
+
+The operation is one of the
+[privileged operations](/client/grpc-socket#privileged-operations) and the HTTP
+client is not root, or not an administrator on Windows. The response body carries a
+`PRIVILEGE_REQUIRED` detail in domain `daemon.netbird.io`, with a summary and the
+command that performs the same operation with the privileges it needs. On a TCP
+gateway socket these operations are always refused.
 
 ### A TCP Request Cannot Connect
 

--- a/src/pages/get-started/cli.mdx
+++ b/src/pages/get-started/cli.mdx
@@ -42,7 +42,7 @@ Below is the list of global flags:
       --admin-url string        Admin Panel URL [http|https]://[host]:[port] (default "https://app.netbird.io:443")
   -A, --anonymize               anonymize IP addresses and non-netbird.io domains in logs and status output
   -c, --config string           Overrides the default profile file location. Deprecated on `up` and `login`; use `--service-env NB_CONFIG=<path>` instead.
-      --daemon-addr string      Daemon service address to serve CLI requests [unix|tcp]://[path|host:port] (default "unix:///var/run/netbird.sock")
+      --daemon-addr string      Daemon service address to serve CLI requests [unix|tcp|npipe]://[path|host:port|name] (default "unix:///var/run/netbird.sock", "npipe://netbird" on Windows)
   -n, --hostname string         Sets a custom hostname for the device
       --log-file console        Sets NetBird log paths written to simultaneously. If "console" is specified the log will be output to stdout. If "syslog" is specified the log will be sent to the syslog daemon. You can pass the flag multiple times or separate entries by comma (default [/var/log/netbird/client.log])
   -l, --log-level string        Sets NetBird log level (default "info")
@@ -509,9 +509,9 @@ For SFTP and SCP, use native clients (`sftp` and `scp` commands) which work with
 
 **Connection fails:**
 
-- Ensure SSH is enabled on the target peer:
+- Ensure SSH is enabled on the target peer, which requires root or an administrator:
   ```shell
-  netbird up --allow-server-ssh
+  sudo netbird down; sudo netbird up --allow-server-ssh
   ```
 - Verify SSH Access is enabled in the dashboard (Peers > your_peer > SSH Access)
 - Check that an ACL policy allows TCP port 22022
@@ -520,13 +520,13 @@ For SFTP and SCP, use native clients (`sftp` and `scp` commands) which work with
 
 - Complete the OIDC flow when prompted (browser window will open)
 - Verify your IdP is properly configured
-- To disable JWT authentication: `netbird up --allow-server-ssh --disable-ssh-auth`
+- To disable JWT authentication, as root or an administrator: `sudo netbird down; sudo netbird up --allow-server-ssh --disable-ssh-auth`
 
 **Port forwarding not working:**
 
 - Ensure the server has the appropriate flags:
   ```shell
-  netbird up --allow-server-ssh \
+  sudo netbird up --allow-server-ssh \
     --enable-ssh-local-port-forwarding \
     --enable-ssh-remote-port-forwarding
   ```

--- a/src/pages/get-started/cli.mdx
+++ b/src/pages/get-started/cli.mdx
@@ -833,6 +833,7 @@ This will output:
   -S, --system-info                Adds system information to the debug bundle (default true)
   -U, --upload-bundle              Uploads the debug bundle to a server
       --upload-bundle-url string   Service URL to get an upload URL for the debug bundle (default "https://upload.debug.netbird.io/upload-url")
+      --upload-bundle-insecure     Allow uploading to an http or untrusted-TLS upload server (self-hosted); requires root
 ```
 
 ### debug for
@@ -872,6 +873,7 @@ Log level restored to INFO
   -S, --system-info                Adds system information to the debug bundle (default true)
   -U, --upload-bundle              Uploads the debug bundle to a server
       --upload-bundle-url string   Service URL to get an upload URL for the debug bundle (default "https://upload.debug.netbird.io/upload-url")
+      --upload-bundle-insecure     Allow uploading to an http or untrusted-TLS upload server (self-hosted); requires root
 ```
 
 ### debug log

--- a/src/pages/help/troubleshooting-client.mdx
+++ b/src/pages/help/troubleshooting-client.mdx
@@ -308,6 +308,11 @@ Upload file key:
 <Note>
   The flag `--anonymize` can be used to anonymize IP addresses and non-netbird.io domains in logs and status output when needed.
 </Note>
+
+<Note>
+  Uploading to a custom endpoint with `--upload-bundle-url` (for example a self-hosted upload server) requires root/administrator and an `https` URL. To upload to a server that uses `http` or an untrusted TLS certificate, add `--upload-bundle-insecure`.
+</Note>
+
 ### Debug bundle uploads with GUI
 The desktop app can create and optionally upload a debug bundle without using the CLI. Open **Settings → Troubleshoot**.
 

--- a/src/pages/manage/peers/access-infrastructure/setup-keys-add-servers-to-network.mdx
+++ b/src/pages/manage/peers/access-infrastructure/setup-keys-add-servers-to-network.mdx
@@ -202,7 +202,7 @@ This feature allows you to securely access your VM with SSH without exposing it 
 for distributing and managing SSH keys. To enable NetBird SSH access, run the following command on your VM:
 
 ```bash
-netbird up --allow-server-ssh
+sudo netbird up --allow-server-ssh
 ```
 
 You can then use the NetBird SSH client to connect to your VM:

--- a/src/pages/manage/peers/ssh.mdx
+++ b/src/pages/manage/peers/ssh.mdx
@@ -69,12 +69,18 @@ On the machine you want to access via SSH, enable the NetBird SSH server.
 
 <Note>
   **Enable SSH Server**, **Enable Root Login** and the SSH authentication switch
-  require privileges. On Linux and macOS the desktop app runs as your own user, so
-  it cannot make these changes: it shows those switches as unavailable with the
-  equivalent command next to them, which you run in a terminal with `sudo`. On
-  Windows, either start the app as administrator or run the same command from an
-  elevated prompt. A switch that is already on stays operable, because turning
-  these settings off never requires privileges.
+  require privileges on every platform, because the background service runs as root
+  or LocalSystem while the desktop app runs as you. The app shows those switches as
+  unavailable and puts the equivalent command next to them, to run with `sudo` on
+  Linux and macOS or from an elevated prompt on Windows.
+
+  On a machine where you do not have those rights, which is the normal case for a
+  managed workstation, you cannot enable the SSH server yourself: an administrator
+  has to run the command, or push
+  [`allowServerSSH`](/client/mdm-integration#policy-keys-reference) through MDM,
+  which the client applies itself and so needs nothing from you. A switch that is
+  already on stays operable, because turning these settings off never requires
+  privileges.
 </Note>
 
 <p>

--- a/src/pages/manage/peers/ssh.mdx
+++ b/src/pages/manage/peers/ssh.mdx
@@ -67,6 +67,16 @@ On the machine you want to access via SSH, enable the NetBird SSH server.
 2. Go to **Settings → SSH**.
 3. Toggle **Enable SSH Server**. Configure local forwarding, remote forwarding, SFTP, or root access only when required.
 
+<Note>
+  **Enable SSH Server**, **Enable Root Login** and the SSH authentication switch
+  require privileges. On Linux and macOS the desktop app runs as your own user, so
+  it cannot make these changes: it shows those switches as unavailable with the
+  equivalent command next to them, which you run in a terminal with `sudo`. On
+  Windows, either start the app as administrator or run the same command from an
+  elevated prompt. A switch that is already on stays operable, because turning
+  these settings off never requires privileges.
+</Note>
+
 <p>
     <img src="/docs-static/img/manage/peers/ssh/ssh-client.png" alt="SSH server settings in the NetBird desktop app"
          className="imagewrapper"/>

--- a/src/pages/manage/peers/ssh.mdx
+++ b/src/pages/manage/peers/ssh.mdx
@@ -68,7 +68,7 @@ On the machine you want to access via SSH, enable the NetBird SSH server.
 3. Toggle **Enable SSH Server**. Configure local forwarding, remote forwarding, SFTP, or root access only when required.
 
 <Note>
-  **Enable SSH Server**, **Enable Root Login** and the SSH authentication switch
+  **Enable SSH Server**, **Enable Root Login** and turning SSH authentication off
   require privileges on every platform, because the background service runs as root
   or LocalSystem while the desktop app runs as you. The app shows those switches as
   unavailable and puts the equivalent command next to them, to run with `sudo` on

--- a/src/pages/manage/peers/ssh.mdx
+++ b/src/pages/manage/peers/ssh.mdx
@@ -75,19 +75,28 @@ On the machine you want to access via SSH, enable the NetBird SSH server.
 **Using the CLI:**
 
 ```bash
-netbird down  # if NetBird is already running
-netbird up --allow-server-ssh
+sudo netbird down  # if NetBird is already running
+sudo netbird up --allow-server-ssh
 ```
 
 For additional SSH server features, use these flags:
 
 ```bash
-netbird up --allow-server-ssh \
+sudo netbird up --allow-server-ssh \
   --enable-ssh-local-port-forwarding \
   --enable-ssh-remote-port-forwarding \
   --enable-ssh-sftp \
   --enable-ssh-root
 ```
+
+<Note>
+  Enabling the SSH server, enabling root login, and disabling SSH
+  authentication require root on Linux and macOS, or an administrator on
+  Windows. The daemon reads the identity of whoever calls it locally and refuses
+  these changes to anyone else, since they decide who may obtain a shell on the
+  machine. Turning any of them off does not require privileges. Run the
+  commands with `sudo`, or from an elevated prompt on Windows.
+</Note>
 
 **Flag Reference:**
 


### PR DESCRIPTION
Documents the local daemon IPC authorization added in client v0.76.0, and corrects the Windows daemon address, which is now a named pipe rather than loopback TCP.

- Add a "Privileged Operations" section to the gRPC socket page: which operations require root or an administrator, how the daemon identifies a local caller on each platform, and the `PRIVILEGE_REQUIRED` error detail an integration should render instead of the raw error
- Replace the Windows default address `tcp://127.0.0.1:41731` with `npipe://netbird`, explain the protected-namespace and fallback pipe paths, and note that existing installations are migrated automatically
- Warn that a TCP daemon or gateway socket carries no caller identity, so privileged operations are refused on it whoever runs the client
- Note on the JSON socket page that the gateway forwards its HTTP client's identity, and that a refusal arrives as HTTP 403 with the same detail
- Use `sudo` in the SSH server examples on the SSH, CLI and setup-key pages, since enabling the SSH server, root login or the auth bypass now requires privileges
- Explain on the SSH and desktop app pages that the app cannot change those switches on Linux and macOS, where it runs as your own user, and shows the equivalent command instead
- Add troubleshooting entries for a refused call on both socket pages

## Screenshots

Full-page captures of the changed pages are local PNGs from the dev server, in
`/tmp/claude-1000/-home-vma-dev-netbird/ca53bbcd-1c59-460f-a74f-e719b663a766/scratchpad/shots/`
(`docs-grpc-socket`, `docs-json-socket`, `docs-peers-ssh`), taken at 1920px.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/docs/pr/894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787990042&installation_model_id=427504&pr_number=894&repository=netbirdio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdocs%2Fpull%2F894&signature=ed2988df460408b0636c7bc18c50383e65e6531869770703bae2cdf83535c18d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that enabling SSH server access, root login, and SSH authentication changes require elevated privileges (while disabling may remain usable in some cases), including managed workstation guidance.
  * Updated CLI/automation examples to use elevated `netbird down` / `netbird up --allow-server-ssh`.
  * Added Windows named-pipe (`npipe://netbird`) support and refreshed default address guidance.
  * Expanded security and troubleshooting for privileged-operation denials over TCP/HTTP (including `PRIVILEGE_REQUIRED`), plus grpcurl testing notes.
  * Added warnings for debug bundle uploads, including root/admin and secure URL requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->