### PR TITLE
docs: point the domain-classification note to NetBird Support

### DIFF
--- a/src/pages/manage/team/add-users-to-your-network.mdx
+++ b/src/pages/manage/team/add-users-to-your-network.mdx
@@ -27,7 +27,7 @@ Public domains are the ones of the public email providers like Gmail.
 <Note>
     It might happen (unlikely) that the domain classification system didn't classify your company's domain as private.
     Our system was unsure about your domain and assigned an unclassified or public category to be on the safe side.
-    Just email us at [hello@netbird.io](mailto:hello@netbird.io) or ping us on [Slack](/slack-url) to fix this.
+    Just [contact NetBird Support](/help/netbird-support) to fix this.
 </Note>
 
 ## Direct user invites


### PR DESCRIPTION
On the Add Users page, the "Indirect user invites" note asked users to email hello@netbird.io or ping Slack to fix a company domain that was not classified as private. This points that note to the [NetBird Support](/help/netbird-support) page instead, so these requests go through the same support channel as the rest of the docs.

One-line change, no new links or assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated support instructions to direct users to NetBird Support via a link.
  * Removed references to emailing support or contacting the team on Slack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->