### PR TITLE
docs: fix stale file references in MDM templates

### DIFF
--- a/public/docs-static/files/io.netbird.client.plist
+++ b/public/docs-static/files/io.netbird.client.plist
@@ -19,17 +19,17 @@
 
     For MDM platforms that expect a full Configuration Profile instead
     of a bare plist (Custom Configuration Profile / .mobileconfig upload),
-    use docs/netbird-macos.mobileconfig — same keys, additional Payload*
+    use netbird-macos.mobileconfig — same keys, additional Payload*
     envelope.
 
     Editing this file:
       - Remove or comment out any key you do NOT want to enforce. The
         daemon treats an absent key as "no enforcement" for that field.
       - Keep the document well-formed XML. Validate locally with:
-            plutil -lint docs/io.netbird.client.plist
+            plutil -lint io.netbird.client.plist
       - Keys are camelCase; values are typed (<string>, <true/>, <false/>,
-        <integer>). See docs/src/pages/client/mdm-integration.mdx (the
-        public docs page) for the full reference.
+        <integer>). See https://docs.netbird.io/client/mdm-integration
+        for the full reference.
 
     Persistence caveat:
       macOS wipes /Library/Managed Preferences/ at every boot on

--- a/public/docs-static/files/netbird-macos.mobileconfig
+++ b/public/docs-static/files/netbird-macos.mobileconfig
@@ -8,17 +8,17 @@
         /Library/Managed Preferences/io.netbird.client.plist
 
     Read at runtime by the netbird daemon's macOS loader
-    (client/mdm/policy_darwin.go — Phase 2). Key names match the canonical
-    lowerCamelCase form used in docs/netbird.admx and the mdm.Key*
+    (client/mdm/policy_darwin.go). Key names match the canonical
+    lowerCamelCase form used in netbird.admx and the mdm.Key*
     constants in client/mdm/policy.go.
 
     Bundle identifier: io.netbird.client
         (confirm against the signed pkg before fleet roll-out)
 
     Distribution:
-      - sign with `productsign --sign "Developer ID Installer: ..." ...`
-        before fleet roll-out (Apple-Configurator-2 won't install an
-        unsigned profile on Sonoma+ without user override).
+      - sign the profile with your Developer ID Installer identity before
+        fleet roll-out (Apple-Configurator-2 won't install an unsigned
+        profile on Sonoma+ without user override).
       - For local dev install: `sudo profiles install -path netbird-macos.mobileconfig`.
       - For MDM (Jamf/Kandji/Mosyle/Intune): upload as a Custom Profile.
 
@@ -36,7 +36,7 @@
       UserDefaults[com.apple.configuration.managed] under a different
       payload type (com.apple.app.configuration.managed); the wrapper
       structure is the same but the inner payload dictionary differs.
-      See docs/netbird-ios.mobileconfig (Phase 5) when shipped.
+      An iOS sample profile is not shipped yet.
 -->
 <plist version="1.0">
 <dict>

--- a/public/docs-static/files/netbird-macos.sh
+++ b/public/docs-static/files/netbird-macos.sh
@@ -4,7 +4,7 @@
 #   Push the NetBird MDM policy to a macOS device via JumpCloud Commands.
 #
 # DESCRIPTION
-#   This is the macOS counterpart of docs/netbird-policy.reg.ps1.
+#   This is the macOS counterpart of netbird-policy.reg.ps1.
 #   It writes the values declared in the "POLICY VALUES" block below to
 #   the managed-preferences plist that the NetBird daemon's
 #   client/mdm/policy_darwin.go loader reads on every 1-minute MDM
@@ -25,7 +25,7 @@
 # IMPORTANT: PERSISTENCE
 #   macOS wipes /Library/Managed Preferences/ at every boot on devices
 #   that are NOT MDM-enrolled. For a persistent fleet rollout, push the
-#   companion docs/netbird-macos.mobileconfig as a Custom Configuration
+#   companion netbird-macos.mobileconfig as a Custom Configuration
 #   Profile (Admin Console -> MDM -> Mac Custom Configuration Profiles)
 #   instead of this script. Use this script when:
 #     - the device is MDM-enrolled (file survives reboots), or
@@ -49,8 +49,8 @@ set -euo pipefail
 #
 # Reference for key names + accepted values:
 #   client/mdm/policy.go (Key* constants)
-#   docs/netbird-macos.mobileconfig (sample profile)
-#   docs/netbird.admx + .adml (Windows ADMX schema)
+#   netbird-macos.mobileconfig (sample profile)
+#   netbird.admx + netbird.adml (Windows ADMX schema)
 #
 NULL='__UNSET__'
 managementURL='https://api.netbird.io:443'

--- a/public/docs-static/files/netbird-policy.reg.ps1
+++ b/public/docs-static/files/netbird-policy.reg.ps1
@@ -5,7 +5,7 @@
   by importing a sidecar netbird-policy.reg file.
 
 .DESCRIPTION
-  Windows counterpart of docs/netbird-macos.sh. Outcome:
+  Windows counterpart of netbird-macos.sh. Outcome:
   HKLM\Software\Policies\NetBird populated from the attached
   netbird-policy.reg file, daemon picks up the change via the
   1-minute MDM reload ticker.


### PR DESCRIPTION
The downloadable MDM templates referenced sibling files with a `docs/` prefix that does not exist from the reader's point of view: the files are served flat under /docs-static/files/, and admins download them individually. Reference them by plain filename instead, and point the plist at the public docs URL rather than the .mdx source path.

Also drop two internal-only details that leaked into public templates (the "Phase 2"/"Phase 5" roadmap markers) and fix netbird-macos.mobileconfig, which was not well-formed XML: the header comment contained `--` (`productsign --sign`), which XML 1.0 forbids inside a comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS MDM and policy script documentation with corrected file references and validation paths.
  * Simplified profile-signing guidance and clarified that no sample iOS profile is currently provided.
  * Added links to the relevant MDM integration documentation.
  * Clarified PowerShell and shell script documentation without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->