### PR TITLE
Team docs accuracy audit: corrections and third-party verification

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -350,12 +350,48 @@ export const docsNavigation = [
                         title: 'Single Sign-On',
                         href: '/manage/team/single-sign-on',
                         isOpen: false,
-                        //                        links: [
-                        //                            { title: 'Authentik', href: '/manage/team/single-sign-on/authentik' },
-                        //                            { title: 'Keycloak', href: '/manage/team/single-sign-on/keycloak' },
-                        //                            { title: 'Auth0', href: '/manage/team/single-sign-on/auth0' },
-                        //                            { title: 'JumpCloud', href: '/manage/team/single-sign-on/jumpcloud' },
-                        //                        ]
+                        links: [
+                            {
+                                title: 'Authentik',
+                                href: '/manage/team/single-sign-on/authentik',
+                            },
+                            {
+                                title: 'Keycloak',
+                                href: '/manage/team/single-sign-on/keycloak',
+                            },
+                            {
+                                title: 'JumpCloud',
+                                href: '/manage/team/single-sign-on/jumpcloud',
+                            },
+                            {
+                                title: 'Auth0',
+                                href: '/manage/team/single-sign-on/auth0',
+                            },
+                            {
+                                title: 'Duo Security',
+                                href: '/manage/team/single-sign-on/duo-security',
+                            },
+                            {
+                                title: 'Zitadel',
+                                href: '/manage/team/single-sign-on/zitadel',
+                            },
+                            {
+                                title: 'cidaas',
+                                href: '/manage/team/single-sign-on/cidaas',
+                            },
+                            {
+                                title: 'AWS Cognito',
+                                href: '/manage/team/single-sign-on/aws-cognito',
+                            },
+                            {
+                                title: 'Zoho',
+                                href: '/manage/team/single-sign-on/zoho',
+                            },
+                            {
+                                title: 'IIJ ID',
+                                href: '/manage/team/single-sign-on/iij-id',
+                            },
+                        ],
                     },
                 ],
             },

--- a/src/pages/manage/team/add-users-to-your-network.mdx
+++ b/src/pages/manage/team/add-users-to-your-network.mdx
@@ -35,6 +35,8 @@ As the name stands, this way of inviting users is straightforward and works thro
 To invite a new user, proceed to `Team` then select the `Users` tab and click the <button name="button" className="button-6">Invite User</button> button.
 A window will appear, allowing you to specify the name and email address of the user you want to invite. Optionally, you could select a set of groups with which you want this user to be associated.
 
+On a self-hosted installation the same button reads `Add User`, and it only appears when [local user management](/selfhosted/identity-providers/local) is enabled. If you have [disabled local authentication](/selfhosted/identity-providers/disable-local-authentication), the button is disabled and users have to come from your IdP instead.
+
 The invited users will receive an email invitation that they have to confirm.
 After logging in to the system, they will join your network automatically.
 
@@ -43,15 +45,14 @@ After logging in to the system, they will join your network automatically.
 </p>
 
 <Note>
-    If a user already has a NetBird account, you can't invite them.
-    This is a limitation that is likely to be removed in future versions.
+    If a user already has a NetBird account, you can't invite them. The invite is rejected with
+    `can't invite a user with an existing NetBird account`.
 </Note>
 
 ## Identity Provider (IdP) Sync
 
 NetBird's IdP-Sync automates user access management by integrating with your IdP and automatically
-provisioning users and groups. You can enable this feature from the `Users` tab by clicking the `Identity Provider Sync`
-button.
+provisioning users and groups. You configure it from the `Integrations` page, on the `Identity Provider Sync` tab.
 
 <p>
     <img src="/docs-static/img/manage/team/idp-sync-reference.png" alt="idp-sync-reference" className="imagewrapper"/>

--- a/src/pages/manage/team/add-users-to-your-network.mdx
+++ b/src/pages/manage/team/add-users-to-your-network.mdx
@@ -25,9 +25,7 @@ The domains of the private category are the ones that are automatically grouped 
 Public domains are the ones of the public email providers like Gmail.
 
 <Note>
-    It might happen (unlikely) that the domain classification system didn't classify your company's domain as private.
-    Our system was unsure about your domain and assigned an unclassified or public category to be on the safe side.
-    Just email us at [hello@netbird.io](mailto:hello@netbird.io) or ping us on [Slack](/slack-url) to fix this.
+    It might happen (unlikely) that the domain classification system didn't classify your company's domain as private. Our system was unsure about your domain and assigned an unclassified or public category to be on the safe side. Just email us at [hello@netbird.io](mailto:hello@netbird.io) or ping us on [Slack](/slack-url) to fix this.
 </Note>
 
 ## Direct user invites
@@ -41,21 +39,19 @@ The invited users will receive an email invitation that they have to confirm.
 After logging in to the system, they will join your network automatically.
 
 <p>
-    <img src="/docs-static/img/manage/team/user-invites.png" alt="high-level-dia" className="imagewrapper"/>
+    <img src="/docs-static/img/manage/team/user-invites.png" alt="The Invite User dialog with name, email, and group fields" className="imagewrapper"/>
 </p>
 
 <Note>
-    If a user already has a NetBird account, you can't invite them. The invite is rejected with
-    `can't invite a user with an existing NetBird account`.
+    If a user already has a NetBird account, you can't invite them. The invite is rejected with `can't invite a user with an existing NetBird account`.
 </Note>
 
 ## Identity Provider (IdP) Sync
 
-NetBird's IdP-Sync automates user access management by integrating with your IdP and automatically
-provisioning users and groups. You configure it from the `Integrations` page, on the `Identity Provider Sync` tab.
+NetBird's IdP-Sync automates user access management by integrating with your IdP and automatically provisioning users and groups. You configure it from the `Integrations` page, on the `Identity Provider Sync` tab.
 
 <p>
-    <img src="/docs-static/img/manage/team/idp-sync-reference.png" alt="idp-sync-reference" className="imagewrapper"/>
+    <img src="/docs-static/img/manage/team/idp-sync-reference.png" alt="The Identity Provider Sync tab on the Integrations page" className="imagewrapper"/>
 </p>
 
 See the [Provision Users and Groups From Your Identity Provider](/manage/team/idp-sync) section for more details.

--- a/src/pages/manage/team/approve-users.mdx
+++ b/src/pages/manage/team/approve-users.mdx
@@ -1,43 +1,38 @@
 import {Note} from "@/components/mdx";
 
 # Approve users
-The user approval feature enhances security by requiring manual administrator approval before a user can join your NetBird organization via domain matching.
-New NetBird Cloud accounts have user approval enabled by default.
+
+NetBird groups people by email domain. When someone signs up with an address at your company's private domain, they land in your organization automatically, without anyone inviting them. That is [domain matching](/manage/team/add-users-to-your-network#indirect-user-invites), and it is convenient right up until a contractor, a former employee with a lingering mailbox, or anyone who can receive mail at your domain signs up and joins your network.
+
+User approval closes that gap. With it on, a user who arrives through domain matching is held until an administrator approves them. New NetBird Cloud accounts have it enabled by default, and leaving it on is the safer setting.
 
 ## Require user approval
 Navigate to the Dashboard's `Settings` page and the `Authentication` tab and enable or disable `User Approval Required`.
 
-- **Enabled**: Require manual approval for new users joining via domain matching. Users will be blocked until approved. Learn how to approve or reject users in the section [below](#approve-or-reject-user).
-- **Disabled**: Manual approval for new users is not required. Users joining via domain matching will be automatically added to the organization.
+- **Enabled** (recommended): users arriving through domain matching are blocked until an administrator approves them. See [Approve or reject user](#approve-or-reject-user) for what to do with the queue.
+- **Disabled**: anyone who signs up with an email address at your domain joins the organization immediately, with no review.
 
 <p>
-    <img src="/docs-static/img/manage/team/approve-users/netbird-authentication-settings-approval.png" alt="netbird-authentication-settings-approval" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/approve-users/netbird-authentication-settings-approval.png" alt="The User Approval Required toggle on the Authentication tab of Settings" className="imagewrapper-big"/>
 </p>
 
 ## What a pending user sees
-Until an administrator approves them, the user can sign in but can't reach the dashboard. They get a
-`User Approval Pending` screen telling them their account is pending approval from an administrator.
-They hold the `Pending` status in the `Users` table until you act on them.
+Until an administrator approves them, the user can sign in but can't reach the dashboard. They get a `User Approval Pending` screen telling them their account is pending approval from an administrator. They hold the `Pending` status in the `Users` table until you act on them.
 
 ## Approve or reject user
 To approve a user, navigate to the [Users Page](https://app.netbird.io/team/users) and click the `Approve` or `Reject` button on the right side of the users table.
 
 <p>
-    <img src="/docs-static/img/manage/team/approve-users/netbird-user-approval.png" alt="netbird-user-approval" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/approve-users/netbird-user-approval.png" alt="Approve and Reject buttons on a pending user row in the Users table" className="imagewrapper-big"/>
 </p>
 
-When several people are waiting, the `Pending Approval` button above the table filters it down to just
-those users, and carries a badge with the number outstanding. The button only appears while at least one
-user is waiting.
+When several people are waiting, the `Pending Approval` button above the table filters it down to just those users, and carries a badge with the number outstanding. The button only appears while at least one user is waiting.
 
 <Note>
-    `Reject` is permanent. It removes the user from the account and can't be undone. Use `Block` instead
-    if you want to keep the user on the account but deny access.
+    `Reject` is permanent. It removes the user from the account and can't be undone. Use `Block` instead if you want to keep the user on the account but deny access.
 </Note>
 
-The `Approve` and `Reject` buttons only render for roles that can update users, which means `Owner` and
-`Admin`. A `Network Admin` has read-only access to the `Team` tab and won't see them. See
-[User Roles](/manage/team/user-roles) for the full breakdown.
+The `Approve` and `Reject` buttons only render for roles that can update users, which means `Owner` and `Admin`. A `Network Admin` has read-only access to the `Team` tab and won't see them. See [User Roles](/manage/team/user-roles) for the full breakdown.
 
 ## Get started
 <div>

--- a/src/pages/manage/team/approve-users.mdx
+++ b/src/pages/manage/team/approve-users.mdx
@@ -14,12 +14,30 @@ Navigate to the Dashboard's `Settings` page and the `Authentication` tab and ena
     <img src="/docs-static/img/manage/team/approve-users/netbird-authentication-settings-approval.png" alt="netbird-authentication-settings-approval" className="imagewrapper-big"/>
 </p>
 
+## What a pending user sees
+Until an administrator approves them, the user can sign in but can't reach the dashboard. They get a
+`User Approval Pending` screen telling them their account is pending approval from an administrator.
+They hold the `Pending` status in the `Users` table until you act on them.
+
 ## Approve or reject user
 To approve a user, navigate to the [Users Page](https://app.netbird.io/team/users) and click the `Approve` or `Reject` button on the right side of the users table.
 
 <p>
     <img src="/docs-static/img/manage/team/approve-users/netbird-user-approval.png" alt="netbird-user-approval" className="imagewrapper-big"/>
 </p>
+
+When several people are waiting, the `Pending Approval` button above the table filters it down to just
+those users, and carries a badge with the number outstanding. The button only appears while at least one
+user is waiting.
+
+<Note>
+    `Reject` is permanent. It removes the user from the account and can't be undone. Use `Block` instead
+    if you want to keep the user on the account but deny access.
+</Note>
+
+The `Approve` and `Reject` buttons only render for roles that can update users, which means `Owner` and
+`Admin`. A `Network Admin` has read-only access to the `Team` tab and won't see them. See
+[User Roles](/manage/team/user-roles) for the full breakdown.
 
 ## Get started
 <div>

--- a/src/pages/manage/team/auto-offboard-users.mdx
+++ b/src/pages/manage/team/auto-offboard-users.mdx
@@ -1,18 +1,15 @@
 # Automatically Offboard Team Members from NetBird
 
-[NetBird's IdP-Sync integration](/manage/team/idp-sync) simplifies offboarding team members, enhancing
-security and efficiency. With this integration, you can automatically revoke access when users leave the company, when
-temporary access for a freelancer ends after project completion, or when a seasonal employee's contract concludes.
-Likewise, you can use this integration to restrict access to specific resources or environments when a project finishes.
-For instance, you can limit network and resource access when a team member is removed from a group or when an entire group
-is deleted from your Identity Provider.
+Offboarding is where manual user management fails quietly. Someone leaves, their accounts get closed one by one, and the VPN is the one everybody forgets. [IdP-Sync](/manage/team/idp-sync) removes that step: delete the user in your identity provider and NetBird drops them too.
+
+The same applies to narrower changes. Remove someone from a group, or delete the group entirely, and any network access that depended on that group goes with it. That covers a freelancer whose project ended, a seasonal contract running out, or a team member moving off a system they no longer need.
 
 ## Removing Team Members
 
 In this tutorial, we will focus on `user_01`, `user_02`, and `user_03`. From NetBird's `Users` dashboard, you can see
 that `user_01` is part of the `IT Administrators` group, while `user_02` and `user_03` belong to the `Staging` group.
 
-![NetBird Users](/docs-static/img/manage/team/auto-offboard-users/GT3eAeU.png)
+![The NetBird Users table showing the three example users and their groups](/docs-static/img/manage/team/auto-offboard-users/GT3eAeU.png)
 
 To get started, access your Identity Provider (IdP) dashboard. For this example, we'll use [Microsoft Entra ID (Azure AD)](/manage/team/idp-sync/microsoft-entra-id-sync).
 
@@ -46,7 +43,6 @@ Let's say the current project is finished, and you no longer want members of the
 
 ![IdP Delete Group](/docs-static/img/manage/team/auto-offboard-users/TOZjFKC.png)
 
-Once the changes synchronize in NetBird, users and their group memberships will be updated; therefore,
-[network access associated with that group](/manage/access-control/manage-network-access) will automatically be revoked.
+Once the changes synchronize in NetBird, users and their group memberships will be updated; therefore, [network access associated with that group](/manage/access-control/manage-network-access) will automatically be revoked.
 
 ![NetBird No Group](/docs-static/img/manage/team/auto-offboard-users/NKabmN6.png)

--- a/src/pages/manage/team/auto-offboard-users.mdx
+++ b/src/pages/manage/team/auto-offboard-users.mdx
@@ -1,6 +1,6 @@
 # Automatically Offboard Team Members from NetBird
 
-[NetBird's IdP-Sync integration](https://docs.netbird.io/manage/team/idp-sync) simplifies offboarding team members, enhancing
+[NetBird's IdP-Sync integration](/manage/team/idp-sync) simplifies offboarding team members, enhancing
 security and efficiency. With this integration, you can automatically revoke access when users leave the company, when
 temporary access for a freelancer ends after project completion, or when a seasonal employee's contract concludes.
 Likewise, you can use this integration to restrict access to specific resources or environments when a project finishes.
@@ -14,7 +14,7 @@ that `user_01` is part of the `IT Administrators` group, while `user_02` and `us
 
 ![NetBird Users](/docs-static/img/manage/team/auto-offboard-users/GT3eAeU.png)
 
