### PR TITLE
docs: add NetBird client compatibility to the operator support matrix

### DIFF
--- a/src/pages/help/support-matrix/kubernetes-operator.mdx
+++ b/src/pages/help/support-matrix/kubernetes-operator.mdx
@@ -5,13 +5,27 @@ export const description =
 
 ## Kubernetes compatibility
 
-The NetBird Kubernetes operator targets the Kubernetes minor versions that are currently receiving patch releases from upstream. The [Kubernetes release policy](https://kubernetes.io/releases/) keeps release branches active for the three most recent minor versions, with roughly one year of patch support each — the operator tracks that same window.
+The NetBird Kubernetes operator targets the Kubernetes minor versions that are currently receiving patch releases from upstream. The [Kubernetes release policy](https://kubernetes.io/releases/) keeps release branches active for the three most recent minor versions, with roughly one year of patch support each. The operator tracks that same window.
 
 In practice this means the operator avoids depending on Kubernetes APIs or features that are not yet available across every supported minor version. When upstream drops a minor version from patch support, the operator may begin adopting capabilities that became generally available during that version's lifetime.
 
 ## NetBird control-plane compatibility
 
 The operator is developed against the latest NetBird control-plane release. Older control-plane versions may continue to work, but compatibility is not actively verified outside the current release.
+
+## NetBird client compatibility
+
+Each operator release is built and tested against a specific NetBird release, and it deploys that exact NetBird client by default. The current operator release, `v0.8.0`, is tested and supported with NetBird `v0.72.4`. Newer NetBird client releases may work, but they are not tested against the operator and are not officially supported.
+
+| NetBird Kubernetes operator | Tested NetBird client |
+|---|---|
+| `v0.8.0` | `v0.72.4` |
+| `v0.7.0` | `v0.72.4` |
+| `v0.6.0` | `v0.71.4` |
+| `v0.5.0` | `v0.71.2` |
+| `v0.4.0`, `v0.4.1` | `v0.70.4` |
+
+Each release pins the client image to its tested version by digest, so a default install already runs the supported combination. Operator `v0.8.0` deploys `ghcr.io/netbirdio/netbird:0.72.4`. Overriding the image with `routingClientImage` in the Helm chart values can be done, but is neither supported nor tested.
 
 ## Reporting compatibility issues
 

--- a/src/pages/help/support-matrix/kubernetes-operator.mdx
+++ b/src/pages/help/support-matrix/kubernetes-operator.mdx
@@ -29,4 +29,4 @@ Each release pins the client image to its tested version by digest, so a default
 
 ## Reporting compatibility issues
 
-If you hit a problem on a supported combination, see [Report bugs and issues](/help/report-bug-issues). Include your operator version, Kubernetes version (`kubectl version`), and NetBird control-plane version.
+If you hit a problem on a supported combination, see [Report bugs and issues](/help/report-bug-issues). Include your operator version, Kubernetes version (`kubectl version`), NetBird control-plane version, and the NetBird client version, along with any `routingClientImage` override you have set.


### PR DESCRIPTION
## What

Adds a **NetBird client compatibility** section to the [Kubernetes Operator Support Matrix](https://docs.netbird.io/help/support-matrix/kubernetes-operator), making explicit which NetBird client each operator release is tested and supported with.

## Why

The page covered Kubernetes and control-plane compatibility, but not the NetBird client. Each operator release is built and tested against a specific NetBird release and ships that exact client, so users had no documented way to know which pairing is supported.

## Details

- States the current supported pairing: operator `v0.8.0` with NetBird `v0.72.4`.
- Adds a table of the tested client per recent operator release (`v0.4.0` through `v0.8.0`).
- Notes that each release pins the client image by digest, so a default install already runs the supported combination, and that overriding `routingClientImage` is neither supported nor tested.
- Versions were taken from each release's pinned client image (and cross-checked against `go.mod`) in the operator repo.

Also replaces an em dash in the Kubernetes compatibility section with two plain sentences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a NetBird client compatibility section to the Kubernetes operator support matrix.
  * Documented tested client versions and the default client deployed for each supported operator release.
  * Clarified that custom client image overrides are unsupported and untested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->