### PR TITLE
fix: correct broken documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The NetBird documentation
 
-This repository contains assets required to build the [documentation website for NetBird](https://netbird.io/docs/). It is built using [Next.js](https://nextjs.org/) with MDX support, a modern React framework for building static and dynamic websites.
+This repository contains assets required to build the [documentation website for NetBird](https://docs.netbird.io/). It is built using [Next.js](https://nextjs.org/) with MDX support, a modern React framework for building static and dynamic websites.
 
 We're glad that you want to contribute!
 


### PR DESCRIPTION
https://netbird.io/docs/ in readme leads to 404

<img width="1681" height="848" alt="Screenshot 2026-08-09 at 22 38 57" src="https://github.com/user-attachments/assets/36206d9e-3205-4249-a235-ee08a119a5f0" />

Updated it to https://docs.netbird.io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the repository description to link to the documentation site at `docs.netbird.io/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->