### PR TITLE
Toned-down Agent Network sidebar entry styling

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -461,11 +461,11 @@ export const docsNavigation = [
     },
     {
         title: 'AGENT NETWORK',
-        // Featured highlight: any group with `featured: true` renders as the
-        // card at the top of the sidebar, with an optional `badge`. isOpen:false
-        // keeps this card collapsed by default, while the other top-level
-        // sections start expanded. To spotlight a different product later, move
-        // these lines to its group; remove them to drop the card entirely.
+        // Featured highlight: any group with `featured: true` is pinned to the
+        // top of the sidebar, with an optional `badge` pill. isOpen:false keeps
+        // it collapsed by default, while the other top-level sections start
+        // expanded. To spotlight a different product later, move these lines to
+        // its group; remove them to drop the highlight entirely.
         featured: true,
         badge: 'New',
         isOpen: false,
@@ -473,6 +473,7 @@ export const docsNavigation = [
             {
                 title: 'Getting Started',
                 href: '/agent-network',
+                isOpen: true,
                 links: [
                     { title: 'What is Agent Network?', href: '/agent-network' },
                     { title: 'How It Works', href: '/agent-network/how-it-works' },
@@ -1198,15 +1199,9 @@ export function NavigationDocs({ className }) {
                 {docsNavigation.map((group, groupIndex) =>
                     group.featured ? (
                         <NavigationStateProvider key={group.title} index={groupIndex}>
-                            <NavigationGroup group={group} index={groupIndex} className="md:mt-0" />
+                            <NavigationGroup group={group} index={groupIndex} className="mb-6 md:mt-0" />
                         </NavigationStateProvider>
                     ) : null
-                )}
-                {docsNavigation.some((group) => group.featured) && (
-                    <li
-                        aria-hidden="true"
-                        className="my-4 border-t border-zinc-900/10 dark:border-white/10"
-                    />
                 )}
                 {docsNavigation.map((group, groupIndex) =>
                     group.featured ? null : (
@@ -1273,7 +1268,7 @@ function NavigationGroup({ group, className, hasChildren }) {
                 className={clsx(
                     'group flex items-center justify-between gap-2',
                     isFeatured
-                        ? 'cursor-pointer select-none rounded-lg border border-netbird/30 bg-netbird/5 px-3 py-2 text-xs font-bold uppercase tracking-wide text-netbird transition hover:bg-netbird/10'
+                        ? '-mx-[9px] cursor-pointer select-none rounded-md border border-netbird/20 px-2 py-1.5 text-xs font-semibold text-zinc-900 transition hover:bg-netbird/5 dark:text-white'
                         : hasChildren
                         ? 'cursor-pointer select-none py-1 pr-3 text-sm font-medium text-zinc-700 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-white'
                         : 'cursor-pointer select-none text-xs font-semibold text-zinc-900 dark:text-white',


### PR DESCRIPTION
## Description

The featured AGENT NETWORK section in the docs sidebar rendered a card that didn't match the rest of the navigation. This PR tones it down so it reads like the other top-level headers (ABOUT, GET STARTED, etc.) while keeping a subtle highlight and the "New" pill, and makes the Getting Started sub-section expand automatically when the dropdown is opened.

## Default View
<img width="1115" height="574" alt="Screenshot From 2026-08-18 11-31-20" src="https://github.com/user-attachments/assets/a639e7c0-1c7a-4b1a-be4d-16e2898459d8" />


## Before and After
<img width="981" height="551" alt="Screenshot From 2026-08-18 11-29-16" src="https://github.com/user-attachments/assets/ff149af8-185d-476c-96ee-2ad4cde61c74" />

## Changes

- Removed the divider line between the featured entry and the ABOUT section, replacing it with normal section spacing
- Matched the header typography to the other top-level headers (`text-xs font-semibold`, zinc/white instead of bold green)
- Replaced the filled green card with a subtle `netbird/20` outline, no background fill, and a light green hover tint
- Offset the box with a negative margin so the text stays aligned with the other headers despite the border and padding
- Auto-expand the Getting Started sub-group whenever the AGENT NETWORK dropdown is opened (`isOpen: true`)
- Kept the green "New" badge pill and updated the code comment describing the `featured` flag

