### PR TITLE
Cross-link cloud and self-hosted quickstarts

### DIFF
--- a/src/pages/get-started/index.mdx
+++ b/src/pages/get-started/index.mdx
@@ -5,6 +5,10 @@ import {Note} from "@/components/mdx";
 Welcome to NetBird! This guide will walk you through our new onboarding process to create your account, connect your first devices,
 and build a secure peer-to-peer overlay network in less than ten minutes.
 
+<Note>
+    This guide covers NetBird Cloud, the managed version of NetBird. If you prefer to run NetBird on your own infrastructure, follow the [Self-Hosting Quickstart](/selfhosted/selfhosted-quickstart) instead.
+</Note>
+
 <YouTube videoId="dr0u-u9uD84" />
 
 ## Create Your Account

--- a/src/pages/selfhosted/selfhosted-quickstart.mdx
+++ b/src/pages/selfhosted/selfhosted-quickstart.mdx
@@ -1,12 +1,16 @@
 import {Tiles} from "@/components/Tiles"
+import {Button} from "@/components/Button"
 
 # Self-Hosting Quickstart Guide (5 min)
 
 NetBird is open source and can be self-hosted on your servers. If you would like to learn more about the architecture please refer to the [Architecture section](/about-netbird/how-netbird-works).
 
-<Note>
-This is the quickest way to try self-hosted NetBird. It should take around 5 minutes to get started if you already have a public domain and a VM.
-</Note>
+Prefer not to manage the infrastructure yourself? **[NetBird Cloud](/get-started)** is the managed version of NetBird, no servers or domain required.
+
+<div className="not-prose mb-12 mt-6 flex justify-end gap-3">
+  <Button href="/about-netbird/self-hosted-vs-cloud" variant="outline-arrow" arrow="right" children="Cloud vs Self-Hosted" />
+  <Button href="https://app.netbird.io" arrow="right" children="Try NetBird Cloud" />
+</div>
 
 ## Infrastructure requirements
 - A Linux VM with at least **1CPU** and **2GB** of memory.


### PR DESCRIPTION
## Summary

<img width="1460" height="558" alt="Screenshot 2026-08-04 at 11 38 23 PM" src="https://github.com/user-attachments/assets/a0cb2793-299e-48da-832a-21ee59d14084" />

### `src/pages/get-started/index.mdx` (cloud quickstart)
- Added a note after the intro clarifying this guide covers NetBird Cloud, with a link to the [Self-Hosting Quickstart](https://docs.netbird.io/selfhosted/selfhosted-quickstart) for users who want to run NetBird on their own infrastructure.

### `src/pages/selfhosted/selfhosted-quickstart.mdx` (self-hosted quickstart)
- Removed the redundant note under the title. It repeated the "quickstart" and "5 min" info already in the H1, and the domain/VM prerequisite is covered in the Infrastructure requirements section right below.
- Added a short pitch for **NetBird Cloud** (linked to the cloud quickstart) for users who prefer not to manage infrastructure themselves.
- Added a right-aligned button row using the existing `Button` component:
  - Grey outline button "Cloud vs Self-Hosted" linking to the [comparison page](https://docs.netbird.io/about-netbird/self-hosted-vs-cloud)
  - Primary button "Try NetBird Cloud" linking to https://app.netbird.io

## Why

Users landing on either quickstart had no clear path to the other deployment option. The self-hosted guide now surfaces the managed option prominently, and the cloud guide points self-hosters to the right place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the Getting Started guide covers NetBird Cloud.
  * Added a link directing self-hosted users to the Self-Hosting Quickstart.
  * Added quick links to compare Cloud and Self-Hosted options and access NetBird Cloud.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->