### PR TITLE
Fix SQLite migration for additional account settings

### DIFF
--- a/src/pages/selfhosted/maintenance/scaling/migrate-sqlite-to-postgresql.mdx
+++ b/src/pages/selfhosted/maintenance/scaling/migrate-sqlite-to-postgresql.mdx
@@ -48,6 +48,8 @@ sudo apt-get install pgloader sqlite3 postgresql-client
 
 # macOS
 brew install pgloader sqlite3 libpq
+# Export libpq to the PATH to allow using it's command-line tools.
+export PATH="$(brew --prefix libpq)/bin:$PATH"
 ```
 
 ## Create the Migration File

--- a/src/pages/selfhosted/maintenance/scaling/migrate-sqlite-to-postgresql.mdx
+++ b/src/pages/selfhosted/maintenance/scaling/migrate-sqlite-to-postgresql.mdx
@@ -48,7 +48,7 @@ sudo apt-get install pgloader sqlite3 postgresql-client
 
 # macOS
 brew install pgloader sqlite3 libpq
-# Export libpq to the PATH to allow using it's command-line tools.
+# Export libpq to the PATH to allow using its command-line tools.
 export PATH="$(brew --prefix libpq)/bin:$PATH"
 ```
 

--- a/src/pages/selfhosted/maintenance/scaling/migrate-sqlite-to-postgresql.mdx
+++ b/src/pages/selfhosted/maintenance/scaling/migrate-sqlite-to-postgresql.mdx
@@ -44,10 +44,10 @@ The migration uses [pgloader](https://github.com/dimitri/pgloader) to transfer d
 
 ```bash
 # Debian/Ubuntu
-sudo apt-get install pgloader
+sudo apt-get install pgloader sqlite3 postgresql-client
 
 # macOS
-brew install pgloader
+brew install pgloader sqlite3 libpq
 ```
 
 ## Create the Migration File
@@ -74,6 +74,8 @@ CAST
      column accounts.settings_lazy_connection_enabled             to boolean,
      column accounts.settings_peer_expose_enabled                 to boolean,
      column accounts.settings_auto_update_always                  to boolean,
+     column accounts.settings_metrics_push_enabled                to boolean,
+     column accounts.settings_agent_network_only                  to boolean,
      column accounts.settings_local_mfa_enabled                   to boolean
 ;
 ```


### PR DESCRIPTION
## Summary

Updates the SQLite-to-PostgreSQL migration guide to cast two additional account settings to PostgreSQL booleans:

- `settings_metrics_push_enabled`
- `settings_agent_network_only`

Without these casts, pgloader can retain incompatible SQLite types and defaults, causing the migration to fail with `invalid input syntax for type numeric: "false"`.

The installation instructions now also include the SQLite and PostgreSQL command-line tools used by the guide.

## Validation

Tested changes in a fresh Ubuntu 24.04 virtual machine.

- `npm run lint:mdx` passes.
- `npm run build` passes.
- `git diff --check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated SQLite-to-PostgreSQL migration instructions for Debian, Ubuntu, and macOS.
  * Added required SQLite and PostgreSQL client tooling to the installation steps.
  * Included macOS `libpq` PATH configuration guidance.
  * Improved migration handling for metrics push and agent network access settings by converting values to boolean format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->