### PR TITLE
Fix update instructions for Synology NAS

### DIFF
--- a/src/pages/get-started/install/synology.mdx
+++ b/src/pages/get-started/install/synology.mdx
@@ -83,8 +83,14 @@ Alternatively, if you are hosting your own Management Service provide `--managem
 
 If you used the one-command script to install, you can follow this to update:
 
+1. SSH into your Synology NAS: If you haven't already, enable SSH in your Synology's Control Panel under Terminal & SNMP. Then, use an SSH client to connect to your NAS. Switch to the root user:
+```bash
+sudo -i
+```
+2. Download and run the upgrade script: Once connected, execute the following command:
 ```bash
 netbird down
+cd /tmp
 curl -fsSLO https://pkgs.netbird.io/install.sh
 chmod +x install.sh
 ./install.sh --update


### PR DESCRIPTION
Updated instructions for updating Netbird on Synology NAS. Existing instructions executed as-is assume the user is root (with permission to chmod). 

- Aligned with the uninstall instructions by first stepping the user into a root shell. 
- `cd` the tmp folder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Synology upgrade instructions with explicit steps for connecting via SSH, switching to root access, stopping NetBird, and running the upgrade from `/tmp`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->