### PR TITLE
[agent-network] Document loading a provider's models from the vendor

### DIFF
--- a/src/pages/agent-network/providers.mdx
+++ b/src/pages/agent-network/providers.mdx
@@ -55,7 +55,8 @@ and budgets (see [How It Works](/agent-network/how-it-works#llm-apis-and-ai-gate
 3. Paste the provider's **API key**. It is stored encrypted server-side and never sent to
    callers.
 4. _(Optional)_ Restrict the **allowed models** and set **per-model pricing** used for cost
-   estimates in usage and logs.
+   estimates in usage and logs. On supported providers, **Load models from provider** fills
+   this in from the vendor — see [Load Models from the Provider](#load-models-from-the-provider).
 5. _(Optional, gateways)_ Fill any gateway-specific fields (for example a Portkey config
    ID) and the identity headers used for attribution.
 6. Save the provider.
@@ -135,6 +136,47 @@ for how these buckets appear in the cost breakdown.
 Self-hosters can seed the catalog defaults these fields prefill from with a
 pricing file. See
 [`server.agentNetwork.pricingDefaultsFile`](/selfhosted/maintenance/configuration-files#agent-network-settings).
+
+### Load Models from the Provider
+
+NetBird ships a catalog of known models, but it can't see your account: which OpenAI models
+your organization is entitled to, which Bedrock inference profiles exist in your account and
+region, or which Vertex AI models your project has enabled. The catalog also drifts as
+vendors retire models.
+
+On the **Models** tab, **Load models from provider** asks the vendor which models your own
+credential can actually reach and turns the answer into editable rows, each pre-filled with
+the price NetBird would bill it at.
+
+Available for **OpenAI**, **Anthropic**, **Amazon Bedrock** and **Google Vertex AI**. AI
+gateways expose no comparable listing endpoint, so the button reports that and the catalog
+list is used instead.
+
+A few details worth knowing:
+
+- **Models already on the form are left alone.** A rate you set deliberately is not
+  overwritten by a reload.
+- **Models NetBird can't price arrive at $0** and are highlighted, rather than being hidden.
+  The vendor says your credential can reach them, so leaving them out would hide models you
+  really have. Saving with any of them prompts for confirmation — usage against a $0 model is
+  tracked at zero and doesn't count toward [budget limits](/agent-network/policies/limits).
+- **Editing a saved provider reuses the stored key.** The API key never returns to your
+  browser, so the refresh runs against the credential already on the record. Change the
+  provider, or type a replacement key over the masked one, and the values on screen are used
+  instead.
+- **Bedrock ids are registered exactly as AWS issues them**, region prefix included
+  (`eu.anthropic.claude-sonnet-5-20260514-v1:0`), because that is the only form that works at
+  invoke time. Only `ACTIVE` inference profiles are offered. The listing comes from the
+  Bedrock control plane, which is a different host from the runtime endpoint you configured —
+  NetBird derives it from your upstream URL.
+- **Vertex AI lists what the publisher offers**, not what your project has enabled, so treat
+  it as a suggestion alongside the catalog rather than a definitive list.
+
+<Note>
+The vendor call is made by NetBird's management service using the provider's credential, not
+from your browser and not over your agents' tunnels. It only ever dials public vendor
+endpoints and does not follow redirects.
+</Note>
 
 ### Adding a Model Not in the Catalog
 

--- a/src/pages/agent-network/providers.mdx
+++ b/src/pages/agent-network/providers.mdx
@@ -55,8 +55,8 @@ and budgets (see [How It Works](/agent-network/how-it-works#llm-apis-and-ai-gate
 3. Paste the provider's **API key**. It is stored encrypted server-side and never sent to
    callers.
 4. _(Optional)_ Restrict the **allowed models** and set **per-model pricing** used for cost
-   estimates in usage and logs. On supported providers, **Load models from provider** fills
-   this in from the vendor — see [Load Models from the Provider](#load-models-from-the-provider).
+   estimates in usage and logs. On supported providers, **Load models from provider** offers
+   the vendor's own list — see [Load Models from the Provider](#load-models-from-the-provider).
 5. _(Optional, gateways)_ Fill any gateway-specific fields (for example a Portkey config
    ID) and the identity headers used for attribution.
 6. Save the provider.
@@ -144,38 +144,50 @@ your organization is entitled to, which Bedrock inference profiles exist in your
 region, or which Vertex AI models your project has enabled. The catalog also drifts as
 vendors retire models.
 
-On the **Models** tab, **Load models from provider** asks the vendor which models your own
-credential can actually reach and turns the answer into editable rows, each pre-filled with
-the price NetBird would bill it at.
+On the **Models** tab, **Load models from provider** asks the vendor which models it offers
+this provider's credential, and adds the answer to the model picker. Nothing is written to
+the form on its own: the models already listed keep the rates you gave them, and you pick
+the ones you want from **Add More**.
 
-Available for **OpenAI**, **Anthropic**, **Amazon Bedrock** and **Google Vertex AI**. AI
-gateways expose no comparable listing endpoint, so the button reports that and the catalog
-list is used instead.
+Available for **OpenAI**, **Anthropic**, **Amazon Bedrock** and **Google Vertex AI**. Every
+other entry in the catalog — Azure OpenAI, Mistral, Kimi, the AI gateways and custom
+endpoints — publishes no listing NetBird can ask for, so the button reports that and the
+catalog list is used instead.
+
+For a provider you are still filling in, the button stays disabled until the **Upstream URL**
+and the credential are both filled in.
 
 A few details worth knowing:
 
-- **Models already on the form are left alone.** A rate you set deliberately is not
-  overwritten by a reload.
-- **Models NetBird can't price arrive at $0** and are highlighted, rather than being hidden.
-  The vendor says your credential can reach them, so leaving them out would hide models you
-  really have. Saving with any of them prompts for confirmation — usage against a $0 model is
-  tracked at zero and doesn't count toward [budget limits](/agent-network/policies/limits).
-- **Editing a saved provider reuses the stored key.** The API key never returns to your
-  browser, so the refresh runs against the credential already on the record. Change the
-  provider, or type a replacement key over the masked one, and the values on screen are used
-  instead.
-- **Bedrock ids are registered exactly as AWS issues them**, region prefix included
-  (`eu.anthropic.claude-sonnet-5-20260514-v1:0`), because that is the only form that works at
-  invoke time. Only `ACTIVE` inference profiles are offered. The listing comes from the
+- **A model the catalog already prices arrives priced.** Anything else arrives with no input
+  or output rate: NetBird outlines the row and asks you to confirm before saving it, rather
+  than hiding the model — the vendor listed it, so leaving it out would hide a model you
+  really have. Set the rates yourself, or usage against it is costed at $0 and adds nothing
+  to the spend side of [token & budget limits](/agent-network/policies/limits). Its tokens
+  still count toward the token caps.
+- **Editing a saved provider reuses the stored credential.** The API key (or, on Vertex AI,
+  the uploaded service account key) never returns to your browser, so the lookup runs against
+  the credential already on the record. Change the provider, the upstream URL, or the masked
+  credential and NetBird asks for a credential to use instead — the values on screen are
+  then used.
+- **Bedrock ids are registered exactly as AWS issues them**, prefix included
+  (`eu.anthropic.claude-sonnet-4-5-20250929-v1:0`), because that is the only form that works
+  at invoke time. The prefix is a cross-region geography (`us.`, `eu.`, `apac.`, `global.`,
+  and so on) rather than the region you configured, and AWS routinely offers the same model
+  under more than one — so expect both an `eu.anthropic.…` and a `global.anthropic.…` entry
+  for it. Both are genuine, and both cost the same, since pricing keys on the model and not
+  the geography. Only `ACTIVE` inference profiles are offered. The listing comes from the
   Bedrock control plane, which is a different host from the runtime endpoint you configured —
   NetBird derives it from your upstream URL.
-- **Vertex AI lists what the publisher offers**, not what your project has enabled, so treat
-  it as a suggestion alongside the catalog rather than a definitive list.
+- **Vertex AI lists the Anthropic publisher's catalog**, not what your project has enabled,
+  so treat it as a suggestion alongside NetBird's catalog rather than a definitive list. Ids
+  come back version-pinned, in the `claude-sonnet-4-5@20250929` form Vertex addresses them by.
 
 <Note>
 The vendor call is made by NetBird's management service using the provider's credential, not
 from your browser and not over your agents' tunnels. It only ever dials public vendor
-endpoints and does not follow redirects.
+endpoints and does not follow redirects. Loading the list spends that credential against the
+vendor, so it needs the same permission as creating a provider.
 </Note>
 
 ### Adding a Model Not in the Catalog
@@ -200,5 +212,4 @@ first provider and reachable only over the NetBird overlay.
 
 Agents send normal provider requests to the endpoint without an API key; which identities
 may reach which providers is governed by [Policies](/agent-network/policies).
-
 


### PR DESCRIPTION
Docs for netbirdio/netbird#7246 (backend) and netbirdio/dashboard#767 (UI), which add a **Load models from provider** button to the Models tab: it asks the vendor which models the stored credential can reach and offers them in the model picker.

## What changed

One new subsection, **Load Models from the Provider**, under *Models and Pricing* in `agent-network/providers.mdx`, plus a pointer to it from step 4 of *Connect a Provider*.

The section already there covers only the manual paths — pick from the catalog, or type an id NetBird doesn't know. Neither says where a live list would come from, and the parts that can catch an operator out aren't guessable from the UI:

- **Loading fills the picker, not the form.** Nothing is written to the tab on its own; the loaded ids show up under **Add More**, and rows already on the form keep the rates you gave them.
- **Only a model the catalog already prices arrives priced.** Anything else arrives with no rates, is outlined, and prompts for confirmation on save — usage against it is costed at $0, so it adds nothing to the spend cap, though its tokens still count toward the token cap. It's offered rather than hidden: the vendor listed it, so omitting it would hide a real model.
- **Not just gateways fall back to the catalog.** Only OpenAI, Anthropic, Bedrock and Vertex declare a listing endpoint, so Azure OpenAI, Mistral, Kimi and custom endpoints report the same "no listing" result.
- **Editing a saved provider reuses the stored credential**, because it never returns to the browser. Changing the vendor or the masked credential switches to what's on screen.
- **Bedrock ids keep their prefix** (`eu.anthropic.…`) since that's the only form AWS accepts at invoke time, and only `ACTIVE` inference profiles are offered. That prefix is a cross-region geography rather than the configured region, and AWS offers the same model under several — so one model shows up as both an `eu.` and a `global.` entry. Pricing keys on the geography-stripped id, so the duplicates cost the same. The listing comes from the control plane, a different host from the configured runtime endpoint.
- **Vertex AI lists the Anthropic publisher's catalog**, not what a project has enabled — a suggestion beside the catalog rather than a definitive list — and returns version-pinned ids.

There's also a note that the vendor call is made by the management service using the provider's credential, not from the browser and not over an agent's tunnel; that it dials only public endpoints and doesn't follow redirects; and that it's gated on the create-provider permission, since pressing the button spends the credential.

## Not included

The API reference for `POST /api/agent-network/catalog/providers/models` is **generated** from `openapi.yml` on `netbirdio/netbird@main` via `npm run gen`, so it lands automatically. Hand-writing it here would be overwritten on the next regeneration.

No screenshot yet — the existing subsections each have one, and this should get a matching shot of the Models tab after a load (the loaded-count line, an outlined unpriced row, the warning callout). Happy to add it if someone can grab it, or to merge as-is and follow up.

## Validation

- The first commit was checked with `npm run lint:mdx` (293 files, no heading hierarchy violations) and a full `npm run build`.
- The follow-up commit (`cd20cdd`), which corrects the prose against the merged backend and UI, has **not** been linted or built locally — it changes prose only, within the existing `###` heading and `<Note>` structure, and adds no new components or links beyond one already used on the page.
- Only `src/pages/agent-network/providers.mdx` is touched; no navigation change needed since this adds a section rather than a page.

## Related

- netbirdio/netbird#7246 — the endpoint and the pricing in its response
- netbirdio/netbird#7250 — Bedrock discovery served from the control plane
- netbirdio/dashboard#767 — the button, the picker merge and the warnings
