### PR TITLE
docs: document the fallback when the client cannot manage firewall rules

### DIFF
--- a/src/pages/get-started/install/synology.mdx
+++ b/src/pages/get-started/install/synology.mdx
@@ -51,6 +51,13 @@ fi
 ```
 4. If you’d like to see the logs for this task, select the task you create and click on Settings. Check the box that says Save output results, select a save location, and click OK. Now, if you select the task and **Action > View Result**, you’ll see any error logs and status.
 
+<Note>
+    Synology devices do not always expose every kernel module NetBird uses. Alongside the `tun` module above, the
+    netfilter match modules behind the client's firewall rules can be missing, `mark` and `ipset` in particular. The
+    client then logs a `failed to create native firewall` warning and falls back to userspace filtering. See
+    [When the client cannot manage firewall rules](/help/troubleshooting-client#when-the-client-cannot-manage-firewall-rules).
+</Note>
+
 ## Running with a Setup Key
 In case you are activating a server peer, you can use a [setup key](/manage/peers/register-machines-using-setup-keys) as described in the steps below.
 > This is especially helpful when you are running multiple server instances with infrastructure-as-code tools like ansible and terraform.

--- a/src/pages/help/troubleshooting-client.mdx
+++ b/src/pages/help/troubleshooting-client.mdx
@@ -483,6 +483,67 @@ sudo netbird service stop
 sudo bash -c 'NB_WG_KERNEL_DISABLED=true netbird up -F'  > /tmp/netbird.log
 ```
 
