### PR TITLE
[doc] Document Relay metrics and healthcheck loopback binding

### DIFF
--- a/src/pages/selfhosted/observability/relay.mdx
+++ b/src/pages/selfhosted/observability/relay.mdx
@@ -17,6 +17,27 @@ The Relay service forwards encrypted WireGuard traffic between peers that cannot
 netbird-relay --metrics-port 9090
 ```
 
+For the standalone Relay service, `--metrics-port` accepts either a port or a
+`host:port` address. A bare port such as `9090`, or `:9090`, listens on all
+interfaces. To bind both metrics and healthcheck to IPv4 loopback, add these
+flags to your Relay command:
+
+```bash
+--metrics-port 127.0.0.1:9090 --health-listen-address 127.0.0.1:9000
+```
+
+The equivalent environment variables are:
+
+```bash
+NB_METRICS_PORT=127.0.0.1:9090
+NB_HEALTH_LISTEN_ADDRESS=127.0.0.1:9000
+```
+
+Use `[::1]:9090` and `[::1]:9000` for IPv6 loopback. Metrics remain at
+`/metrics` and healthcheck at `/health`. Existing numeric metrics settings and
+the defaults (`:9090` and `:9000`) are unchanged. Port `0` selects a random
+port; it does not disable the listener.
+
 In the combined container, the metrics port is set with `server.metricsPort` in `config.yaml` and is shared with Management and Signal. See [Combined](/selfhosted/observability/combined).
 
 <Note>


### PR DESCRIPTION
Operators running Relay on bare metal need to bind metrics and healthcheck to loopback. Document the standalone Relay host:port metrics syntax, existing healthcheck address flag, and their environment variables, including unchanged defaults and IPv6 examples.

Related to https://github.com/netbirdio/netbird/issues/2836. Companion implementation: https://github.com/netbirdio/netbird/pull/7468. Keep this draft until that implementation lands.

Validation: `npm run build` and `npm run lint:mdx` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented standalone Relay metrics and health check listener binding.
  - Clarified that `--metrics-port` supports both port-only and `host:port` values.
  - Added IPv4 and IPv6 loopback configuration examples, including equivalent environment variables.
  - Clarified metrics and health check paths, default behavior, and port `0` handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->