### PR TITLE
Document the remote-jobs opt-in and MDM keys

### DIFF
--- a/src/pages/client/mdm-integration.mdx
+++ b/src/pages/client/mdm-integration.mdx
@@ -70,6 +70,8 @@ PascalCase variant in the Group Policy Editor — both are recognized.
 | `preSharedKey` | string | WireGuard pre-shared key. Treated as secret and redacted in logs. |
 | `wireguardPort` | integer | UDP port the local WireGuard interface binds to. Range `1–65535`. |
 | `allowServerSSH` | boolean | Allow the embedded NetBird SSH server on this peer. |
+| `allowRemoteJobs` | boolean | Allow management-requested remote jobs (e.g. debug bundles) on this peer. Off by default; equivalent to `--allow-remote-jobs`. |
+| `debugBundleUploadURL` | string | Override the upload service used for debug bundles produced by remote jobs, taking precedence over the value requested by Management. Must be an `https` URL with a host. |
 | `disableAutoConnect` | boolean | Skip auto-connecting on startup; require an explicit `netbird up`. |
 | <span id="disableAutostart"></span>`disableAutostart` | boolean | Prevent the GUI from registering itself as an OS autostart entry on fresh installs, and — when enabled at any later point — remove an existing registration on the next GUI launch (Windows Registry `Run` key, macOS Login Item, Linux `.desktop`). Desktop GUIs only; no-op on iOS/Android. Once the admin lifts the policy, the setting stays off until the user re-enables it in Settings. |
 | `lazyConnection` | boolean | Local override for lazy connections. `true` forces lazy connections on, `false` forces them off, and an absent key defers to the Management setting. `NB_LAZY_CONN` takes precedence when both are configured. |

--- a/src/pages/manage/peers/remote-jobs.mdx
+++ b/src/pages/manage/peers/remote-jobs.mdx
@@ -8,6 +8,10 @@ Remote Jobs allow administrators to trigger actions on connected peers without r
     Remote Jobs require the target peer to be **online** and running **NetBird v0.64.0 or later**.
 </Note>
 
+<Note>
+    Remote Jobs are **opt-in on the peer** and disabled by default. A peer accepts remote jobs only when started with `--allow-remote-jobs`, or when the `allowRemoteJobs` [MDM policy](/client/mdm-integration) is set. Enabling it is a privileged operation on the client (like enabling the embedded SSH server). Peers that have not opted in report this to Management, and the Dashboard disables the **Run Remote Job** button for them.
+</Note>
+
 ## Overview
 
 Remote Jobs are managed per-peer and follow a simple lifecycle:
@@ -57,6 +61,8 @@ The Debug Bundle job remotely collects diagnostic information from a peer, inclu
 | Log File Count | Number of log files to include | 1 - 1000 | 10 |
 | Bundle Duration | Time period to collect logs before creating the bundle | 1 - 5 minutes | Disabled |
 | Anonymize | Remove sensitive information (IP addresses, domains, etc.) | On / Off | Off |
+| Anonymization Level | With Anonymize on, `default` keeps internal (private) IP ranges readable; `strict` also anonymizes private, CGNAT and link-local addresses | `default` / `strict` | `default` |
+| Upload URL | Upload service the peer requests an upload URL from (must be an `https` URL). A peer with the `debugBundleUploadURL` [MDM policy](/client/mdm-integration) set overrides this value | https URL | Default upload server |
 
 **Result:**
 
@@ -81,7 +87,7 @@ On success, the job returns an **upload key** that can be used to retrieve the d
 </p>
 
 <Note>
-    The **Run Remote Job** button is disabled when the peer is offline or when you lack the required permissions.
+    The **Run Remote Job** button is disabled when the peer is offline, when the peer has not opted into remote jobs, or when you lack the required permissions.
 </Note>
 
 ### Viewing Job History
@@ -137,6 +143,7 @@ curl https://api.netbird.io/api/peers/{peerId}/jobs/{jobId} \
 ## Limitations
 
 - The target peer must be **online and connected** to the management server
+- The target peer must have **opted into remote jobs** (`--allow-remote-jobs` or the `allowRemoteJobs` MDM policy)
 - Only **one pending job** per peer at a time
 - Peers must be running **NetBird v0.64.0 or later**
 - Jobs time out after **5 minutes** if the peer does not respond


### PR DESCRIPTION
Documents the remote-jobs client opt-in and the two new MDM policy keys introduced in netbirdio/netbird#7153, plus the new debug-bundle parameters from netbirdio/netbird#7147.

- **MDM integration reference** (`client/mdm-integration`): add `allowRemoteJobs` (boolean) and `debugBundleUploadURL` (string) to the managed-keys table.
- **Remote Jobs** (`manage/peers/remote-jobs`): note that remote jobs are opt-in on the peer (default off; `--allow-remote-jobs` or the `allowRemoteJobs` MDM policy), that peers which haven't opted in are surfaced to the Dashboard (Run Remote Job disabled), and add the new **Anonymization Level** and **Upload URL** bundle parameters.

Tracked in NET-1489 (parent NET-1484). Pairs with netbirdio/netbird#7153 and #7147; merge alongside them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUdj7EhXdGMd953nHoBUTD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added MDM policy reference entries for authorizing Remote Jobs and overriding Debug Bundle upload URLs.
  * Clarified that peers must explicitly opt in to Remote Jobs.
  * Documented anonymization levels and configurable Debug Bundle upload URLs.
  * Updated Dashboard guidance for peers that have not opted in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->