+## When the client cannot manage firewall rules
+
+On Linux the client installs its own `nftables` or `iptables` rules to filter traffic and, on a routing peer, to forward
+routed traffic. Some hosts are missing the netfilter modules those rules depend on, such as the `mark` match used for
+policy routing or `ipset` used to match sets of addresses. The client reports this and carries on without the native
+firewall:
+
+```
+WARN client/firewall/create_linux.go:55: failed to create native firewall:
+init firewall: router init: create containers: add static nat rules:
+add outbound masquerade rule: running [/sbin/iptables -t nat
+-A NETBIRD-RT-NAT -m mark --mark 0x1bd21 ! -o lo -j MASQUERADE --wait]:
+exit status 2: iptables v1.8.3 (legacy):
+Couldn't load match `mark':No such file or directory
+. Proceeding with userspace
+```
+
+NetBird keeps working after this. Filtering moves to the userspace packet filter, and on a routing peer the forwarding
+path moves to userspace as well, which is slower than letting the kernel forward. Appliance and NAS firmware is where
+this usually shows up.
+
+To get the kernel path back, start with the narrower options, because they keep NetBird in charge of filtering:
+
+- Load the missing module on the host if the firmware ships it, for example `xt_mark` for the `mark` match above.
+- `NB_SKIP_NFTABLES_CHECK` sends the client straight to the iptables backend, which helps when nftables is present but
+non-functional.
+- `NB_USE_LEGACY_ROUTING` avoids the `fwmark` and ip-rule based routing and falls back to the simpler method.
+
+Both variables are described in [Client Environment Variables](/client/environment-variables).
+
+If the host cannot support the client's rules and you would rather use the firewall tooling it does have, stop the
+client from managing rules at all:
+
+```shell
+netbird up --disable-firewall
+```
+
+<Warning>
+This flag is not the same as the automatic fallback above. With `--disable-firewall` the client does not manage host
+firewall rules and the userspace packet filter does not take over, so NetBird enforces no access control on this peer.
+The policies you configure in NetBird are not applied here, and any peer that can reach this one over the tunnel is
+unfiltered until you recreate those restrictions with the host's own firewall. Only use it where you will do that.
+</Warning>
+
+You then cover the two jobs the client was doing.
+
+1. Turn on forwarding, if this peer routes traffic for others:
+
+```shell
+sudo sysctl -w net.ipv4.ip_forward=1
+sudo sysctl -w net.ipv6.conf.all.forwarding=1
+```
+
+2. Replace the access control NetBird was enforcing with your own filtering rules for the NetBird interface (`wt0`),
+using whatever the host does provide, such as iptables, nftables, or the appliance's own firewall interface. Mirror the
+access you intended in your NetBird policies, and default to denying anything you have not explicitly allowed.
+
+To confirm the result, check forwarding with `sysctl net.ipv4.ip_forward`, then test the traffic you actually care about
+from another peer. A tunnel can come up and report healthy in `netbird status -d` while filtering or forwarding is still
+missing.
+
 ## Debugging GRPC
 
 The NetBird client communicates with the Management and Signal servers using the GRPC framework. With these parameters,

--- a/src/pages/help/troubleshooting-client.mdx
+++ b/src/pages/help/troubleshooting-client.mdx
@@ -509,7 +509,7 @@ To get the kernel path back, start with the narrower options, because they keep 
 - Load the missing module on the host if the firmware ships it, for example `xt_mark` for the `mark` match above.
 - `NB_SKIP_NFTABLES_CHECK` sends the client straight to the iptables backend, which helps when nftables is present but
 non-functional.
-- `NB_USE_LEGACY_ROUTING` avoids the `fwmark` and ip-rule based routing and falls back to the simpler method.
+- `NB_USE_LEGACY_ROUTING` falls back to the simpler routing method, which does not rely on `fwmark` or `ip rule`.
 
 Both variables are described in [Client Environment Variables](/client/environment-variables).
 


### PR DESCRIPTION
## What

Adds a **When the client cannot manage firewall rules** section to [Troubleshooting Client Issues](https://docs.netbird.io/help/troubleshooting-client), and references it from the [Synology install page](https://docs.netbird.io/get-started/install/synology).

## Why

On hosts that are missing the netfilter modules the client's firewall rules depend on, the client cannot create its native `nftables` or `iptables` firewall. Appliance and NAS firmware is the usual place this happens. None of this was documented. `--disable-firewall` existed only as a single line in the CLI flag list, with nothing about when to reach for it or what you take over when you do.

## Details

- Includes the client log excerpt so the error is findable by search. Timestamps, hostname and peer identifiers were removed, and the lines are wrapped so the key strings stay visible and contiguous rather than scrolling out of the code block.
- Documents the real behaviour: the client logs the failure and **proceeds with the userspace packet filter**, so NetBird keeps working and keeps enforcing policy, with the forwarding path moving to userspace on a routing peer.
- Orders the remedies from narrowest to broadest, so the options that keep NetBird in charge of filtering come first: load the missing module (for example `xt_mark`), then `NB_SKIP_NFTABLES_CHECK`, then `NB_USE_LEGACY_ROUTING`, and only then `--disable-firewall`.
- Warns that `--disable-firewall` is **not** equivalent to that automatic fallback. The userspace filter does not take over, so NetBird enforces no access control on that peer and the operator has to recreate the restrictions with the host's own firewall. The manual steps cover forwarding and that replacement filtering.
- Synology gets a short note next to the existing `tun` module guidance, since the same class of missing modules applies there.

Validated with `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Synology installation guidance covering missing kernel modules, firewall warnings, and userspace filtering.
  * Added troubleshooting guidance for clients unable to install native `nftables` or `iptables` rules.
  * Documented recovery options, including loading missing modules and relevant configuration settings.
  * Clarified the effects of disabling firewall management, including the need to configure IP forwarding and firewall rules manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Screenshots

**New section on Troubleshooting Client Issues** ([`/help/troubleshooting-client#when-the-client-cannot-manage-firewall-rules`](https://docs.netbird.io/help/troubleshooting-client))

![When the client cannot manage firewall rules](https://raw.githubusercontent.com/emrcbrn/docs/pr-assets-disable-firewall/pr-assets/disable-firewall-section-dark.png)

**Note added to the Synology install page** ([`/get-started/install/synology`](https://docs.netbird.io/get-started/install/synology))

![Synology netfilter module note](https://raw.githubusercontent.com/emrcbrn/docs/pr-assets-disable-firewall/pr-assets/synology-note-dark.png)
