### PR TITLE
Event streaming is also available in self-hosted with an enterprise license

### DIFF
--- a/src/pages/about-netbird/self-hosted-vs-cloud.mdx
+++ b/src/pages/about-netbird/self-hosted-vs-cloud.mdx
@@ -50,7 +50,7 @@ some additional features that are targeted at business customers and help with n
 
 - **[Users and groups provisioning](/manage/team/idp-sync)** from your identity provider (IdP).
 - **[Traffic events logging](/manage/activity/traffic-events-logging)** of connections to internal resources for audit and analysis.
-- **[Event streaming](/manage/activity/event-streaming)** to 3rd party platforms and SIEM systems.
+- **[Event streaming](/manage/activity/event-streaming)** to 3rd party platforms and SIEM systems (also available in self-hosted deployments with an [enterprise license](/selfhosted/enterprise)).
 - **[Integrations with EDR](/manage/access-control/endpoint-detection-and-response)** like CrowdStrike and others.
 - **[Peer approval](/manage/peers/approve-peers)** to join the network.
 - **[User invites](/manage/team/add-users-to-your-network#direct-user-invites)**.

--- a/src/pages/manage/activity/event-streaming/amazon-firehose.mdx
+++ b/src/pages/manage/activity/event-streaming/amazon-firehose.mdx
@@ -5,7 +5,7 @@ an other AWS services. You can use Amazon Data Firehose as a bridge between NetB
 to ingest, transform and analyze your network activity events.
 
 <Note>
-    This feature is only available in the cloud version of NetBird.
+    This feature is available in the cloud version of NetBird and in self-hosted deployments with an [enterprise license](/selfhosted/enterprise).
 </Note>
 
 ## Prerequisites

--- a/src/pages/manage/activity/event-streaming/amazon-s3.mdx
+++ b/src/pages/manage/activity/event-streaming/amazon-s3.mdx
@@ -11,7 +11,7 @@ Storing one event per object is not the most efficient way to save data in S3, t
 data ingestion.
 
 <Note>
-    This feature is only available in the cloud version of NetBird.
+    This feature is available in the cloud version of NetBird and in self-hosted deployments with an [enterprise license](/selfhosted/enterprise).
 </Note>
 
 ## Prerequisites

--- a/src/pages/manage/activity/event-streaming/datadog.mdx
+++ b/src/pages/manage/activity/event-streaming/datadog.mdx
@@ -9,7 +9,7 @@ and sends activity events to Datadog in real-time once they occur. The events ap
 search, filter, and analyze them right away.
 
 <Note>
-    This feature is only available in the cloud version of NetBird.
+    This feature is available in the cloud version of NetBird and in self-hosted deployments with an [enterprise license](/selfhosted/enterprise).
 </Note>
 
 ## Prerequisites

--- a/src/pages/manage/activity/event-streaming/generic-http.mdx
+++ b/src/pages/manage/activity/event-streaming/generic-http.mdx
@@ -5,7 +5,7 @@ The Generic HTTP integration allows you to stream your NetBird network activity 
 For every event, NetBird will send a POST request to your configured endpoint. You have full control over the request's body format and headers, allowing for seamless integration with various APIs.
 
 <Note>
-    This feature is only available in the cloud version of NetBird.
+    This feature is available in the cloud version of NetBird and in self-hosted deployments with an [enterprise license](/selfhosted/enterprise).
 </Note>
 
 ## Prerequisites

--- a/src/pages/manage/activity/event-streaming/index.mdx
+++ b/src/pages/manage/activity/event-streaming/index.mdx
@@ -12,7 +12,7 @@ NetBird provides an event streaming feature that allows you to stream network [a
 to third-party SIEM systems, such as [Datadog](https://www.datadoghq.com/dg/security/siem-solution/), [Amazon S3](https://aws.amazon.com/s3/), [Amazon Data Firehose](https://aws.amazon.com/firehose/), and others through a generic HTTP integration.
 
 <Note>
-    This feature is only available in the cloud version of NetBird.
+    This feature is available in the cloud version of NetBird and in self-hosted deployments with an [enterprise license](/selfhosted/enterprise). The open-source self-hosted version does not include event streaming.
 </Note>
 
 This documentation provides step-by-step guides and best practices for integrating NetBird activity event streaming with

--- a/src/pages/manage/activity/event-streaming/sentinelone-data-lake.mdx
+++ b/src/pages/manage/activity/event-streaming/sentinelone-data-lake.mdx
@@ -5,7 +5,7 @@
 This integration leverages NetBird's Generic HTTP streaming capability with SentinelOne Singularity Data Lake-specific configurations to ensure seamless data ingestion into your Data Lake environment.
 
 <Note>
-    This feature is only available in the cloud version of NetBird.
+    This feature is available in the cloud version of NetBird and in self-hosted deployments with an [enterprise license](/selfhosted/enterprise).
 </Note>
 
 ## Prerequisites


### PR DESCRIPTION
## Description

The event streaming docs stated the feature is "only available in the cloud version of NetBird", but it is also available in self-hosted deployments with an enterprise license (Self-Hosted Enterprise Custom plan).

This PR updates the availability note on the event streaming overview page and all integration guides (Datadog, Amazon S3, Amazon Data Firehose, SentinelOne Data Lake, Generic HTTP), reusing the phrasing already established on the notifications page. It also updates the self-hosted vs. cloud comparison, which listed event streaming as a cloud-only feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that event streaming is available in the cloud version and in self-hosted deployments with an enterprise license.
  - Noted that event streaming is not included in the open-source self-hosted version.
  - Updated availability details across all supported integrations, including Amazon Firehose, Amazon S3, Datadog, Generic HTTP, and SentinelOne Data Lake.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->