### PR TITLE
Fix API docs sidebar not expanding on client-side navigation

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -103,7 +103,16 @@ const nextConfig = {
             {
                 source: '/ipa/:path*',
                 destination: '/api/:path*',
-                permanent: true
+                permanent: true,
+                // Client-side navigations fetch page props from
+                // /_next/data/<buildId>/ipa/... — redirecting those requests
+                // strips pageProps (title, sections), so skip data requests.
+                missing: [
+                    {
+                        type: 'header',
+                        key: 'x-nextjs-data',
+                    },
+                ],
             },
             // documentation redirects for about
             {


### PR DESCRIPTION
## Problem

Navigating to an API resource page (e.g. `/api/resources/networks`) via a link left the sidebar method list collapsed and set the browser tab title to `undefined - NetBird API`. Both fixed themselves only after a full page reload.

## Cause

On client-side navigation, Next.js fetches the target page's props from `/_next/data/<buildId>/ipa/...`. Next matches these data URLs against redirects using the page path, so the canonical-URL redirect `/ipa/:path*` → `/api/:path*` answered the props fetch with a 308 instead of JSON. The router never received `pageProps`, which carries both `sections` (the method list the sidebar expands from) and `title`. A full reload worked because statically generated HTML has the props inlined.

## Fix

Add a `missing` condition on the `x-nextjs-data` header to that redirect. The router's props fetch always sends this header, so data requests now bypass the redirect and return JSON; plain browser visits to `/ipa/*` don't send it and still get the canonical 308 to `/api/*`.

- Props fetch for `/ipa/resources/networks` now returns 200 with full `pageProps` (title and all method sections)
- Direct request to `/ipa/resources/networks` still returns 308 → `/api/resources/networks`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Next.js client-side data requests could be incorrectly redirected from `/ipa` to `/api`.
  * Existing permanent redirects remain unchanged for other requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->