### PR TITLE
List each supported IdP as a heading on the IdP-Sync page

### DIFF
--- a/src/pages/manage/team/idp-sync/index.mdx
+++ b/src/pages/manage/team/idp-sync/index.mdx
@@ -30,17 +30,33 @@ offboarding scenarios:
 
 ## Supported Identity Providers
 
-NetBird provides native support for syncing with the most popular identify providers.
-For detailed setup and configuration steps, select an IdP from the section below:
+NetBird provides native support for syncing with the most popular identity providers. Pick yours below for detailed setup and configuration steps.
 
-* [Entra ID (API)](/manage/team/idp-sync/microsoft-entra-id-sync)
-* [Entra ID (SCIM)](/manage/team/idp-sync/microsoft-entra-id-scim-sync)
-* [Okta](/manage/team/idp-sync/okta-sync)
-* [Google Workspace](/manage/team/idp-sync/google-workspace-sync)
-* [JumpCloud](/manage/team/idp-sync/jumpcloud-sync)
-* [Keycloak](/manage/team/idp-sync/keycloak-sync)
+### Entra ID (API)
 
-### Generic SCIM
+Provision users and groups from Microsoft Entra ID through the Graph API. See [Entra ID (API) setup](/manage/team/idp-sync/microsoft-entra-id-sync).
+
+### Entra ID (SCIM)
+
+Provision users and groups from Microsoft Entra ID over SCIM. See [Entra ID (SCIM) setup](/manage/team/idp-sync/microsoft-entra-id-scim-sync).
+
+### Okta
+
+Provision users and groups from Okta. See [Okta setup](/manage/team/idp-sync/okta-sync).
+
+### Google Workspace
+
+Provision users and groups from Google Workspace. See [Google Workspace setup](/manage/team/idp-sync/google-workspace-sync).
+
+### JumpCloud
+
+Provision users and groups from JumpCloud. See [JumpCloud setup](/manage/team/idp-sync/jumpcloud-sync).
+
+### Keycloak
+
+Provision users and groups from Keycloak. See [Keycloak setup](/manage/team/idp-sync/keycloak-sync).
+
+## Generic SCIM
 
 NetBird provides a way to sync users and groups from any identity provider that supports the SCIM (System for Cross-domain Identity Management) protocol.
 SCIM is a standardized protocol that works with most modern identity providers, although configuration varies between providers.


### PR DESCRIPTION
## What

On the [IdP-Sync page](/manage/team/idp-sync), the supported identity providers were a bulleted list of links, so none of them showed up in the right-hand "On this page" navigation. Only "Supported Identity Providers" and "Generic SCIM" appeared, and "Generic SCIM" was nested as a sub-item.

This makes each supported IdP a subsection heading (with its setup link) and promotes "Generic SCIM" to a top-level section, so the TOC lists them all:

- Supported Identity Providers
  - Entra ID (API), Entra ID (SCIM), Okta, Google Workspace, JumpCloud, Keycloak
- Generic SCIM

Also fixes a typo ("identify" to "identity"). No content was removed, and the setup links are unchanged.

## Screenshot

"On this page" after the change:

<img src="https://raw.githubusercontent.com/emrcbrn/docs/pr-assets-idp-sync-toc/pr-assets/idp-toc-dark.png" width="360">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the identity provider synchronization guide with dedicated sections for Entra ID API, Entra ID SCIM, Okta, Google Workspace, JumpCloud, and Keycloak.
  * Added provider descriptions and setup links while retaining the Generic SCIM guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->