### PR TITLE
docs: surface exit nodes under Routes and document broad-access mitigations

### DIFF
--- a/src/components/NavigationDocs.jsx
+++ b/src/components/NavigationDocs.jsx
@@ -228,6 +228,10 @@ export const docsNavigation = [
                         href: '/manage/network-routes/use-cases/site-to-site',
                     },
                     {
+                        title: 'Exit Nodes',
+                        href: '/use-cases/remote-access/exit-nodes',
+                    },
+                    {
                         title: 'Access Control',
                         href: '/manage/network-routes/access-control',
                     },

--- a/src/pages/manage/network-routes/index.mdx
+++ b/src/pages/manage/network-routes/index.mdx
@@ -9,6 +9,8 @@ Routes are deprecated. Every use case except [exit nodes](/use-cases/remote-acce
 
 Routes let you route traffic from NetBird peers to private networks without installing the NetBird client on every device. A routing peer forwards packets between your NetBird mesh network and your internal networks (LANs, VPCs, data centers).
 
+Routes also power [exit nodes](/use-cases/remote-access/exit-nodes): a default route (`0.0.0.0/0`) that sends all internet traffic from peers in its distribution groups through a routing peer. That route grants access to any network the routing peer can reach; see the [exit nodes guide](/use-cases/remote-access/exit-nodes#routing-peer) for how to limit this with **Block LAN access**.
+
 <p>
     <img src="/docs-static/img/manage/network-routes/concepts/netbird-network-routes.png" alt="Routes diagram" className="imagewrapper-big"/>
 </p>

--- a/src/pages/manage/networks/how-routing-peers-work.mdx
+++ b/src/pages/manage/networks/how-routing-peers-work.mdx
@@ -216,6 +216,9 @@ Specifics:
 - The minimum policy for an exit node to function is ICMP from source group to the routing peer group.
 - Auto Apply controls whether clients use the exit node automatically (v0.55.0+) or only when manually selected.
 - Set a DNS server with match domain `ALL` to prevent DNS-based location leaks. Local DNS servers may not be reachable from the exit node in any case.
+- The `0.0.0.0/0` route exposes any network the exit node can reach, including its local LAN, not just the internet.
+
+For setup steps and ways to limit what the exit node exposes (Block LAN access, network isolation), see [Configuring Exit Nodes for Internet Traffic](/use-cases/remote-access/exit-nodes#routing-peer).
 
 ## Observability and troubleshooting
 

--- a/src/pages/use-cases/remote-access/exit-nodes.mdx
+++ b/src/pages/use-cases/remote-access/exit-nodes.mdx
@@ -18,6 +18,17 @@ When [IPv6 overlay addressing](#ipv6-support) is enabled for the peer, the manag
 
 The routing peer acts as the exit node for internet traffic. It applies masquerading so that traffic appears to originate from the routing peer's public IP address.
 
+<Warning>
+An exit node route (`0.0.0.0/0`) matches all traffic, not just internet-bound traffic. Peers using the exit node can reach any network the routing peer can reach, including its local LAN.
+</Warning>
+
+You can limit this in two ways:
+
+- Enable **Block LAN access** on the routing peer (in the peer's settings, or with `netbird up --block-lan-access`) to block forwarded traffic to its local networks. It breaks site-to-site or LAN routes served by the same peer, so enable it only on a dedicated exit node. It does not restrict remote networks reachable through the exit node's upstream gateway.
+- Place the exit node on an isolated network segment (a DMZ or dedicated VLAN) that can only reach the internet. This enforces the restriction outside the peer and also covers upstream networks.
+
+Both options assume the exit node does nothing else. If peers also need to reach resources on that site's LAN, serve those through a separate routing peer using a [Network](/manage/networks) with scoped access policies instead of the exit node's broad route.
+
 <Note>
 For the mental model — see [How Routing Peers Work — Exit node mode](/manage/networks/how-routing-peers-work#exit-node-mode).
 </Note>


### PR DESCRIPTION
## Summary

Exit nodes previously lived only under **Use Cases → Remote Access**, even though they are the one remaining use case for (legacy) Routes. This PR surfaces them from the Routes section and documents the broad-access risk of a default route.

- **Sidebar**: add an Exit Nodes entry to the Routes group (page stays at `/use-cases/remote-access/exit-nodes`; the nav already has precedent for the same href in two groups).
- **Routes overview** (`/manage/network-routes`): mention in the intro that Routes power exit nodes, that a default route grants access to any network the routing peer can reach, and link to the mitigation guidance.
- **Exit nodes guide**: new warning under the Routing Peer concept — a `0.0.0.0/0` route matches all traffic, so peers can reach anything the routing peer can reach, including its local LAN — plus two mitigations (**Block LAN access** on the routing peer, or placing the exit node on an isolated internet-only segment) and the best practice of keeping the exit node dedicated, serving LAN resources through a separate routing peer with a Network and scoped policies.
- **How Routing Peers Work**: exit node mode now notes the broad-access behavior and links back to the exit nodes guide for setup and mitigations (the reference was previously one-way).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Exit Nodes link under the Routes navigation section.
  - Documented how to configure default routes to forward internet traffic through an exit node.

- **Documentation**
  - Clarified that exit-node routes may expose networks reachable by the routing peer, including local LANs.
  - Added guidance on restricting LAN access and isolating exit nodes.
  - Documented limitations and recommended separation of exit-node and site-resource routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->