### PR TITLE
Forward UDP 443 for QUIC in external relay setup

### DIFF
--- a/src/pages/selfhosted/maintenance/scaling/set-up-external-relays.mdx
+++ b/src/pages/selfhosted/maintenance/scaling/set-up-external-relays.mdx
@@ -12,7 +12,7 @@ For each relay server you want to deploy:
 - Public IP address
 - A domain name pointing to the server (e.g., `relay-us.example.com`)
 - Docker installed
-- Firewall ports open: **80/tcp** (Let's Encrypt HTTP challenge), **443/tcp** (relay), and **3478/udp** (STUN). If you configure multiple STUN ports, open all of them
+- Firewall ports open: **80/tcp** (Let's Encrypt HTTP challenge), **443/tcp** and **443/udp** (relay: WebSocket and QUIC), and **3478/udp** (STUN). If you configure multiple STUN ports, open all of them
 
 ## Generate Authentication Secret
 
@@ -68,7 +68,10 @@ services:
     container_name: netbird-relay
     restart: unless-stopped
     ports:
+      # TCP for the WebSocket transport
       - '443:443'
+      # UDP for QUIC; without the /udp suffix Docker forwards TCP only
+      - '443:443/udp'
       # Expose all ports listed in NB_STUN_PORTS
       - '3478:3478/udp'
     env_file:


### PR DESCRIPTION
Fixes the issue reported in https://github.com/netbirdio/netbird/discussions/6235

The relay serves WebSocket and QUIC on the same port (default :443). The relay code in netbirdio/netbird starts both listeners on that address: a TCP listener for WebSocket and a QUIC listener over UDP (relay/server/server.go). Docker only forwards TCP unless a port mapping carries the /udp suffix, so the compose example on this page silently disabled QUIC for external relays.

Changes:
- Add '443:443/udp' to the docker-compose example
- List 443/udp alongside 443/tcp in the firewall requirements

Question while I was here: high-availability.mdx also publishes relay traffic as 443:443 behind a load balancer. If QUIC is wanted there too, that deployment needs UDP forwarding through the LB as well, so I left it out of this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the external relay setup guide to include UDP port 443 for QUIC.
  * Updated the Docker Compose example to expose port 443 for both TCP and UDP traffic.
  * Added explanations for WebSocket, QUIC, and Docker port forwarding requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->