### PR TITLE
generator: support x-omit-from-example on spec properties

### DIFF
--- a/generator/api.ts
+++ b/generator/api.ts
@@ -203,6 +203,15 @@ async function gen_v3(spec: OpenAPIV3.Document, dest: string) {
   })
 }
 
+// A property marked with `x-omit-from-example: true` in the spec is left out
+// of the composed request/response examples (e.g. one side of a mutually
+// exclusive pair, where including both would show an invalid payload). It
+// remains fully documented in the parameter list, which renders from the
+// schema directly.
+function isOmittedFromExample(schema): boolean {
+  return typeof schema === 'object' && schema !== null && schema['x-omit-from-example'] === true;
+}
+
 function extractInfo(obj, mode = 'example') {
   // Handle the root level object that represents an array
   if (obj.type === 'array' && obj.hasOwnProperty('items')) {
@@ -231,6 +240,9 @@ function extractInfo(obj, mode = 'example') {
       const result = {};
       for (const key in obj.properties) {
         if (obj.properties.hasOwnProperty(key)) {
+          if (mode === 'example' && isOmittedFromExample(obj.properties[key])) {
+            continue;
+          }
           result[key] = extractInfo(obj.properties[key], mode);
         }
       }
@@ -249,10 +261,15 @@ function extractInfo(obj, mode = 'example') {
   }
 
   // Special handling for objects that represent schemas (e.g., with 'type' and 'properties')
+  // Also reached with a bare `properties` map (see the array-items branch above),
+  // so the example omission applies here as well.
   if (typeof obj === 'object' && obj !== null) {
     const result = {};
     for (const key in obj) {
       if (obj.hasOwnProperty(key)) {
+        if (mode === 'example' && isOmittedFromExample(obj[key])) {
+          continue;
+        }
         result[key] = extractInfo(obj[key], mode);
       }
     }


### PR DESCRIPTION
The generator composes request and response examples by including every optional field that has an example. For mutually exclusive field pairs this produces payloads the API rejects: the policies pages show `ports` and `port_ranges` together in one rule, while the management API returns HTTP 422 for exactly that combination.

This adds a small vendor-extension contract, following the existing pattern of `x-cloud-only` and `x-experimental`: a property marked `x-omit-from-example: true` in the spec is left out of composed examples, while remaining fully documented in the Request-Body Parameters list and the Schema blocks (those render from the schema directly and are untouched).

Verification against the current management spec:

- Without the marker, output is byte-identical to the current generator across all 36 pages.
- With the marker on the policy `ports` field, exactly one file changes (`policies.mdx`): the 18 example payloads drop `ports` and keep `port_ranges`, with no other line touched. All trimmed examples remain valid JSON.
- The marker survives `expandOpenAPIRef` (raw YAML node processing) and is a no-op for the current generator, so merge order relative to the spec change does not matter.

Companion spec change (adds the marker plus mutual-exclusivity descriptions): https://github.com/netbirdio/netbird/pull/7158
Related Knowledge Hub clarification: https://github.com/netbirdio/netbird.io/pull/350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated request and response examples now exclude schema properties marked for omission.
  * Exclusions work consistently for nested objects and property maps without affecting schema documentation or type information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->