### PR TITLE
[agent-network] Document the provider save-time check

### DIFF
--- a/src/pages/agent-network/providers.mdx
+++ b/src/pages/agent-network/providers.mdx
@@ -216,7 +216,8 @@ A few details worth knowing:
   still count toward the token caps.
 - **Editing a saved provider reuses the stored credential.** The API key (or, on Vertex AI,
   the uploaded service account key) never returns to your browser, so the lookup runs against
-  the credential already on the record. Change the provider, the upstream URL, or the masked
+  the credential already on the record. A retyped **Upstream URL** is sent with it, so a new
+  endpoint can be listed before it is saved. Change the provider or type over the masked
   credential and NetBird asks for a credential to use instead — the values on screen are
   then used.
 - **Bedrock ids are registered exactly as AWS issues them**, prefix included

--- a/src/pages/agent-network/providers.mdx
+++ b/src/pages/agent-network/providers.mdx
@@ -59,11 +59,55 @@ and budgets (see [How It Works](/agent-network/how-it-works#llm-apis-and-ai-gate
    the vendor's own list — see [Load Models from the Provider](#load-models-from-the-provider).
 5. _(Optional, gateways)_ Fill any gateway-specific fields (for example a Portkey config
    ID) and the identity headers used for attribution.
-6. Save the provider.
+6. Save the provider. NetBird checks the upstream URL and the credential against the
+   vendor before storing them — see [The Save-Time Check](#the-save-time-check).
 
 <p>
     <img src="/docs-static/img/agent-network/providers/agent-network-create-provider.png" alt="agent network connect provider modal" className="imagewrapper" />
 </p>
+
+### The Save-Time Check
+
+Before storing a provider, NetBird asks the vendor whether the upstream URL and the
+credential work, using the same model listing that
+[Load models from provider](#load-models-from-the-provider) uses. A record that cannot reach
+its vendor is refused at the form, rather than saving cleanly and surfacing later as a
+refused request or an empty model list with nothing tying it back to the record.
+
+If the vendor refuses, the provider is not saved. The form stays open with what you typed
+still in it, and the message names which of the two is at fault: the credential was
+rejected, or the upstream URL could not be reached or does not answer a model listing. Fix
+the field it names and save again.
+
+On an existing provider, the check runs only when you change the **Upstream URL** or the
+**API key** — renaming a provider, editing model rows or changing prices saves without
+asking the vendor anything. Two consequences worth knowing:
+
+- **Changing only the URL tests it against the stored credential.** The key never returns to
+  your browser, so there is nothing else it could be tested with.
+- **A rejected key never replaces a working one.** If you paste a new key and the vendor
+  refuses it, the provider keeps running on the old one.
+
+**Which providers are checked.** The same four that can list their models: **OpenAI**,
+**Anthropic**, **Amazon Bedrock** and **Google Vertex AI**. Everything else saves without a
+check, because there is no listing to ask for or no way to reach it:
+
+- Azure OpenAI, Mistral, Kimi, the AI gateways and custom endpoints, which publish no
+  listing NetBird can ask for.
+- A Bedrock provider pointed at a proxy or a self-hosted endpoint rather than an AWS runtime
+  host, because the control plane that serves the listing is derived from that URL and
+  cannot be worked out from an address AWS does not own.
+- Any upstream on a private address. Your agents reach it through the tunnel, but NetBird's
+  management service has no route to it, so there is nothing it can ask.
+
+An unchecked provider is not a lesser one; NetBird simply has no way to verify it up front,
+so it saves what you entered.
+
+<Note>
+A vendor outage also fails the save — the check cannot confirm the provider either way, and
+saving something unverified is what it exists to prevent. If the message says the provider
+returned an error rather than naming your URL or credential, wait and save again.
+</Note>
 
 ## Custom & Self-hosted Providers
 

--- a/src/pages/agent-network/providers.mdx
+++ b/src/pages/agent-network/providers.mdx
@@ -79,14 +79,17 @@ still in it, and the message names which of the two is at fault: the credential 
 rejected, or the upstream URL could not be reached or does not answer a model listing. Fix
 the field it names and save again.
 
-On an existing provider, the check runs only when you change the **Upstream URL** or the
-**API key** — renaming a provider, editing model rows or changing prices saves without
-asking the vendor anything. Two consequences worth knowing:
+On an existing provider, the check runs only when you change the **Upstream URL**, the
+**API key**, or the **Provider** the record is connected to — renaming a provider, editing
+model rows or changing prices saves without asking the vendor anything. Three consequences
+worth knowing:
 
 - **Changing only the URL tests it against the stored credential.** The key never returns to
   your browser, so there is nothing else it could be tested with.
 - **A rejected key never replaces a working one.** If you paste a new key and the vendor
   refuses it, the provider keeps running on the old one.
+- **Switching the provider re-checks the credential you already stored.** It was accepted by
+  one vendor; the record now points at another, which has never seen it.
 
 **Which providers are checked.** The same four that can list their models: **OpenAI**,
 **Anthropic**, **Amazon Bedrock** and **Google Vertex AI**. Everything else saves without a
@@ -96,7 +99,9 @@ check, because there is no listing to ask for or no way to reach it:
   listing NetBird can ask for.
 - A Bedrock provider pointed at a proxy or a self-hosted endpoint rather than an AWS runtime
   host, because the control plane that serves the listing is derived from that URL and
-  cannot be worked out from an address AWS does not own.
+  cannot be worked out from an address AWS does not own. The credential goes unverified, but
+  the URL does not: Bedrock lists from a different host than it serves requests on, so the
+  one you entered is resolved on its own, and one that does not exist is refused.
 - Any upstream on a private address. Your agents reach it through the tunnel, but NetBird's
   management service has no route to it, so there is nothing it can ask.
 


### PR DESCRIPTION
Docs for netbirdio/netbird#7301 (backend) and netbirdio/dashboard#772 (UI), which check a provider's upstream URL and credential against the vendor before storing them.

**Stacked on #945** — it adds the *Load Models from the Provider* section this one refers to, and both edit `providers.mdx`. Retarget to `main` once #945 merges.

## What changed

Step 6 of *Connect a Provider* now says saving is checked, and a new **The Save-Time Check** subsection sits under it covering what the steps cannot say in one line:

- Which of the two fields a refusal names, and that the form keeps what you typed.
- That an edit is only re-checked when the **Upstream URL**, the **API key** or the **Provider** the record points at moves — renames, model rows and price edits save without asking the vendor anything.
- That a URL-only change is tested against the stored credential, since the key never returns to the browser.
- That a rejected key never replaces a working one.
- That switching the provider re-checks a credential one vendor accepted against another that has never seen it.

The list of what *isn't* checked is the part worth getting right: an operator whose provider saved without a word should be able to see why it was exempt rather than assume the check silently passed. Three cases — providers that publish no listing NetBird can ask for, a Bedrock record pointed at a proxy or self-hosted endpoint rather than an AWS runtime host, and any upstream on a private address that the agents reach through the tunnel but the management service cannot reach at all.

The Bedrock case is a partial exemption rather than a whole one, and the text says so: its listing comes from the control plane, which cannot vouch for the runtime host, so the credential goes unverified while the URL itself is still resolved.

A `<Note>` covers the vendor-outage case, since "the provider returned an error" is the one message that names neither of the operator's own fields and the right response is to wait rather than to edit anything.

## Not included

No screenshot. The refusal state is worth one eventually — the modal staying open with the message against the form — but I can't produce it. Happy to merge as-is and follow up.

## Validation

`npm run lint:mdx` — 293 files, no heading hierarchy violations.

I did **not** run `npm run build`; flagging that rather than implying otherwise. One anchor was removed rather than guessed at: linking to *Custom &amp; Self-hosted Providers* needs a slug for a heading containing `&amp;`, and nothing else in the repo links to such a heading, so there was no precedent to copy. The bullet reads fine without it.
