### PR TITLE
docs: add QUIC UDP/443 relay transport to Ports & Firewalls

### DIFF
--- a/src/pages/about-netbird/ports-and-firewalls.mdx
+++ b/src/pages/about-netbird/ports-and-firewalls.mdx
@@ -54,7 +54,7 @@ NetBird usually won't need open ports, but sometimes you or your IT team needs t
   * **Endpoints**: *.relay.netbird.io and relay.netbird.io
   * **Ports**: TCP/443 (WebSocket) and UDP/443 (QUIC)
   * Clients v0.36.0 and later try both transports and use whichever connects first. If UDP/443 is blocked, the client falls back to WebSocket over TCP/443, so QUIC is an optimization, not a requirement.
-  * **IPv4**: The list is dynamic and geo-distributed; When looking at the `netbird status -d` output, you can see which relay you are connecting to.
+  * **IPv4**: The list is dynamic and geo-distributed. The `netbird status -d` output shows which relay you are connecting to.
   * It is advised to wildcard `*.relay.netbird.io` when possible, to avoid interrupts.
 * Relay service (legacy):
   * **Endpoint**: turn.netbird.io

--- a/src/pages/about-netbird/ports-and-firewalls.mdx
+++ b/src/pages/about-netbird/ports-and-firewalls.mdx
@@ -50,19 +50,20 @@ NetBird usually won't need open ports, but sometimes you or your IT team needs t
     * In more restricted environments, `netbird status` will show `keepalive ping failed` errors without a firewall rule for STUN
         * Example `nftables` outbound firewall rule: `ip daddr stun.netbird.io udp dport { 80, 443, 3478, 5555 } accept`
         * Note that `nftables` resolves hostnames only when the ruleset is loaded, pinning the rule to the IPs resolved at that moment. Since the pool is dynamic and geo-distributed, reload the ruleset periodically or keep the allowlist updated by other means.
-* Relay service (UDP/TCP):
+* Relay service (TCP/QUIC):
+  * **Endpoints**: *.relay.netbird.io and relay.netbird.io
+  * **Ports**: TCP/443 (WebSocket) and UDP/443 (QUIC)
+  * Clients v0.36.0 and later try both transports and use whichever connects first. If UDP/443 is blocked, the client falls back to WebSocket over TCP/443, so QUIC is an optimization, not a requirement.
+  * **IPv4**: The list is dynamic and geo-distributed; When looking at the `netbird status -d` output, you can see which relay you are connecting to.
+  * It is advised to wildcard `*.relay.netbird.io` when possible, to avoid interrupts.
+* Relay service (legacy):
   * **Endpoint**: turn.netbird.io
-    * **Legacy fallback only**: clients v0.29.0 and later relay through the NetBird relay service below (`relay.netbird.io` and `*.relay.netbird.io`, TCP/443) and use the legacy TURN relay only when that relay is unreachable or the other peer runs an older client.
+    * **Legacy fallback only**: needed for clients older than v0.29.0. Newer clients relay through the NetBird relay service above and fall back to this TURN relay only if that relay is unreachable.
     * **Port range**: UDP/80,443 and TCP/443-65535
     * **IPv4**: The list is dynamic and geo-distributed; we advise you to check the nearest cluster with the following command:
         * `nslookup turn.netbird.io`
     * In more restricted environments, `netbird status` will show `keepalive ping failed` errors without a firewall rule for the relay
         * Example `nftables` outbound firewall rule: `ip daddr turn.netbird.io tcp dport 443-65535 accept`
-* Relay service (TCP):
-  * **Endpoints**: *.relay.netbird.io and relay.netbird.io
-  * **Port**: TCP/443
-  * **IPv4**: The list is dynamic and geo-distributed; When looking at the `netbird status -d` output, you can see which relay you are connecting to.
-  * It is advised to wildcard `*.relay.netbird.io` when possible, to avoid interrupts.
 
 <Note>
     Download the full list of NetBird Cloud STUN and Relay endpoints and port requirements in <a href="/docs-static/files/netbird-cloud-endpoints.json" download>JSON format.</a>


### PR DESCRIPTION
## Summary

- Add **UDP/443 (QUIC)** alongside TCP/443 (WebSocket) to the relay service entry (`relay.netbird.io` / `*.relay.netbird.io`). QUIC relay support landed in client v0.36.0 ([release notes](https://github.com/netbirdio/netbird/releases/tag/v0.36.0)); clients try both transports and use whichever connects first, falling back to WebSocket over TCP/443 when UDP/443 is blocked.
- Reorder the relay entries so the current relay service is listed above the legacy TURN one, and relabel the TURN entry as **Relay service (legacy)**.
- Tighten the legacy fallback note to lead with the actionable case (clients older than v0.29.0), keeping the unreachable-relay fallback consistent with the [troubleshooting relayed connections](https://docs.netbird.io/help/troubleshooting-relayed-connections) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated relay and firewall guidance to distinguish current relays from the legacy TURN relay.
  * Documented TCP/443 WebSocket and UDP/443 QUIC connectivity options.
  * Clarified transport selection and fallback behavior for supported and older client versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->