### PR TITLE
docs: add Quantum Resistance check to client status and make its fields navigable

### DIFF
--- a/src/pages/help/troubleshooting-client.mdx
+++ b/src/pages/help/troubleshooting-client.mdx
@@ -156,15 +156,15 @@ As for peers, the status reports the following fields:
 
 ### ICE candidate (Local/Remote)
 
-For example `relay/host`, where `relay` indicates the local peer is using a relay connection and `host` indicates the remote peer is using a direct connection.
+For example `relay/host`, where `relay` is the local ICE candidate type and `host` is the remote ICE candidate type. Use `Connection type` above to tell whether the selected path is direct (`P2P`) or `Relayed`.
 
 ### Last WireGuard handshake
 
-The last time the WireGuard handshake was performed, usually every 2 minutes. If you do not see an update here, or the value is empty, the connection was not possible yet.
+The last time the WireGuard handshake completed, usually refreshed every 2 minutes on an active connection. An empty value means no handshake has completed yet. An old timestamp means the peer connected before but the handshake is stale, so check whether it is still current.
 
 ### Quantum resistance
 
-`true` or `false`, whether post-quantum encryption ([Rosenpass](/client/post-quantum-cryptography)) is active on the connection. A peer with Quantum Resistance enabled only connects to peers that also have it enabled, so a mismatch, where the other side has it off, runs an older client, or is on mobile (unsupported), can keep a peer from connecting or showing up at all. If a peer is missing or stuck, match the setting on both sides, enable [permissive mode](/client/post-quantum-cryptography#enable-permissive-mode) so non-Rosenpass peers can still connect, or turn it off.
+`true` or `false`, whether post-quantum key exchange ([Rosenpass](/client/post-quantum-cryptography)) is active on the connection. A peer with Quantum Resistance enabled only connects to peers that also have it enabled, so a mismatch, where the other side has it off, runs an older client, or is on mobile (unsupported), can keep a peer from connecting or showing up at all. If a peer is missing or stuck, match the setting on both sides, enable [permissive mode](/client/post-quantum-cryptography#enable-permissive-mode) so non-Rosenpass peers can still connect, or turn it off.
 
 ### Transfer status (received/sent)
 

--- a/src/pages/help/troubleshooting-client.mdx
+++ b/src/pages/help/troubleshooting-client.mdx
@@ -144,20 +144,31 @@ As you can see, the output shows the peers connected, the NetBird IP address, th
 the connection type. The status will also report if there is an issue connecting to the relay servers,
 the management server, or the signal server.
 
-As for Peers, the status will show the following information:
+As for peers, the status reports the following fields:
 
-* `Connection type`: P2P, Relayed, where relayed connections indicate a limitation in the network that prevents a direct
-  connection between the peers. To diagnose and fix a relayed connection, see
-  [Troubleshooting relayed connections](/help/troubleshooting-relayed-connections).
-* `Direct`: true/false, where true indicates a direct connection between the peers without a local proxy. This case is
-  common when the local peer is allocating the relay connection.
-* `ICE candidate (Local/Remote)`: relay/host, where relay indicates that the local peer is using a relay connection and
-  host indicates that the remote peer is using a direct connection.
-* `Last Wireguard handshake`: Indicating the last time the Wireguard handshake was performed. Usually, this is performed
-  every 2 minutes, and if you don\'t see an update here or if the value is empty, that indicates that the connection
-  wasn\'t possible yet.
-* `Transfer status (received/sent)`: Indicating the amount of data received and sent by the peer. This is useful to
-  check if the connection is being used.
+### Connection type
+
+`P2P` or `Relayed`. A relayed connection indicates a network limitation that prevents a direct connection between the peers. To diagnose and fix a relayed connection, see [Troubleshooting relayed connections](/help/troubleshooting-relayed-connections).
+
+### Direct
+
+`true` or `false`. `true` indicates a direct connection between the peers without a local proxy, which is common when the local peer is allocating the relay connection.
+
+### ICE candidate (Local/Remote)
+
+For example `relay/host`, where `relay` indicates the local peer is using a relay connection and `host` indicates the remote peer is using a direct connection.
+
+### Last WireGuard handshake
+
+The last time the WireGuard handshake was performed, usually every 2 minutes. If you do not see an update here, or the value is empty, the connection was not possible yet.
+
+### Quantum resistance
+
+`true` or `false`, whether post-quantum encryption ([Rosenpass](/client/post-quantum-cryptography)) is active on the connection. A peer with Quantum Resistance enabled only connects to peers that also have it enabled, so a mismatch, where the other side has it off, runs an older client, or is on mobile (unsupported), can keep a peer from connecting or showing up at all. If a peer is missing or stuck, match the setting on both sides, enable [permissive mode](/client/post-quantum-cryptography#enable-permissive-mode) so non-Rosenpass peers can still connect, or turn it off.
+
+### Transfer status (received/sent)
+
+The amount of data received and sent by the peer, useful to check whether the connection is being used.
 
 See more details about the status command [here](/get-started/cli#status).
 


### PR DESCRIPTION
## What

Two related updates to the "NetBird client status" section of the client troubleshooting page, both prompted by a support incident where a peer stayed invisible until the customer turned off Quantum Resistance.

- **Quantum Resistance as a troubleshooting step.** The `Quantum resistance` field in `netbird status -d` now explains the cause and fix: a peer with Quantum Resistance (Rosenpass) enabled only connects to peers that also have it enabled, so a mismatch (the other side has it off, runs an older client, or is on mobile, which is unsupported) can keep a peer from connecting or showing up. It cross-links the [Quantum-Resistance doc](/client/post-quantum-cryptography) and its [permissive-mode section](/client/post-quantum-cryptography#enable-permissive-mode).
- **Navigable status fields.** The flat peer-field list is now per-field `h3` subsections (Connection type, Direct, ICE candidate, Last WireGuard handshake, Quantum resistance, Transfer status), so each appears in the "On this page" nav and the reader can jump straight to a field.

Also tidied "Wireguard" to "WireGuard" in the affected lines.

## Notes

Placed on the client page rather than resource-connectivity because a Quantum Resistance mismatch blocks the peer connection itself, a peer-connectivity symptom (the resource-connectivity page explicitly punts "peer not Connected" to the client page). Verified the new h3 anchors render and appear in the "On this page" nav. Validated with `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded peer status troubleshooting guidance with dedicated explanations for connection types, direct connectivity, ICE candidates, WireGuard handshake timing, quantum resistance, and transfer statistics.
  * Added troubleshooting steps for diagnosing connectivity and handshake issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->