### PR TITLE
docs: unmanaged DNS mode also ignores Custom Zone records

### DIFF
--- a/src/pages/manage/dns/custom-zones.mdx
+++ b/src/pages/manage/dns/custom-zones.mdx
@@ -108,6 +108,7 @@ Custom DNS Zones have the following limitations:
 - **Cannot use peer DNS domain**: Zone domain must not conflict with your NetBird peer DNS domain (e.g., `netbird.cloud`, `netbird.selfhosted`, or a custom domain configured via the `--dns-domain` flag or in **Settings** > **Network** > **DNS Domain**)
 - **CNAME exclusivity**: CNAME records cannot coexist with A or AAAA records for the same hostname
 - **Empty zones not distributed**: Zones without any DNS records are not distributed to peers
+- **Requires managed DNS**: Peers in groups listed under **DNS** > **DNS Settings** (Disable DNS Management), or started with `netbird up --disable-dns`, run in [unmanaged mode](/manage/dns/dns-settings#unmanaged-mode) and will not resolve zone records, even when the zone's distribution groups include them
 
 ## Use Cases
 

--- a/src/pages/manage/dns/dns-settings.mdx
+++ b/src/pages/manage/dns/dns-settings.mdx
@@ -15,7 +15,7 @@ NetBird configures the system's DNS settings. All DNS queries route through NetB
 
 ### Unmanaged Mode
 
-NetBird does not modify system DNS settings. The peer uses its pre-existing DNS configuration and all configured nameservers are ignored.
+NetBird does not modify system DNS settings. The peer uses its pre-existing DNS configuration, and all configured nameservers and [Custom Zone](/manage/dns/custom-zones) records are ignored, including zones distributed to a group this peer belongs to.
 
 Use unmanaged mode when a peer has conflicting VPN or DNS requirements, corporate policy requires specific DNS settings, or you're troubleshooting DNS issues.
 
@@ -36,7 +36,7 @@ netbird up --disable-dns=false
 ```
 
 <Note>
-The `--disable-dns` flag takes precedence over server-side DNS settings. Even if the management server configures nameservers for this peer's group, the peer will ignore them when this flag is set.
+The `--disable-dns` flag takes precedence over server-side DNS settings. Even if the management server configures nameservers or Custom Zone records for this peer's group, the peer will ignore them when this flag is set. The flag persists across reconnects: a later plain `netbird up` keeps DNS management disabled until you run `netbird up --disable-dns=false`.
 </Note>
 
 ## Configuring DNS Settings
@@ -86,7 +86,7 @@ curl -X PUT https://api.netbird.io/api/dns/settings \
   }'
 ```
 
-See the full [API Reference](/ipa/resources/dns) for more details.
+See the full [API Reference](/api/resources/dns) for more details.
 
 ---
 

--- a/src/pages/manage/dns/index.mdx
+++ b/src/pages/manage/dns/index.mdx
@@ -142,4 +142,4 @@ You can disable DNS management for specific groups in [DNS Settings](/manage/dns
 - **[Custom Zones](/manage/dns/custom-zones)** - Create private DNS records distributed to peers
 - **[Extra DNS Labels](/manage/dns/extra-dns-labels)** - Assign additional DNS names to peers for service discovery and load balancing
 - **[Troubleshooting](/manage/dns/troubleshooting)** - Diagnose DNS issues
-- **[API Reference](/ipa/resources/dns)** - Automate DNS configuration
+- **[API Reference](/api/resources/dns)** - Automate DNS configuration

--- a/src/pages/manage/dns/troubleshooting.mdx
+++ b/src/pages/manage/dns/troubleshooting.mdx
@@ -57,6 +57,18 @@ nslookup google.com
 
 If any of these fail, continue to the relevant section below.
 
+### First: Confirm the Peer Is in Managed Mode
+
+Before anything else, confirm NetBird is managing DNS on this peer at all. If any group the peer belongs to is listed under **DNS** > **DNS Settings** (Disable DNS Management), the peer runs in [unmanaged mode](/manage/dns/dns-settings#unmanaged-mode): NetBird never wires its resolver into the operating system, so nameservers and [Custom Zone](/manage/dns/custom-zones) records are silently ignored, even when their distribution groups include the peer. This is easy to miss: nothing on the Nameservers or Zones screens indicates that a peer is unmanaged, and the result is exactly the symptoms this page covers.
+
+1. In the dashboard, open **DNS** > **DNS Settings** and check whether any of the peer's groups is listed. Remove it (or move the peer out of that group) if DNS should be managed.
+2. On the peer, run `netbird status -d`. If the **Nameservers** section is empty even though nameservers are configured for the peer's groups, the peer is in unmanaged mode.
+3. Also check the peer wasn't started with `netbird up --disable-dns`. In that case `netbird status -d` still lists the nameservers as Available, but the system's active DNS configuration (step 3 of the checklist above) won't show NetBird's resolver. The flag persists across reconnects; clear it with `netbird up --disable-dns=false`.
+
+<Note>
+A peer in unmanaged mode also makes the isolation test below misleading: disabling DNS management on a peer where it was never applied changes nothing, so "problem persists" would wrongly suggest the issue is unrelated to NetBird DNS.
+</Note>
+
 <Note>
 **Quick isolation test**: To check if an issue is caused by NetBird DNS, temporarily disable DNS management on the peer:
 ```bash
@@ -988,4 +1000,4 @@ Avoid future DNS issues:
 - **[DNS Overview](/manage/dns)** - Understand DNS architecture
 - **[Internal DNS Servers](/manage/dns/internal-dns-servers)** - Nameserver configuration and internal DNS
 - **[DNS Settings](/manage/dns/dns-settings)** - Management modes
-- **[API Reference](/ipa/resources/dns)** - Automate DNS
+- **[API Reference](/api/resources/dns)** - Automate DNS


### PR DESCRIPTION
## Summary

A user configured a Custom Zone with an A record plus a nameserver group, and resolution failed on their peer. The cause: the peer's group was also listed under **DNS → DNS Settings → Disable DNS Management**, which puts those peers in unmanaged mode. In unmanaged mode NetBird never wires its resolver into the OS, so Custom Zone records are silently ignored along with nameservers. The current docs describe unmanaged mode purely in terms of nameservers, so there was no way to connect the two screens.

## Changes

- **dns-settings.mdx**: the Unmanaged Mode description and the `--disable-dns` note now state that Custom Zone records are ignored too, including zones distributed to a group the peer belongs to. Also documents that `--disable-dns` persists across reconnects until cleared with `--disable-dns=false`.
- **custom-zones.mdx**: new "Requires managed DNS" entry in Limitations, linking to unmanaged mode.
- **troubleshooting.mdx**: new "Confirm the Peer Is in Managed Mode" first check, placed before the `--disable-dns` isolation test. Without it, a peer that is already unmanaged makes the isolation test read as "problem persists → not NetBird DNS", which is exactly wrong. Includes how to confirm each variant: an empty `Nameservers:` section in `netbird status -d` for the dashboard-driven case, and the system's active DNS configuration for the `--disable-dns` case (where `status -d` still lists nameservers as Available).
- **Link fix**: `/ipa/resources/dns` → `/api/resources/dns` in dns-settings.mdx and troubleshooting.mdx (`/ipa/*` 301-redirects; `/api` is the canonical path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that unmanaged DNS mode does not resolve Custom Zone records, including group-distributed zones.
  * Documented that `--disable-dns` remains active across reconnects until manually re-enabled.
  * Added troubleshooting guidance for identifying unmanaged DNS mode and interpreting isolation tests.
  * Corrected API Reference links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->