### PR TITLE
[doc] Explain custom domain verification expiry

### DIFF
--- a/src/pages/manage/reverse-proxy/custom-domains.mdx
+++ b/src/pages/manage/reverse-proxy/custom-domains.mdx
@@ -108,6 +108,16 @@ NetBird performs a CNAME lookup on `*.<your-domain>` and verifies that it resolv
     DNS changes can take time to propagate. If NetBird does not find the record immediately, please wait up to 24 hours and try again.
 </Note>
 
+### Verification deadline
+
+Complete verification within 48 hours of adding a custom domain. Retrying verification does not extend this deadline. Once a domain becomes **Active**, it is exempt from this expiry.
+
+NetBird removes expired, unverified registrations at management server startup and every 60 minutes. With management running normally, removal happens between 48 and 49 hours after registration. The account's activity log records **Unvalidated domain registration expired**. After removal, you can add the domain again and complete verification within a new 48-hour window.
+
+<Note>
+    When upgrading a self-hosted management server, existing unverified registrations receive a 48-hour verification window. Legacy registrations that still have services using their domain are retained for administrator review.
+</Note>
+
 ## Managing custom domains
 
 The **Custom Domains** page lists all domains associated with your account, including both built-in and custom domains.

--- a/src/pages/manage/reverse-proxy/custom-domains.mdx
+++ b/src/pages/manage/reverse-proxy/custom-domains.mdx
@@ -57,6 +57,8 @@ Follow these steps to add a custom domain to your account:
 4. Select the target **proxy cluster** that will handle traffic for this domain.
 5. Click **Save**.
 
+NetBird stores new domain names in lowercase and converts internationalized names to ASCII (punycode). A trailing dot is removed. Equivalent spellings, such as `App.Example.com.` and `app.example.com`, refer to the same registration. Invalid names and wildcard registrations such as `*.example.com` are rejected; enter the domain without the wildcard prefix.
+
 <p>
     <img src="/docs-static/img/manage/reverse-proxy/custom-domains/custom-domains-add.png" alt="Add Domain modal showing domain name and proxy cluster fields" className="imagewrapper"/>
 </p>


### PR DESCRIPTION
Pending custom domains now have a 48-hour verification deadline. Explain when cleanup removes an expired registration, the activity log entry, and how to register the domain again, including the upgrade window and retained legacy registrations. Also describe normalization and syntax checks for new domain names.

Companion to https://github.com/netbirdio/netbird/pull/7497; publish with that change.

Validation: `npm run lint:mdx` passed for all 296 pages, and the updated page compiles with the repository's installed MDX compiler.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented custom domain name normalization during setup.
  * Added details about the 48-hour verification deadline, expiration, cleanup timing, activity-log entries, re-registration, and self-hosted upgrade handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->