-To get started, access your Identity Provider (IdP) dashboard. For this example, we'll use [Microsoft Entra ID (Azure AD)](https://docs.netbird.io/manage/team/idp-sync/microsoft-entra-id-sync).
+To get started, access your Identity Provider (IdP) dashboard. For this example, we'll use [Microsoft Entra ID (Azure AD)](/manage/team/idp-sync/microsoft-entra-id-sync).
 
 Next, locate the user you want to offboard in your IdP's user management section. Let’s say you want to revoke access to
 `user_01`, in that case, you will need to select it and click the `Delete` button as shown below.
@@ -25,7 +25,9 @@ After deletion, click the `Refresh` button to confirm that the user is no longer
 
 ![IdP Confirm Deletion](/docs-static/img/manage/team/auto-offboard-users/LJ6QHRV.png)
 
-Wait for the NetBird integration to complete its next synchronization cycle, which usually takes 300 seconds. Alternatively, go to the `Integrations` screen in the NetBird admin console and click the corresponding integration button to manually trigger the synchronization.
+Wait for the NetBird integration to complete its next synchronization cycle, which usually takes 300 seconds. Alternatively, go to `Integrations` in the NetBird dashboard, open the `Identity Provider Sync` tab, and trigger the synchronization manually.
+
+Manual sync is only available for the API-based integrations, Google Workspace and Microsoft Entra ID via API, because NetBird pulls from those providers. SCIM-based integrations such as Okta, JumpCloud, Keycloak, and IIJ ID are push-based: the provider sends changes to NetBird, so there is nothing to trigger from the NetBird side and deprovisioning lands as soon as your IdP pushes it.
 
 ![NetBird Integrations Force Sync](/docs-static/img/manage/team/auto-offboard-users/ogiiUeT.png)
 
@@ -45,6 +47,6 @@ Let's say the current project is finished, and you no longer want members of the
 ![IdP Delete Group](/docs-static/img/manage/team/auto-offboard-users/TOZjFKC.png)
 
 Once the changes synchronize in NetBird, users and their group memberships will be updated; therefore,
-[network access associated with that group](https://docs.netbird.io/manage/access-control/manage-network-access) will automatically be revoked.
+[network access associated with that group](/manage/access-control/manage-network-access) will automatically be revoked.
 
 ![NetBird No Group](/docs-static/img/manage/team/auto-offboard-users/NKabmN6.png)

--- a/src/pages/manage/team/entra-id-app-enablement.mdx
+++ b/src/pages/manage/team/entra-id-app-enablement.mdx
@@ -10,10 +10,7 @@ Before your organization can use Microsoft Entra ID features with NetBird, such 
 - An account with the **Privileged Role Administrator** or **Global Administrator** role
 
 <Note>
-    **Cloud Application Administrator may not be enough.** Microsoft allows that role to grant consent for any
-    API *except* Microsoft Graph application permissions. NetBird's provisioning and group sync read directory
-    data through Microsoft Graph, so if the consent screen lists Graph application permissions, the grant has to
-    come from a **Privileged Role Administrator** or a **Global Administrator**.
+    **Cloud Application Administrator may not be enough.** Microsoft allows that role to grant consent for any API *except* Microsoft Graph application permissions. NetBird's provisioning and group sync read directory data through Microsoft Graph, so if the consent screen lists Graph application permissions, the grant has to come from a **Privileged Role Administrator** or a **Global Administrator**.
 </Note>
 
 ## Step 1: Find the NetBird Enterprise Application

--- a/src/pages/manage/team/entra-id-app-enablement.mdx
+++ b/src/pages/manage/team/entra-id-app-enablement.mdx
@@ -7,14 +7,24 @@ Before your organization can use Microsoft Entra ID features with NetBird, such 
 ## Prerequisites
 
 - A Microsoft Entra ID tenant
-- An account with **Global Administrator** or **Cloud Application Administrator** role
+- An account with the **Privileged Role Administrator** or **Global Administrator** role
+
+<Note>
+    **Cloud Application Administrator may not be enough.** Microsoft allows that role to grant consent for any
+    API *except* Microsoft Graph application permissions. NetBird's provisioning and group sync read directory
+    data through Microsoft Graph, so if the consent screen lists Graph application permissions, the grant has to
+    come from a **Privileged Role Administrator** or a **Global Administrator**.
+</Note>
 
 ## Step 1: Find the NetBird Enterprise Application
 
-1. Sign in to the [Azure portal](https://portal.azure.com)
-2. Navigate to **Home** → **Microsoft Entra ID** → **Enterprise Applications**
+1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com)
+2. Navigate to **Entra ID** → **Enterprise apps** → **All applications**
 3. Search for the application with Application ID: `7a7538de-b7ed-4e49-befe-edbe74d5e0a1`
 4. Select the **NetBird** application from the results
+
+You can reach the same blade from the [Azure portal](https://portal.azure.com) under
+**Microsoft Entra ID** → **Enterprise applications**.
 
 <p>
     <img src="/docs-static/img/manage/team/entra-id-app-enablement/enterprise-applications.png" alt="Find NetBird in Enterprise Applications" className="imagewrapper-big"/>
@@ -22,9 +32,9 @@ Before your organization can use Microsoft Entra ID features with NetBird, such 
 
 ## Step 2: Grant Admin Consent
 
-1. In the NetBird application overview, click **Permissions** in the left menu
-2. Click **Grant admin consent for Default Directory**
-3. Review the requested permissions and confirm
+1. In the NetBird application overview, select **Permissions** under **Security**
+2. Review the requested permissions carefully, then click **Grant admin consent for `<your tenant name>`**
+3. Confirm the consent prompt
 
 <p>
     <img src="/docs-static/img/manage/team/entra-id-app-enablement/grant-admin-consent.png" alt="Grant admin consent for NetBird" className="imagewrapper-big"/>

--- a/src/pages/manage/team/entra-id-app-enablement.mdx
+++ b/src/pages/manage/team/entra-id-app-enablement.mdx
@@ -2,7 +2,7 @@ import {Note} from "@/components/mdx";
 
 # Enable NetBird for Microsoft Entra ID
 
-Before your organization can use Microsoft Entra ID features with NetBird — such as user provisioning, group sync, or single sign-on — you need to enable the NetBird enterprise application in your Entra ID tenant and grant admin consent.
+Before your organization can use Microsoft Entra ID features with NetBird, such as user provisioning, group sync, or single sign-on, you need to enable the NetBird enterprise application in your Entra ID tenant and grant admin consent.
 
 ## Prerequisites
 

--- a/src/pages/manage/team/idp-sync/embedded/keycloak-sync.mdx
+++ b/src/pages/manage/team/idp-sync/embedded/keycloak-sync.mdx
@@ -2,17 +2,12 @@ import {Note} from "@/components/mdx";
 
 # Provision Users and Groups From Keycloak (Embedded IdP)
 
-Keycloak is an open source identity and access management solution that provides features like single sign-on (SSO),
-multi-factor authentication (MFA), user federation, and centralized identity management to help organizations
-secure and manage access to their applications and resources.
+Keycloak is an open source identity and access management solution that provides features like single sign-on (SSO), multi-factor authentication (MFA), user federation, and centralized identity management to help organizations secure and manage access to their applications and resources.
 
-NetBird's Keycloak integration enhances user management by allowing you to utilize Keycloak as your identity provider.
-This integration automates user authentication in your network, adds SSO and MFA support, and simplifies network access management
-to your applications and resources.
+Connecting Keycloak to NetBird lets your existing Keycloak users and groups drive network access. Users sign in with the credentials they already have, including any MFA you enforce in Keycloak, and group membership flows into NetBird so your access policies follow it.
 
 <Note>
-    Before creating this integration, ensure you have a Keycloak connector configured in your embedded IdP.
-    If not, refer to the [Identity Providers](/selfhosted/identity-providers/keycloak) documentation to set it up.
+    Before creating this integration, ensure you have a Keycloak connector configured in your embedded IdP. If not, refer to the [Identity Providers](/selfhosted/identity-providers/keycloak) documentation to set it up.
 </Note>
 
 ## Prerequisites
@@ -33,7 +28,7 @@ To enable SCIM synchronization in NetBird, navigate to `Integrations > Identity 
 Select your **Keycloak** identity provider connector for this integration and click **Continue** to proceed.
 
 <p>
-    <img src="/docs-static/img/manage/team/idp-sync/keycloak-sync/select-idp.png" alt="select-identity-provider" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/idp-sync/keycloak-sync/select-idp.png" alt="The connector picker with the Keycloak identity provider selected" className="imagewrapper-big"/>
 </p>
 
 This will open a pop-up window featuring a user-friendly wizard to guide you through the configuration process.
@@ -200,8 +195,7 @@ After completing the initial sync, you can verify that users and groups have bee
 ![NetBird Verify Users](/docs-static/img/manage/team/idp-sync/keycloak-sync/netbird-verify-users.png)
 
 <Note>
-    SCIM provisioning will manage only resources that are created through Keycloak. Any resources created directly in
-    NetBird will not be managed by SCIM.
+    SCIM provisioning will manage only resources that are created through Keycloak. Any resources created directly in NetBird will not be managed by SCIM.
 </Note>
 
 <Note>

--- a/src/pages/manage/team/idp-sync/embedded/keycloak-sync.mdx
+++ b/src/pages/manage/team/idp-sync/embedded/keycloak-sync.mdx
@@ -2,7 +2,7 @@ import {Note} from "@/components/mdx";
 
 # Provision Users and Groups From Keycloak (Embedded IdP)
 
-Keycloak is an open-source identity and access management solution that provides features like single sign-on (SSO),
+Keycloak is an open source identity and access management solution that provides features like single sign-on (SSO),
 multi-factor authentication (MFA), user federation, and centralized identity management to help organizations
 secure and manage access to their applications and resources.
 

--- a/src/pages/manage/team/idp-sync/google-workspace-sync.mdx
+++ b/src/pages/manage/team/idp-sync/google-workspace-sync.mdx
@@ -110,7 +110,7 @@ Navigate to [https://console.cloud.google.com/apis/credentials](https://console.
 ![Google Workspace Service Account](/docs-static/img/manage/team/idp-sync/google-workspace-sync/rDU0Puv.png)
 
 Complete the form with the supplied values:
-* `NerBird` for the service account name
+* `NetBird` for the service account name
 * `netbird` for the service account ID
 
 Click `DONE` when ready.

--- a/src/pages/manage/team/idp-sync/google-workspace-sync.mdx
+++ b/src/pages/manage/team/idp-sync/google-workspace-sync.mdx
@@ -4,10 +4,7 @@
 communication. Notably, its [identity management](https://cloud.google.com/architecture/identity/overview-google-authentication) features streamline user authentication and access control,
 ensuring efficiency and security across your organization.
 
-NetBird's Google Workspace integration enhances user management capabilities by synchronizing users and groups from
-Google Workspace to NetBird. You can utilize these synchronized groups to configure your network, establish network
-access policies, and automate onboarding and offboarding processes, adding significant value to your organizational
-workflow and security posture.
+Connecting Google Workspace to NetBird syncs your users and groups across, so the org chart you already maintain in Workspace becomes the basis for network access. Point a policy at a synced group and onboarding and offboarding stop being separate NetBird chores.
 
 The integration process involves two complementary services: Google Workspace and Google Cloud Platform (GCP).
 Google Workspace serves as your Identity Provider (IdP), managing user and group identities and providing Single Sign-On (SSO)
@@ -249,7 +246,7 @@ The next screen, should be similar the following one, verifying that the integra
 
 To verify the integration is working correctly, you can also navigate to `Team` > `Users`. Here, you should see your synchronized Google Workspace users listed.
 
-![NetBird Users](/docs-static/img/manage/team/idp-sync/google-workspace-sync/5AcaIqW.png)
+![The NetBird Users table listing users synced from Google Workspace](/docs-static/img/manage/team/idp-sync/google-workspace-sync/5AcaIqW.png)
 
 The users should be the same listed in Google Workspace Admin console:
 

--- a/src/pages/manage/team/idp-sync/index.mdx
+++ b/src/pages/manage/team/idp-sync/index.mdx
@@ -20,7 +20,9 @@ or update network configurations like [DNS](/manage/dns#distribution-groups),
 eliminating the need for manual grouping.
 
 <Note>
-    This feature is only available in the cloud version of NetBird in the [Team plan](https://netbird.io/pricing) and above.
+    IdP-Sync is available on NetBird Cloud in the [Team plan](https://netbird.io/pricing) and above. It is also
+    available on self-hosted deployments running a [Commercial License](https://netbird.io/pricing#on-prem) with the
+    embedded IdP, which use a separate set of setup guides listed under Self-hosted.
 </Note>
 
 This video guide walks you through an example integration with Microsoft Entra ID, covering both user onboarding and
@@ -28,9 +30,42 @@ offboarding scenarios:
 
 <YouTube videoId="RxYWTpf7cgY" />
 
+## How syncing works
+
+NetBird syncs in one of two directions, and which one you get depends on the provider.
+
+**Pull, over the provider's API.** NetBird holds credentials for your IdP and reads users and groups from it on a
+schedule. You can also trigger a sync by hand from the dashboard. Google Workspace and Entra ID (API) work this way.
+
+**Push, over SCIM.** Your IdP sends changes to NetBird as they happen, using a SCIM endpoint and token that NetBird
+issues. There is no manual sync to trigger, because NetBird is the receiver. Entra ID (SCIM), Okta, JumpCloud, and any
+generic SCIM provider work this way.
+
+The practical difference is timing and troubleshooting. A pull integration is late by at most one sync cycle and you can
+force it. A push integration is near-immediate, but when it stalls you fix it in your IdP's provisioning logs, not in
+NetBird.
+
 ## Supported Identity Providers
 
 NetBird provides native support for syncing with the most popular identity providers. Pick yours below for detailed setup and configuration steps.
+
+| Provider | Direction | Set up in NetBird with |
+| --- | --- | --- |
+| Google Workspace | Pull (API) | `Connect Google Workspace` |
+| Entra ID (API) | Pull (API) | `Connect Entra ID (API)` |
+| Entra ID (SCIM) | Push (SCIM) | `Connect Entra ID (SCIM)` |
+| Okta | Push (SCIM) | `Connect Okta` |
+| JumpCloud | Push (SCIM) | `Connect Jumpcloud` |
+| Keycloak | Push (SCIM) | `Connect Generic SCIM` |
+| IIJ ID | Push (SCIM) | `Connect Generic SCIM` |
+
+Keycloak and IIJ ID have no dedicated card on the `Identity Provider Sync` tab. Both are set up through
+`Connect Generic SCIM`, and their guides below walk through that path.
+
+<Note>
+    You can only have one IdP-Sync integration enabled at a time. While one is enabled, the setup buttons on
+    every other card are disabled, so switching providers means disabling the current integration first.
+</Note>
 
 ### Entra ID (API)
 

--- a/src/pages/manage/team/idp-sync/index.mdx
+++ b/src/pages/manage/team/idp-sync/index.mdx
@@ -63,7 +63,7 @@ Keycloak and IIJ ID have no dedicated card on the `Identity Provider Sync` tab. 
 `Connect Generic SCIM`, and their guides below walk through that path.
 
 <Note>
-    You can only have one IdP-Sync integration enabled at a time. While one is enabled, the setup buttons on
+    The dashboard configures one IdP-Sync integration at a time. While one is enabled, the setup buttons on
     every other card are disabled, so switching providers means disabling the current integration first.
 </Note>
 

--- a/src/pages/manage/team/idp-sync/index.mdx
+++ b/src/pages/manage/team/idp-sync/index.mdx
@@ -1,28 +1,18 @@
 # Provision Users and Groups From Your Identity Provider
 
 <p>
-    <img src="/docs-static/img/manage/team/idp-sync/supported-identity-providers.png" alt="supported-identity-providers"
+    <img src="/docs-static/img/manage/team/idp-sync/supported-identity-providers.png" alt="The Identity Provider Sync tab showing a card for each supported provider"
          className="imagewrapper-big"/>
 </p>
 
-Managing private network access in a business environment is a critical yet often cumbersome task.
-As companies grow and evolve, the manual process of granting access for new employees and revoking it for
-departing ones becomes increasingly time-consuming and error-prone. This challenge strains IT resources, poses significant
-security risks, and impacts productivity.
+Every time someone joins your company you add them to NetBird by hand, and every time someone leaves you have to remember to remove them. Miss one and a former employee keeps network access. Your identity provider already knows who works here and which teams they belong to, so IdP-Sync makes it the source of truth and keeps NetBird in step with it.
 
-NetBird's IdP-Sync automates user access management to private networks by integrating with your identity provider (IdP)
-and automatically provisioning users and groups. This integration ensures that changes to groups and users are
-synchronized from your identity provider to NetBird, granting appropriate network access to new users and immediately
-revoking access for departing employees.
+IdP-Sync copies users and groups from your identity provider (IdP) into NetBird and keeps them current. Those synced groups then drive the rest of your configuration: you can point [access control policies](/manage/access-control/manage-network-access#creating-policies) or [DNS distribution](/manage/dns#distribution-groups) at a group and let membership follow your IdP.
 
-NetBird allows you to use synchronized groups to create [access control policies](/manage/access-control/manage-network-access#creating-policies),
-or update network configurations like [DNS](/manage/dns#distribution-groups),
-eliminating the need for manual grouping.
+There are two things to understand before picking a provider: which direction the sync runs, and what IdP-Sync will and will not manage for you. Both are covered below, then you pick your provider from the table.
 
 <Note>
-    IdP-Sync is available on NetBird Cloud in the [Team plan](https://netbird.io/pricing) and above. It is also
-    available on self-hosted deployments running a [Commercial License](https://netbird.io/pricing#on-prem) with the
-    embedded IdP, which use a separate set of setup guides listed under Self-hosted.
+    IdP-Sync is available on NetBird Cloud in the [Team plan](https://netbird.io/pricing) and above. It is also available on self-hosted deployments running a [Commercial License](https://netbird.io/pricing#on-prem) with the embedded IdP, which use a separate set of setup guides listed under Self-hosted.
 </Note>
 
 This video guide walks you through an example integration with Microsoft Entra ID, covering both user onboarding and
@@ -34,75 +24,54 @@ offboarding scenarios:
 
 NetBird syncs in one of two directions, and which one you get depends on the provider.
 
-**Pull, over the provider's API.** NetBird holds credentials for your IdP and reads users and groups from it on a
-schedule. You can also trigger a sync by hand from the dashboard. Google Workspace and Entra ID (API) work this way.
+**Pull, over the provider's API.** NetBird holds credentials for your IdP and reads users and groups from it on a schedule. You can also trigger a sync by hand from the dashboard. Google Workspace and Entra ID (API) work this way.
 
-**Push, over SCIM.** Your IdP sends changes to NetBird as they happen, using a SCIM endpoint and token that NetBird
-issues. There is no manual sync to trigger, because NetBird is the receiver. Entra ID (SCIM), Okta, JumpCloud, and any
-generic SCIM provider work this way.
+**Push, over SCIM.** SCIM, the System for Cross-domain Identity Management, is a standard protocol for provisioning users and groups between systems. Your IdP sends changes to NetBird as they happen, using a SCIM endpoint and token that NetBird issues. There is no manual sync to trigger, because NetBird is the receiver. Entra ID (SCIM), Okta, JumpCloud, and any generic SCIM provider work this way.
 
-The practical difference is timing and troubleshooting. A pull integration is late by at most one sync cycle and you can
-force it. A push integration is near-immediate, but when it stalls you fix it in your IdP's provisioning logs, not in
-NetBird.
+The practical difference is timing and troubleshooting. A pull integration is late by at most one sync cycle and you can force it. A push integration is near-immediate, but when it stalls you fix it in your IdP's provisioning logs, not in NetBird.
 
 ## Supported Identity Providers
 
-NetBird provides native support for syncing with the most popular identity providers. Pick yours below for detailed setup and configuration steps.
+NetBird supports the most common identity providers directly. Pick yours from the table for the full setup guide.
 
 | Provider | Direction | Set up in NetBird with |
 | --- | --- | --- |
-| Google Workspace | Pull (API) | `Connect Google Workspace` |
-| Entra ID (API) | Pull (API) | `Connect Entra ID (API)` |
-| Entra ID (SCIM) | Push (SCIM) | `Connect Entra ID (SCIM)` |
-| Okta | Push (SCIM) | `Connect Okta` |
-| JumpCloud | Push (SCIM) | `Connect Jumpcloud` |
-| Keycloak | Push (SCIM) | `Connect Generic SCIM` |
-| IIJ ID | Push (SCIM) | `Connect Generic SCIM` |
+| [Google Workspace](/manage/team/idp-sync/google-workspace-sync) | Pull (API) | `Connect Google Workspace` |
+| [Entra ID (API)](/manage/team/idp-sync/microsoft-entra-id-sync) | Pull (API) | `Connect Entra ID (API)` |
+| [Entra ID (SCIM)](/manage/team/idp-sync/microsoft-entra-id-scim-sync) | Push (SCIM) | `Connect Entra ID (SCIM)` |
+| [Okta](/manage/team/idp-sync/okta-sync) | Push (SCIM) | `Connect Okta` |
+| [JumpCloud](/manage/team/idp-sync/jumpcloud-sync) | Push (SCIM) | `Connect Jumpcloud` |
+| [Keycloak](/manage/team/idp-sync/keycloak-sync) | Push (SCIM) | `Connect Generic SCIM` |
+| [IIJ ID](/manage/team/idp-sync/iij-id-sync) | Push (SCIM) | `Connect Generic SCIM` |
 
-Keycloak and IIJ ID have no dedicated card on the `Identity Provider Sync` tab. Both are set up through
-`Connect Generic SCIM`, and their guides below walk through that path.
+Keycloak and IIJ ID have no dedicated card on the `Identity Provider Sync` tab. Both are set up through `Connect Generic SCIM`, and their linked guides walk through that path.
 
 <Note>
-    The dashboard configures one IdP-Sync integration at a time. While one is enabled, the setup buttons on
-    every other card are disabled, so switching providers means disabling the current integration first.
+    The dashboard configures one IdP-Sync integration at a time. While one is enabled, the setup buttons on every other card are disabled, so switching providers means disabling the current integration first.
 </Note>
 
-### Entra ID (API)
+## What IdP-Sync does not do
 
-Provision users and groups from Microsoft Entra ID through the Graph API. See [Entra ID (API) setup](/manage/team/idp-sync/microsoft-entra-id-sync).
+IdP-Sync manages users and group membership. It does not manage anything else, and two boundaries surprise people:
 
-### Entra ID (SCIM)
+- **Roles stay in NetBird.** A synced group never sets a user's NetBird role. If you move someone into an `Administrators` group in your IdP, they do not become a NetBird `Admin`. You assign roles in NetBird, as described in [User Roles](/manage/team/user-roles).
+- **Access still comes from policies.** Syncing a group grants no access on its own. A group is only useful once a [policy](/manage/access-control/manage-network-access#creating-policies) references it.
 
-Provision users and groups from Microsoft Entra ID over SCIM. See [Entra ID (SCIM) setup](/manage/team/idp-sync/microsoft-entra-id-scim-sync).
-
-### Okta
-
-Provision users and groups from Okta. See [Okta setup](/manage/team/idp-sync/okta-sync).
-
-### Google Workspace
-
-Provision users and groups from Google Workspace. See [Google Workspace setup](/manage/team/idp-sync/google-workspace-sync).
-
-### JumpCloud
-
-Provision users and groups from JumpCloud. See [JumpCloud setup](/manage/team/idp-sync/jumpcloud-sync).
-
-### Keycloak
-
-Provision users and groups from Keycloak. See [Keycloak setup](/manage/team/idp-sync/keycloak-sync).
-
-### IIJ ID
-
-Provision users and groups from IIJ ID over SCIM. See [IIJ ID setup](/manage/team/idp-sync/iij-id-sync).
+If you have a handful of users and no group structure worth mirroring, IdP-Sync buys you little. Invite them directly instead, as described in [Add users to your network](/manage/team/add-users-to-your-network). IdP-Sync earns its setup cost when your IdP already carries the group structure you want access to follow.
 
 ## Generic SCIM
 
-NetBird provides a way to sync users and groups from any identity provider that supports the SCIM (System for Cross-domain Identity Management) protocol.
-SCIM is a standardized protocol that works with most modern identity providers, although configuration varies between providers.
-
-If your provider is not listed above, contact us at support@netbird.io for assistance with your specific IdP setup.
+If your provider is not in the table, it can still work as long as it speaks SCIM. Set it up with `Connect Generic SCIM`, which is the same path the Keycloak and IIJ ID guides follow. Configuration details vary between providers, so contact us at support@netbird.io if you get stuck on yours.
 
 <p>
-    <img src="/docs-static/img/manage/team/idp-sync/generic-scim.png" alt="generic-scim"
+    <img src="/docs-static/img/manage/team/idp-sync/generic-scim.png" alt="The Generic SCIM setup dialog in the NetBird dashboard"
          className="imagewrapper-big"/>
 </p>
+
+## In one breath
+
+- Your IdP already knows who works here and which teams they are on. IdP-Sync makes NetBird follow it.
+- Google Workspace and Entra ID (API) **pull** on a schedule, and you can force a sync. Everything else **pushes**
+  over SCIM the moment your IdP sends a change.
+- You get users and group membership. You do not get roles, and you do not get access.
+- Point a policy at a synced group, and access follows your IdP from then on.

--- a/src/pages/manage/team/idp-sync/keycloak-sync.mdx
+++ b/src/pages/manage/team/idp-sync/keycloak-sync.mdx
@@ -1,12 +1,8 @@
 # Provision Users and Groups From Keycloak
 
-Keycloak is an open source identity and access management solution that provides features like single sign-on (SSO),
-multi-factor authentication (MFA), user federation, and centralized identity management to help organizations
-secure and manage access to their applications and resources.
+Keycloak is an open source identity and access management solution that provides features like single sign-on (SSO), multi-factor authentication (MFA), user federation, and centralized identity management to help organizations secure and manage access to their applications and resources.
 
-NetBird's Keycloak integration enhances user management by allowing you to utilize Keycloak as your identity provider.
-This integration automates user authentication in your network, adds SSO and MFA support, and simplifies network access management
-to your applications and resources.
+Connecting Keycloak to NetBird lets your existing Keycloak users and groups drive network access. Users sign in with the credentials they already have, including any MFA you enforce in Keycloak, and group membership flows into NetBird so your access policies follow it.
 
 import {Note} from "@/components/mdx";
 
@@ -201,8 +197,7 @@ After completing the initial sync, you can verify that users and groups have bee
 ![NetBird Verify Users](/docs-static/img/manage/team/idp-sync/keycloak-sync/netbird-verify-users.png)
 
 <Note>
-    SCIM provisioning will manage only resources that are created through Keycloak. Any resources created directly in
-    NetBird will not be managed by SCIM.
+    SCIM provisioning will manage only resources that are created through Keycloak. Any resources created directly in NetBird will not be managed by SCIM.
 </Note>
 
 <Note>

--- a/src/pages/manage/team/idp-sync/keycloak-sync.mdx
+++ b/src/pages/manage/team/idp-sync/keycloak-sync.mdx
@@ -1,6 +1,6 @@
 # Provision Users and Groups From Keycloak
 
-Keycloak is an open-source identity and access management solution that provides features like single sign-on (SSO),
+Keycloak is an open source identity and access management solution that provides features like single sign-on (SSO),
 multi-factor authentication (MFA), user federation, and centralized identity management to help organizations
 secure and manage access to their applications and resources.
 

--- a/src/pages/manage/team/single-sign-on/auth0.mdx
+++ b/src/pages/manage/team/single-sign-on/auth0.mdx
@@ -5,8 +5,7 @@ import {Note} from "@/components/mdx";
 You can use Auth0 as your Identity Provider with NetBird, but it will require some additional configuration steps. Auth0 is a flexible, drop-in solution to add authentication and authorization services to your applications. It's a managed service that offers extensive customization options, developer-friendly APIs, universal login, social identity providers, and advanced security features like anomaly detection and breached password detection.
 
 <Note>
-    Support for OIDC-compliant IdPs is available on the Team plan and higher.
-    The Free plan supports Google, Microsoft, and social logins.
+    Support for OIDC-compliant IdPs is available on the Team plan and higher. The Free plan supports Google, Microsoft, and social logins.
 </Note>
 
 1. Access the [Auth0 console](https://manage.auth0.com/) and navigate to Applications > Applications
@@ -16,14 +15,11 @@ You can use Auth0 as your Identity Provider with NetBird, but it will require so
 3. Enter **NetBird** as the name, select **Regular Web Applications** as the application type and click **Create**
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/auth0-idp/application-create.png" alt="auth0-application-create" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/auth0-idp/application-create.png" alt="The Auth0 Create Application dialog with Regular Web Applications selected" className="imagewrapper-big"/>
 </p>
 
 <Note>
-    The application type has to be **Regular Web Applications**. NetBird exchanges the authorization code
-    server-side using a Client Secret, which makes this a confidential client. Auth0 treats single-page and
-    native apps as public clients and does not show a Credentials tab for them, so those types never issue the
-    Client Secret you record in step 5.
+    The application type has to be **Regular Web Applications**. NetBird exchanges the authorization code server-side using a Client Secret, which makes this a confidential client. Auth0 treats single-page and native apps as public clients and does not show a Credentials tab for them, so those types never issue the Client Secret you record in step 5.
 </Note>
 
 4. On the New Application screen, go to the Settings tab and under Application URIs set the following values:
@@ -33,7 +29,7 @@ You can use Auth0 as your Identity Provider with NetBird, but it will require so
 - **Allowed Web Origins**: `https://app.netbird.io`
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/auth0-idp/application-configure.png" alt="auth0-application-configure" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/auth0-idp/application-configure.png" alt="The Auth0 Application URIs section filled in with the NetBird callback and logout URLs" className="imagewrapper-big"/>
 </p>
 
 5. Record the **Client ID** and **Client Secret** that Auth0 generates for your application.
@@ -41,7 +37,7 @@ You can use Auth0 as your Identity Provider with NetBird, but it will require so
 6. Retrieve Application's **Domain** from the **Basic Information** tab
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/auth0-idp/application-domain.png" alt="auth0-application-domain" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/auth0-idp/application-domain.png" alt="The Auth0 Basic Information tab showing the application Domain" className="imagewrapper-big"/>
 </p>
 
 7. Share the following with our team. Please use a secure method for sharing the sensitive parts of this information:

--- a/src/pages/manage/team/single-sign-on/auth0.mdx
+++ b/src/pages/manage/team/single-sign-on/auth0.mdx
@@ -13,11 +13,18 @@ You can use Auth0 as your Identity Provider with NetBird, but it will require so
 
 2. Click **+ Create Application**
 
-3. Enter **NetBird** as the name, select **Single Page Web Applications** as the application type and click **Create**
+3. Enter **NetBird** as the name, select **Regular Web Applications** as the application type and click **Create**
 
 <p>
     <img src="/docs-static/img/manage/team/single-sign-on/auth0-idp/application-create.png" alt="auth0-application-create" className="imagewrapper-big"/>
 </p>
+
+<Note>
+    The application type has to be **Regular Web Applications**. NetBird exchanges the authorization code
+    server-side using a Client Secret, which makes this a confidential client. Auth0 treats single-page and
+    native apps as public clients and does not show a Credentials tab for them, so those types never issue the
+    Client Secret you record in step 5.
+</Note>
 
 4. On the New Application screen, go to the Settings tab and under Application URIs set the following values:
 - **Application Login URI**: `https://app.netbird.io`

--- a/src/pages/manage/team/single-sign-on/auth0.mdx
+++ b/src/pages/manage/team/single-sign-on/auth0.mdx
@@ -1,8 +1,13 @@
 import {Note} from "@/components/mdx";
 
-# Auth0 on NetBird Cloud 
+# Auth0 on NetBird Cloud
 
 You can use Auth0 as your Identity Provider with NetBird, but it will require some additional configuration steps. Auth0 is a flexible, drop-in solution to add authentication and authorization services to your applications. It's a managed service that offers extensive customization options, developer-friendly APIs, universal login, social identity providers, and advanced security features like anomaly detection and breached password detection.
+
+<Note>
+    Support for OIDC-compliant IdPs is available on the Team plan and higher.
+    The Free plan supports Google, Microsoft, and social logins.
+</Note>
 
 1. Access the [Auth0 console](https://manage.auth0.com/) and navigate to Applications > Applications
 
@@ -15,24 +20,24 @@ You can use Auth0 as your Identity Provider with NetBird, but it will require so
 </p>
 
 4. On the New Application screen, go to the Settings tab and under Application URIs set the following values:
-- Application Login URI: https://app.netbird.io
-- Allowed Callback URLs: https://login.netbird.io/login/callback
-- Allowed Logout URLs: https://app.netbird.io
-- Allowed Web Origins: https://app.netbird.io
+- **Application Login URI**: `https://app.netbird.io`
+- **Allowed Callback URLs**: `https://login.netbird.io/login/callback`
+- **Allowed Logout URLs**: `https://app.netbird.io`
+- **Allowed Web Origins**: `https://app.netbird.io`
 
 <p>
     <img src="/docs-static/img/manage/team/single-sign-on/auth0-idp/application-configure.png" alt="auth0-application-configure" className="imagewrapper-big"/>
 </p>
 
-6. Record the **Client ID** and **Client Secret** that Auth0 generates for your application.
+5. Record the **Client ID** and **Client Secret** that Auth0 generates for your application.
 
-7. Retrieve Application's **Domain** from the **Basic Information** tab
+6. Retrieve Application's **Domain** from the **Basic Information** tab
 
 <p>
     <img src="/docs-static/img/manage/team/single-sign-on/auth0-idp/application-domain.png" alt="auth0-application-domain" className="imagewrapper-big"/>
 </p>
 
-8. Share following with our team. Please use a secure method for sharing the sensitive parts of this information:
+7. Share the following with our team. Please use a secure method for sharing the sensitive parts of this information:
    1. Application's **Domain**,
    2. (sensitive) **Client ID** and **Client Secret**,
    3. list of email domains to be registered for this SSO configuration,

--- a/src/pages/manage/team/single-sign-on/authentik.mdx
+++ b/src/pages/manage/team/single-sign-on/authentik.mdx
@@ -5,61 +5,60 @@ import {Note} from "@/components/mdx";
 You can use Authentik as your Identity Provider with NetBird, but it will require some additional configuration steps. Authentik is an open source identity provider focused on flexibility and security. It serves as a self-hosted alternative to commercial solutions like Okta and Auth0, providing single sign-on (SSO), multi-factor authentication (MFA), access policies, user management, and support for SAML and OIDC protocols.
 
 <Note>
-    Support for OIDC-compliant IdPs is available on the Team plan and higher.
-    The Free plan supports Google, Microsoft, and social logins.
+    Support for OIDC-compliant IdPs is available on the Team plan and higher. The Free plan supports Google, Microsoft, and social logins.
 </Note>
 
 1. You need to create a new Application and Provider.
     - Browse to the Applications Administration menu, click on Application, and then click on Create with Provider:
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/1-create-with-provider.png" alt="create-with-provider" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/1-create-with-provider.png" alt="The Authentik Applications list with the Create with Provider button" className="imagewrapper-big"/>
 </p>
         - Name the Application and select a suitable explicit user flow. In the example below, we used NetBird:
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/2-new-application.png" alt="new-application" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/2-new-application.png" alt="Naming the Authentik application and choosing an explicit user flow" className="imagewrapper-big"/>
 </p>
 
     - Click Next and select the OAuth2/OpenID Provider Type:
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/3-new-application-type.png" alt="new-application" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/3-new-application-type.png" alt="Selecting OAuth2/OpenID Provider as the Authentik provider type" className="imagewrapper-big"/>
 </p>
 
     - Click Next and select an explicit user authorization flow, then take note of the Client ID and Client Secret:
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/4-new-application-client-id.png" alt="new-application" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/4-new-application-client-id.png" alt="The Authentik provider screen showing the Client ID and Client Secret" className="imagewrapper-big"/>
 </p>
 
     - Add the following redirect URL and select a signing key: <br/>
     URL: `https://login.netbird.io/login/callback`
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/5-new-application-sign.png" alt="new-application" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/5-new-application-sign.png" alt="Entering the NetBird redirect URL and selecting a signing key in Authentik" className="imagewrapper-big"/>
 </p>
 
     - Click on Advanced protocol settings and ensure that the `openid`, `email`, and `profile` scopes are selected and that Based on the User’s Hash ID is selected for Subject mode:
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/6-new-application-scopes.png" alt="new-application" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/6-new-application-scopes.png" alt="Authentik Advanced protocol settings with the openid, email, and profile scopes selected" className="imagewrapper-big"/>
 </p>
 
     - Click Next on the following two screens and Submit to create the provider and application:
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/7-new-application-submit.png" alt="new-application" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/7-new-application-submit.png" alt="The final Authentik confirmation screen before submitting the provider and application" className="imagewrapper-big"/>
 </p>
 
     - You should see an application listed as follow:
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/8-list-applications.png" alt="list-applications" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/8-list-applications.png" alt="The new NetBird application listed in Authentik" className="imagewrapper-big"/>
 </p>
 
 2. We need to copy the OpenID Configuration URL for the new provider. You can do that by navigating to Providers in the left menu and then selecting the newly created provider. There you should see a windows similar to the following:
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/9-list-providers.png" alt="list-providers" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/9-list-providers.png" alt="The Authentik Providers list showing the OpenID Configuration URL" className="imagewrapper-big"/>
 </p>
 
     - Copy the OpenID Configuration URL.

--- a/src/pages/manage/team/single-sign-on/authentik.mdx
+++ b/src/pages/manage/team/single-sign-on/authentik.mdx
@@ -1,8 +1,8 @@
 import {Note} from "@/components/mdx";
 
-# Authentik on NetBird Cloud 
+# Authentik on NetBird Cloud
 
-You can use Authentik as your Identity Provider with NetBird, but it will require some additional configuration steps. Authentik is an open-source identity provider focused on flexibility and security. It serves as a self-hosted alternative to commercial solutions like Okta and Auth0, providing single sign-on (SSO), multi-factor authentication (MFA), access policies, user management, and support for SAML and OIDC protocols.
+You can use Authentik as your Identity Provider with NetBird, but it will require some additional configuration steps. Authentik is an open source identity provider focused on flexibility and security. It serves as a self-hosted alternative to commercial solutions like Okta and Auth0, providing single sign-on (SSO), multi-factor authentication (MFA), access policies, user management, and support for SAML and OIDC protocols.
 
 <Note>
     Support for OIDC-compliant IdPs is available on the Team plan and higher.
@@ -38,7 +38,7 @@ You can use Authentik as your Identity Provider with NetBird, but it will requir
     <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/5-new-application-sign.png" alt="new-application" className="imagewrapper-big"/>
 </p>
 
-    - Click on Advanced protocol settings and ensure that the email, opened, and profile scopes are selected and that Based on the User’s Hash ID is selected for Subject mode:
+    - Click on Advanced protocol settings and ensure that the `openid`, `email`, and `profile` scopes are selected and that Based on the User’s Hash ID is selected for Subject mode:
 
 <p>
     <img src="/docs-static/img/manage/team/single-sign-on/authentik-idp/6-new-application-scopes.png" alt="new-application" className="imagewrapper-big"/>

--- a/src/pages/manage/team/single-sign-on/index.mdx
+++ b/src/pages/manage/team/single-sign-on/index.mdx
@@ -2,8 +2,7 @@ import { Note, Button } from '@/components/mdx'
 
 # Authenticate to NetBird with Single Sign On (SSO)
 
-NetBird works out of the box with popular Identity Providers (IdPs) such as Google Workspace, Microsoft Entra ID, and Okta,
-offering seamless Single Sign-On (SSO) for your users.
+NetBird works out of the box with popular Identity Providers (IdPs) such as Google Workspace, Microsoft Entra ID, and Okta, so your users sign in with the credentials they already have.
 
 It also supports social logins including Google, GitHub, and Microsoft accounts.
 
@@ -11,17 +10,15 @@ For other OIDC (OpenID Connect)-compliant IdPs like Authentik, Keycloak, JumpClo
 though some additional configuration is required to complete the integration.
 
 <Note>
-    This guide covers the setup for cloud-hosted NetBird. If you are using the self-hosted version, please refer
-    to the [self-hosted documentation](/selfhosted/identity-providers).
+    This guide covers the setup for cloud-hosted NetBird. If you are using the self-hosted version, please refer to the [self-hosted documentation](/selfhosted/identity-providers).
 </Note>
 
 ## Google, Microsoft, and GitHub
 
-If you're using Google Workspace, Microsoft Entra ID, or a supported social login, you can simply sign in with no extra
-setup. Just click the appropriate button on the [login page](https://app.netbird.io/):
+If you're using Google Workspace, Microsoft Entra ID, or a supported social login, you can simply sign in with no extra setup. Just click the appropriate button on the [login page](https://app.netbird.io/):
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/netbird-login.png" alt="netbird-login" className="imagewrapper"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/netbird-login.png" alt="The NetBird login page with Google, Microsoft, and GitHub sign-in buttons" className="imagewrapper"/>
 </p>
 
 ## Okta
@@ -32,7 +29,7 @@ setup. Just click the appropriate button on the [login page](https://app.netbird
     The detailed setup steps for Okta integration, including SSO configuration and user/group provisioning, are available in our [Provision Users and Groups from Okta](/manage/team/idp-sync/okta-sync) documentation.
 </Note>
 
-NetBird's Okta integration enhances user management by allowing you to utilize Okta as your identity provider. This integration automates user authentication in your network, adds SSO and MFA support, and simplifies network access management to your applications and resources.
+Connecting Okta to NetBird lets your existing Okta users sign in with the credentials they already have, including any MFA you enforce in Okta, and lets Okta group membership drive your NetBird access policies.
 
 <Button href="/manage/team/idp-sync/okta-sync" variant="outline">Setup Okta</Button>
 
@@ -42,8 +39,7 @@ For OIDC-compliant Identity Providers such as **Authentik**, **Keycloak**, **Jum
 to integrate with NetBird. Below are the steps to set up different OIDC-compliant IdPs with NetBird.
 
 <Note>
-    Support for OIDC-compliant IdPs is available on the Team plan and higher.
-    The Free plan supports Google, Microsoft, and social logins.
+    Support for OIDC-compliant IdPs is available on the Team plan and higher. The Free plan supports Google, Microsoft, and social logins.
 </Note>
 
 ### Authentik

--- a/src/pages/manage/team/single-sign-on/index.mdx
+++ b/src/pages/manage/team/single-sign-on/index.mdx
@@ -18,7 +18,7 @@ though some additional configuration is required to complete the integration.
 ## Google, Microsoft, and GitHub
 
 If you're using Google Workspace, Microsoft Entra ID, or a supported social login, you can simply sign in with no extra
-setup—just click the appropriate button on the [login page](https://app.netbird.io/):
+setup. Just click the appropriate button on the [login page](https://app.netbird.io/):
 
 <p>
     <img src="/docs-static/img/manage/team/single-sign-on/netbird-login.png" alt="netbird-login" className="imagewrapper"/>
@@ -48,13 +48,13 @@ to integrate with NetBird. Below are the steps to set up different OIDC-complian
 
 ### Authentik
 
-[Authentik](https://goauthentik.io/) is an open-source identity provider focused on flexibility and security. It serves as a self-hosted alternative to commercial solutions like Okta and Auth0, providing single sign-on (SSO), multi-factor authentication (MFA), access policies, user management, and support for SAML and OIDC protocols. Authentik includes audit logging, password policies, and full API access for automation.
+[Authentik](https://goauthentik.io/) is an open source identity provider focused on flexibility and security. It serves as a self-hosted alternative to commercial solutions like Okta and Auth0, providing single sign-on (SSO), multi-factor authentication (MFA), access policies, user management, and support for SAML and OIDC protocols. Authentik includes audit logging, password policies, and full API access for automation.
 
 <Button href="/manage/team/single-sign-on/authentik" variant="outline">Setup Authentik</Button>
 
 ### Keycloak
 
-[Keycloak](https://www.keycloak.org/) is an open-source Identity and Access Management solution aimed at modern applications and services. It's one of the most popular self-hosted IDP solutions with extensive documentation and community support. Keycloak provides single sign-on, social login, user federation, fine-grained authorization, and supports OpenID Connect, OAuth 2.0, and SAML 2.0 protocols.
+[Keycloak](https://www.keycloak.org/) is an open source Identity and Access Management solution aimed at modern applications and services. It's one of the most popular self-hosted IdP solutions with extensive documentation and community support. Keycloak provides single sign-on, social login, user federation, fine-grained authorization, and supports OpenID Connect, OAuth 2.0, and SAML 2.0 protocols.
 
 <Button href="/manage/team/single-sign-on/keycloak" variant="outline">Setup Keycloak</Button>
 
@@ -72,13 +72,13 @@ to integrate with NetBird. Below are the steps to set up different OIDC-complian
 
 ### Duo Security
 
-[Duo Security](https://duo.com/) is a cloud-based security platform that provides secure access through single sign-on (SSO), multi-factor authentication (MFA), and device trust. Duo offers comprehensive identity verification and access policies to protect applications and data, with a focus on zero trust security architecture.
+[Duo Security](https://duo.com/) is a cloud-based security platform that provides secure access through single sign-on (SSO), multi-factor authentication (MFA), and device trust. Duo offers comprehensive identity verification and access policies to protect applications and data, with a focus on Zero Trust security architecture.
 
 <Button href="/manage/team/single-sign-on/duo-security" variant="outline">Setup Duo Security</Button>
 
 ### Zitadel
 
-[Zitadel](https://zitadel.com/) is an open-source, API-first identity infrastructure platform built with multi-tenancy at its core. It provides single sign-on, passwordless authentication, role-based access control, and supports OpenID Connect, OAuth 2.0, and SAML.
+[Zitadel](https://zitadel.com/) is an open source, API-first identity infrastructure platform built with multi-tenancy at its core. It provides single sign-on, passwordless authentication, role-based access control, and supports OpenID Connect, OAuth 2.0, and SAML.
 
 <Button href="/manage/team/single-sign-on/zitadel" variant="outline">Setup Zitadel</Button>
 

--- a/src/pages/manage/team/single-sign-on/jumpcloud.mdx
+++ b/src/pages/manage/team/single-sign-on/jumpcloud.mdx
@@ -9,7 +9,7 @@ You can use JumpCloud as your Identity Provider with NetBird, but it will requir
     The Free plan supports Google, Microsoft, and social logins.
 </Note>
 
-1. Access JumpCloud and navigate to USER AUTHENTICATION > SSO Applications
+1. In the JumpCloud Admin Console, navigate to **Access** > **SSO Applications**
 
 2. Click + Add New Application, select Custom Application and click Next
 
@@ -42,6 +42,11 @@ You can use JumpCloud as your Identity Provider with NetBird, but it will requir
 8. Go to the User Groups and select the list of groups to which you want to give access to the application and then click activate
 
 9. Record the Client ID and Client Secret that JumpCloud generates for your application.
+
+<Note>
+  JumpCloud shows the Client ID and Secret only once, right after you click activate. Copy them before closing the window, otherwise you have to regenerate the secret.
+</Note>
+
 
 10. Share your Client ID and Client Secret with our team, along with the region your JumpCloud console is in (US, EU, or India). Please use a secure method for sharing this information.
 

--- a/src/pages/manage/team/single-sign-on/jumpcloud.mdx
+++ b/src/pages/manage/team/single-sign-on/jumpcloud.mdx
@@ -36,7 +36,7 @@ You can use JumpCloud as your Identity Provider with NetBird, but it will requir
 7. Under Attribute Mapping enable Email and Profile scopes
 
 <Note>
-  Sometimes, the JumpCloud application configuration will add duplicate attributes, like email and email_verified. The duplicates should be removed. 
+  Sometimes the JumpCloud application configuration adds duplicate attribute mappings. Remove the duplicates so each claim is mapped only once.
 </Note>
 
 8. Go to the User Groups and select the list of groups to which you want to give access to the application and then click activate

--- a/src/pages/manage/team/single-sign-on/jumpcloud.mdx
+++ b/src/pages/manage/team/single-sign-on/jumpcloud.mdx
@@ -5,8 +5,7 @@ import {Note} from "@/components/mdx";
 You can use JumpCloud as your Identity Provider with NetBird, but it will require some additional configuration steps. JumpCloud is a cloud-based directory platform that provides identity, access, and device management in a unified solution. It offers single sign-on, multi-factor authentication, directory services, device management, and network access control, providing a comprehensive approach to managing users, devices, and applications from a single platform.
 
 <Note>
-    Support for OIDC-compliant IdPs is available on the Team plan and higher.
-    The Free plan supports Google, Microsoft, and social logins.
+    Support for OIDC-compliant IdPs is available on the Team plan and higher. The Free plan supports Google, Microsoft, and social logins.
 </Note>
 
 1. In the JumpCloud Admin Console, navigate to **Access** > **SSO Applications**
@@ -16,7 +15,7 @@ You can use JumpCloud as your Identity Provider with NetBird, but it will requir
 3. Enable Manage Single Sign-On (SSO), select Configure SSO with OIDC and click Next
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/jumpcloud-idp/jumpcloud-sso.png" alt="jumpcloud" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/jumpcloud-idp/jumpcloud-sso.png" alt="The JumpCloud custom application dialog with Configure SSO with OIDC selected" className="imagewrapper-big"/>
 </p>
 
 4. Add NetBird as Display Label and click Next. Optionally, you can enter a Description, adjust the User Portal Image and choose to hide or Show in User Portal.
@@ -24,7 +23,7 @@ You can use JumpCloud as your Identity Provider with NetBird, but it will requir
 5. Review the application setting and click Configure Application to proceed
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/jumpcloud-idp/jumpcloud-sso-config.png" alt="jumpcloud-idp" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/jumpcloud-idp/jumpcloud-sso-config.png" alt="The JumpCloud application review screen before configuring the application" className="imagewrapper-big"/>
 </p>
 
 6. On the New Application screen, go to the SSO tab and under Endpoint Configuration set the following values:

--- a/src/pages/manage/team/single-sign-on/jumpcloud.mdx
+++ b/src/pages/manage/team/single-sign-on/jumpcloud.mdx
@@ -1,10 +1,15 @@
 import {Note} from "@/components/mdx";
 
-# JumpCloud on NetBird Cloud 
+# JumpCloud on NetBird Cloud
 
 You can use JumpCloud as your Identity Provider with NetBird, but it will require some additional configuration steps. JumpCloud is a cloud-based directory platform that provides identity, access, and device management in a unified solution. It offers single sign-on, multi-factor authentication, directory services, device management, and network access control, providing a comprehensive approach to managing users, devices, and applications from a single platform.
 
-1. Access the JumpCloud and navigate to USER AUTHENTICATION > SSO Applications
+<Note>
+    Support for OIDC-compliant IdPs is available on the Team plan and higher.
+    The Free plan supports Google, Microsoft, and social logins.
+</Note>
+
+1. Access JumpCloud and navigate to USER AUTHENTICATION > SSO Applications
 
 2. Click + Add New Application, select Custom Application and click Next
 
@@ -24,14 +29,14 @@ You can use JumpCloud as your Identity Provider with NetBird, but it will requir
 
 6. On the New Application screen, go to the SSO tab and under Endpoint Configuration set the following values:
 
-- Redirect URIs: https://login.netbird.io/login/callback
+- **Redirect URIs**: `https://login.netbird.io/login/callback`
 
-- Login URL: https://app.netbird.io
+- **Login URL**: `https://app.netbird.io`
 
 7. Under Attribute Mapping enable Email and Profile scopes
 
 <Note>
-  Sometimes, the Jumpcloud application configuration will add duplicate attributes, like email and email_verified. The duplicates should be removed. 
+  Sometimes, the JumpCloud application configuration will add duplicate attributes, like email and email_verified. The duplicates should be removed. 
 </Note>
 
 8. Go to the User Groups and select the list of groups to which you want to give access to the application and then click activate

--- a/src/pages/manage/team/single-sign-on/keycloak.mdx
+++ b/src/pages/manage/team/single-sign-on/keycloak.mdx
@@ -1,8 +1,13 @@
 import {Note} from "@/components/mdx";
 
-# Keycloak on NetBird Cloud 
+# Keycloak on NetBird Cloud
 
-You can use Keycloak as your Identity Provider with NetBird, but it will require some additional configuration steps. Keycloak is an open-source Identity and Access Management solution aimed at modern applications and services. It's one of the most popular self-hosted IDP solutions with extensive documentation and community support. Keycloak provides single sign-on, social login, user federation, fine-grained authorization, and supports OpenID Connect, OAuth 2.0, and SAML 2.0 protocols.
+You can use Keycloak as your Identity Provider with NetBird, but it will require some additional configuration steps. Keycloak is an open source Identity and Access Management solution aimed at modern applications and services. It's one of the most popular self-hosted IdP solutions with extensive documentation and community support. Keycloak provides single sign-on, social login, user federation, fine-grained authorization, and supports OpenID Connect, OAuth 2.0, and SAML 2.0 protocols.
+
+<Note>
+    Support for OIDC-compliant IdPs is available on the Team plan and higher.
+    The Free plan supports Google, Microsoft, and social logins.
+</Note>
 
 1. You need to create a new client
 

--- a/src/pages/manage/team/single-sign-on/keycloak.mdx
+++ b/src/pages/manage/team/single-sign-on/keycloak.mdx
@@ -5,8 +5,7 @@ import {Note} from "@/components/mdx";
 You can use Keycloak as your Identity Provider with NetBird, but it will require some additional configuration steps. Keycloak is an open source Identity and Access Management solution aimed at modern applications and services. It's one of the most popular self-hosted IdP solutions with extensive documentation and community support. Keycloak provides single sign-on, social login, user federation, fine-grained authorization, and supports OpenID Connect, OAuth 2.0, and SAML 2.0 protocols.
 
 <Note>
-    Support for OIDC-compliant IdPs is available on the Team plan and higher.
-    The Free plan supports Google, Microsoft, and social logins.
+    Support for OIDC-compliant IdPs is available on the Team plan and higher. The Free plan supports Google, Microsoft, and social logins.
 </Note>
 
 1. You need to create a new client
@@ -14,19 +13,19 @@ You can use Keycloak as your Identity Provider with NetBird, but it will require
     - Browse to the clients Administration menu and then click in Create client:
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/keycloak-idp/1-new-client.png" alt="new-client" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/keycloak-idp/1-new-client.png" alt="The Keycloak Clients screen with the Create client button" className="imagewrapper-big"/>
 </p>
 
 2. Create a client with the type OpenID Connect and add any client ID and name for the client:
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/keycloak-idp/2-new-client-type.png" alt="new-client" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/keycloak-idp/2-new-client-type.png" alt="Creating a Keycloak client with type OpenID Connect" className="imagewrapper-big"/>
 </p>
 
 3. Click Next and enable the following options for Capability config:
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/keycloak-idp/3-new-client-capability.png" alt="new-client" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/keycloak-idp/3-new-client-capability.png" alt="The Keycloak Capability config step with the required options enabled" className="imagewrapper-big"/>
 </p>
 
 4. Click Next and fill the following fields:
@@ -35,7 +34,7 @@ You can use Keycloak as your Identity Provider with NetBird, but it will require
     Web origins: `+`
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/keycloak-idp/4-new-client-callback.png" alt="new-client" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/keycloak-idp/4-new-client-callback.png" alt="The Keycloak client with the NetBird redirect URI and web origins set" className="imagewrapper-big"/>
 </p>
 
 5. Click Save.
@@ -43,7 +42,7 @@ You can use Keycloak as your Identity Provider with NetBird, but it will require
 6. Next we need to retrieve the secret for the client, you can get that in the Credentials tab for the client:
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/keycloak-idp/5-new-client-credentials.png" alt="new-client" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/keycloak-idp/5-new-client-credentials.png" alt="The Keycloak Credentials tab showing the client secret" className="imagewrapper-big"/>
 </p>
 
 7. Then, share the following information with the NetBird support team at support@netbird.io:

--- a/src/pages/manage/team/single-sign-on/zitadel.mdx
+++ b/src/pages/manage/team/single-sign-on/zitadel.mdx
@@ -2,7 +2,7 @@ import {Note} from "@/components/mdx";
 
 # Zitadel on NetBird Cloud
 
-You can use Zitadel as your Identity Provider with NetBird, but it will require some additional configuration steps. Zitadel is an open-source, API-first identity infrastructure platform built with multi-tenancy at its core. It provides single sign-on, passwordless authentication, role-based access control, and supports OpenID Connect, OAuth 2.0, and SAML.
+You can use Zitadel as your Identity Provider with NetBird, but it will require some additional configuration steps. Zitadel is an open source, API-first identity infrastructure platform built with multi-tenancy at its core. It provides single sign-on, passwordless authentication, role-based access control, and supports OpenID Connect, OAuth 2.0, and SAML.
 
 <Note>
     Support for OIDC-compliant IdPs is available on the Team plan and higher.
@@ -67,7 +67,7 @@ Click **Continue** to proceed to the review stage. Verify your application setti
 
 ## Step 5: Copy the Client Credentials
 
-After creation, Zitadel displays the **Client ID** and **Client Secret**. Copy and store these securely — the Client Secret is only shown once.
+After creation, Zitadel displays the **Client ID** and **Client Secret**. Copy and store these securely. The Client Secret is only shown once.
 
 <p>
     <img src="/docs-static/img/manage/team/single-sign-on/zitadel-idp/client-credentials.png" alt="zitadel-client-credentials" className="imagewrapper-big"/>

--- a/src/pages/manage/team/single-sign-on/zitadel.mdx
+++ b/src/pages/manage/team/single-sign-on/zitadel.mdx
@@ -5,8 +5,7 @@ import {Note} from "@/components/mdx";
 You can use Zitadel as your Identity Provider with NetBird, but it will require some additional configuration steps. Zitadel is an open source, API-first identity infrastructure platform built with multi-tenancy at its core. It provides single sign-on, passwordless authentication, role-based access control, and supports OpenID Connect, OAuth 2.0, and SAML.
 
 <Note>
-    Support for OIDC-compliant IdPs is available on the Team plan and higher.
-    The Free plan supports Google, Microsoft, and social logins.
+    Support for OIDC-compliant IdPs is available on the Team plan and higher. The Free plan supports Google, Microsoft, and social logins.
 </Note>
 
 ## Step 1: Create a New Project (Optional)
@@ -18,13 +17,13 @@ You can use Zitadel as your Identity Provider with NetBird, but it will require 
 Log in to your Zitadel console at `https://<your-instance>.zitadel.cloud`. Navigate to **Projects** and click **+ Create New Project**. Enter `NetBird` as the project name and click **Continue**.
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/zitadel-idp/create-project.png" alt="zitadel-create-project" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/zitadel-idp/create-project.png" alt="Creating a new project in the Zitadel console" className="imagewrapper-big"/>
 </p>
 
 You should see the project dashboard once the project is created.
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/zitadel-idp/project-created.png" alt="zitadel-project-created" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/zitadel-idp/project-created.png" alt="The Zitadel project dashboard after the project is created" className="imagewrapper-big"/>
 </p>
 
 ## Step 2: Create a New Application
@@ -34,7 +33,7 @@ Inside your project, click **+ New** to create a new application. Configure the 
 - **Type**: `Web`
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/zitadel-idp/create-application.png" alt="zitadel-create-application" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/zitadel-idp/create-application.png" alt="Creating a Zitadel application with type Web" className="imagewrapper-big"/>
 </p>
 
 Click **Continue**.
@@ -44,7 +43,7 @@ Click **Continue**.
 Select **Code** as the authentication method. This enables the Authorization Code flow with a client secret.
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/zitadel-idp/authentication-method.png" alt="zitadel-authentication-method" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/zitadel-idp/authentication-method.png" alt="Selecting Code as the Zitadel authentication method" className="imagewrapper-big"/>
 </p>
 
 Click **Continue**.
@@ -56,13 +55,13 @@ Set the following redirect settings:
 - **Post Logout URIs**: `https://app.netbird.io`
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/zitadel-idp/redirect-uris.png" alt="zitadel-redirect-uris" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/zitadel-idp/redirect-uris.png" alt="The Zitadel redirect and post logout URIs set to the NetBird endpoints" className="imagewrapper-big"/>
 </p>
 
 Click **Continue** to proceed to the review stage. Verify your application settings and click **Create**.
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/zitadel-idp/review-application.png" alt="zitadel-review-application" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/zitadel-idp/review-application.png" alt="The Zitadel review screen before creating the application" className="imagewrapper-big"/>
 </p>
 
 ## Step 5: Copy the Client Credentials
@@ -70,7 +69,7 @@ Click **Continue** to proceed to the review stage. Verify your application setti
 After creation, Zitadel displays the **Client ID** and **Client Secret**. Copy and store these securely. The Client Secret is only shown once.
 
 <p>
-    <img src="/docs-static/img/manage/team/single-sign-on/zitadel-idp/client-credentials.png" alt="zitadel-client-credentials" className="imagewrapper-big"/>
+    <img src="/docs-static/img/manage/team/single-sign-on/zitadel-idp/client-credentials.png" alt="Zitadel displaying the Client ID and Client Secret after creation" className="imagewrapper-big"/>
 </p>
 
 ## Step 6: Share Configuration with NetBird

--- a/src/pages/manage/team/user-roles.mdx
+++ b/src/pages/manage/team/user-roles.mdx
@@ -1,6 +1,6 @@
 import {Note} from "@/components/mdx"
 
-export const description = "Understand NetBird's user roles — Owner, Admin, Network Admin, Billing Admin, Auditor, and User — what each can access, and how to assign them."
+export const description = "Understand NetBird's user roles: Owner, Admin, Network Admin, Billing Admin, Auditor, and User. What each can access, and how to assign them."
 
 # User Roles
 
@@ -22,6 +22,7 @@ Rows are grouped by what a `Network Admin` can do, from full access down to no a
 | Activity | ✅ | ✅ | 📖 | ❌ | 📖 | ❌ |
 | Settings | ✅ | ✅ | 📖 | ✅<sup style={{fontSize: '0.9em', fontWeight: 'bold'}}>2</sup> | 📖 | ❌ |
 | Reverse Proxy | ✅ | ✅ | ❌ | ❌ | 📖 | ❌ |
+| Agent Network | ✅ | ✅ | ❌ | ❌ | 📖 | ❌ |
 | Tenants | ✅ | ✅ | ❌ | ❌ | 📖 | ❌ |
 | Integrations | ✅ | ✅ | ❌ | ❌ | 📖 | ❌ |
 
@@ -29,7 +30,7 @@ Rows are grouped by what a `Network Admin` can do, from full access down to no a
 
 <sup style={{fontSize: '0.9em', fontWeight: 'bold'}}>1</sup> A `User` can only see the peers they own and peers they're allowed to connect to.
 
-<sup style={{fontSize: '0.9em', fontWeight: 'bold'}}>2</sup> A `Billing Admin`'s Settings access is limited to **Plans & Billing** and **Invoices**.
+<sup style={{fontSize: '0.9em', fontWeight: 'bold'}}>2</sup> A `Billing Admin`'s Settings access is limited to `Plans & Billing` and `Invoices`.
 
 ## Owner
 The `Owner` has full access to the account and can manage every aspect of it. There can be only one account owner in NetBird. Owners are the only users who can delete the organization account - see [Delete NetBird account](/manage/settings/delete-account) for more.
@@ -38,7 +39,7 @@ The `Owner` has full access to the account and can manage every aspect of it. Th
 An `Admin` has full access to the account, with two exceptions: administrators can't delete or change the role of the `Owner`, and they can't delete the organization account.
 
 ## Network Admin
-A `Network Admin` fully manages network configuration - Control Center, Access Control, Network Routing, and DNS. They have read-only access to Peers, Setup Keys, Team, Activity, and Settings, and no access to Reverse Proxy, Tenants, or Integrations. A `Network Admin` can view setup keys but not create them, and can't invite users or create service users.
+A `Network Admin` fully manages network configuration - Control Center, Access Control, Network Routing, and DNS. They have read-only access to Peers, Setup Keys, Team, Activity, and Settings, and no access to Reverse Proxy, Agent Network, Tenants, or Integrations. A `Network Admin` can view setup keys but not create them, and can't invite users or create service users.
 
 ## Billing Admin
 A `Billing Admin` manages billing only. They can access `Settings` → `Plans & Billing` and `Settings` → `Invoices`, and have no access to any other part of the account.
@@ -50,7 +51,11 @@ An `Auditor` can read every configuration in the account but can't modify anythi
 A `User` has limited access: they can view the peers they own and other peers they're allowed to connect to.
 
 ## Roles and the API
-Roles apply the same way whether a user works in the dashboard or through the [NetBird management API](/api) - a user's permissions over API resources match their role. Every role except `User` can create a personal access token that carries the same permissions as that user's role, so they can interact with the API programmatically.
+Roles apply the same way whether a user works in the dashboard or through the [NetBird management API](/api) - a user's permissions over API resources match their role.
+
+`Owner`, `Admin`, and `Network Admin` can create personal access tokens, which carry the same permissions as the user who owns them. `Auditor` and `User` cannot create a token, not even for themselves, because token creation is a create operation and neither role is granted one. An `Auditor` that needs programmatic read access has to be issued a token by an admin on a service user instead.
+
+Token expiration must be between 1 and 365 days.
 
 ## Roles and identity provider sync
 <Note>


### PR DESCRIPTION
## Scope

Audit of the whole `manage/team` section, 29 pages, of which 15 changed plus the docs sidebar. No pages were added, none were renamed, and no URLs changed.

## Navigation

`Single Sign-On` now nests its 10 provider pages, which previously existed but were commented out of the sidebar and reachable only through the index page. This mirrors the existing `Provision Users & Groups` pattern. **Sidebar labels and nesting only. No file moved and no URL changed.**

## Per-page corrections

### `user-roles.mdx`

| Was | Now | Source |
| --- | --- | --- |
| "Every role except `User` can create a personal access token" | `Owner`, `Admin`, and `Network Admin` can. `Auditor` and `User` cannot | `roles/auditor.go` sets `AutoAllowNew{Read:true, Create:false}` with no `Pats` override; `management/server/user.go:409` gates `CreatePAT` on `modules.Pats`/`operations.Create` with no self-service bypass |
| No Agent Network row | Agent Network row added | `layouts/Navigation.tsx` renders the section and gates it on `services.read`, same as Reverse Proxy |
| No token expiry bound stated | 1 to 365 days | `management/server/account/pat.go` |

The PAT finding was re-derived a second way: `CreateNewPAT` has exactly one non-test caller, `management/server/user.go:436`, inside the permission-gated `CreatePAT`.

Tag containment on the expiry constants points at v0.70.5, but that commit is a constants refactor. The 1 to 365 bound predates v0.60.0, so **no version gate was added**.

### `add-users-to-your-network.mdx`

- IdP Sync was documented as a button on the `Users` tab. It is not there. It is `Integrations` then the `Identity Provider Sync` tab (`modules/integrations/idp-sync/IdentityProviderTab.tsx:38`).
- Added the self-hosted variant: the button reads `Add User`, appears only with local user management enabled, and is disabled when local authentication is off (`modules/users/UsersTable.tsx:488`).
- Replaced "This is a limitation that is likely to be removed in future versions" with the constraint that is still enforced at `management/server/user.go:178`.

### `approve-users.mdx`

- `Reject` is permanent and removes the user from the account. The page never said so (`modules/users/table-cells/UserActionCell.tsx:63`).
- Documented the `Pending Approval` filter and the pending user's own `User Approval Pending` screen.
- Stated the role gate: the buttons render only for roles with `users.update`, so `Owner` and `Admin` (`UserActionCell.tsx:141`).
- Rewritten opening: the page used "domain matching" four times without defining it.

### `idp-sync/index.mdx`

- Added a pull versus push split. `/sync` endpoints exist only for `google-idp` and `azure-idp`; the SCIM integrations have `/token` and `/logs` but no `/sync`.
- Corrected the provider table to the real card labels. The card button renders `Connect {name}`, giving `Connect Entra ID (API)`, `Connect Entra ID (SCIM)`, `Connect Google Workspace`, `Connect Okta`, `Connect Jumpcloud`, `Connect Generic SCIM`.
- Made explicit that Keycloak and IIJ ID have no dedicated card and are set up through Generic SCIM.
- Corrected the availability note. It claimed cloud only; self-hosted with a Commercial License and the embedded IdP is also supported.
- Added a "What IdP-Sync does not do" section. Synced groups never set a NetBird role, and syncing a group grants no access until a policy references it.
- The one-integration note is scoped to the dashboard (`useIntegrations.tsx`), which is what the source actually proves. The API contract documents no such constraint.

### `auto-offboard-users.mdx`

Manual sync only applies to the pull-based providers. Three absolute `docs.netbird.io` links made relative.

### Third-party walkthroughs, verified against vendor documentation

- **`auth0.mdx`**: the page said to create a **Single Page Web Application**, then two steps later to record the Client Secret. Auth0 documents that single-page apps are public clients and that "the Auth0 Dashboard does not include authentication method or credentials settings for these application types", so the walkthrough could not be followed. Corrected to **Regular Web Applications**, with a note explaining why. Also fixed a numbering gap that skipped step 5.
- **`entra-id-app-enablement.mdx`**: required role was "Global Administrator or Cloud Application Administrator". Microsoft documents that Cloud Application Administrator can consent for any API *except* Microsoft Graph application permissions, and NetBird's Entra sync uses `User.Read.All` and `Group.Read.All` as Graph application permissions. Corrected to Privileged Role Administrator or Global Administrator, and updated the portal path to the Microsoft Entra admin center.
- **`jumpcloud.mdx`**: console path `USER AUTHENTICATION > SSO Applications` is stale. It is now `Access > SSO Applications`. Added JumpCloud's documented warning that the Client ID and Secret are shown only once.
- **`authentik.mdx`**: the page told readers to select the "opened" scope. There is no such OIDC scope; it is `openid`, as every other page in the section says.
- **`google-workspace-sync.mdx`**: `NerBird` typo in the service account name, a value readers type verbatim.

**Verified as already correct and left alone:** AWS Cognito (`Traditional web application`, `Managed login pages configuration`, callback URLs, grant types, scopes) and Duo (`Grant Type`, `Sign-In Redirect URLs`, scopes, Metadata tab), both matching vendor docs field for field.

### Consistency fixes across the SSO cluster

- The Team plan gating note was missing from `auth0`, `jumpcloud`, and `keycloak` while the other seven pages and the index all carried it. A Free plan reader would have completed an entire vendor console setup before discovering the limit. Now on all 10, verified mechanically.
- `https://login.netbird.io/login/callback` confirmed byte-identical across all 10 provider pages.

## Check manually before merging

- **Screenshots across the whole section are unverified.** `auto-offboard-users.mdx` still carries eight images with imgur-style filenames (`GT3eAeU.png` and similar) that predate the current UI. The Entra, JumpCloud, and Auth0 screenshots now contradict the corrected prose, since they were captured against the old console paths and the old Auth0 application type.
- The `cidaas.mdx` logout URL is `https://login.netbird.io/oauth/revoke`, whereas `auth0` and `zitadel` both use `https://app.netbird.io` for the equivalent field. A revoke endpoint is not a post-logout redirect, so one of these is likely wrong. **Not changed**, because it is a NetBird-side value that cannot be verified from the repos.

## Cloud-backend claims left as-is

Not verifiable from the open-source tree, retained rather than deleted:

- **`Billing Admin` is absent from `roles.RolesMap` entirely.** In the open-source server it would fail role resolution, so the whole Billing Admin row and section describe cloud-only behavior. It was deliberately left out of the corrected PAT sentence rather than guessed at.
- Network Admin's no-access marking for Integrations. The open-source tree grants `identity_providers:read`, but the dashboard gates the nav item on a separate cloud `idp` key. Genuinely ambiguous, so not "corrected".
- "New NetBird Cloud accounts have user approval enabled by default" and the 300 second sync cycle.
- The Entra application ID `7a7538de-...` and the `login.netbird.io` endpoints.

## Upstream staleness noticed, not fixable here

- Dashboard links ride legacy redirects: `docs.netbird.io/how-to/idp-sync` and `docs.netbird.io/how-to/approve-users`.
- `IdentityProviderTab` breadcrumb points at `/settings?tab=identity-provider` while the page lives under `/integrations`.
- Agent Network nav gates on `services.read` despite a dedicated `agent_network` module with seven submodules existing.
- The JumpCloud card is named `Jumpcloud`; the vendor's own casing is JumpCloud.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded Single Sign-On navigation with active links for additional identity providers.
  - Clarified self-hosted invitations, pending-user approval workflows, and role-based permissions.
- **Documentation**
  - Added comprehensive guidance for identity provider synchronization, including API- and SCIM-based workflows, supported providers, timing, and troubleshooting.
  - Updated SSO setup guides with plan availability, login options, configuration values, and corrected OAuth requirements.
  - Improved links, terminology, formatting, and instructions across team management documentation. 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->