### PR TITLE
Document where debug bundles are uploaded

### DIFF
--- a/src/pages/manage/peers/remote-jobs.mdx
+++ b/src/pages/manage/peers/remote-jobs.mdx
@@ -62,6 +62,10 @@ The Debug Bundle job remotely collects diagnostic information from a peer, inclu
 
 On success, the job returns an **upload key** that can be used to retrieve the debug bundle. Share this key with NetBird support via GitHub Issues, Slack, or your support channel.
 
+**Where the bundle goes:**
+
+The bundle is uploaded to the destination configured for your account under [Settings > Clients](/manage/settings/clients#debug-bundle-upload), or to the upload service NetBird runs when no destination is configured. Set that setting if the bundles must stay inside your own infrastructure.
+
 ## Using the Dashboard
 
 ### Creating a Remote Job

--- a/src/pages/manage/settings/clients.mdx
+++ b/src/pages/manage/settings/clients.mdx
@@ -1,5 +1,5 @@
 export const description =
-    'Configure account-wide client behavior: automatic updates, lazy connections, and exposing services from the CLI.'
+    'Configure account-wide client behavior: automatic updates, lazy connections, exposing services from the CLI, and where debug bundles are uploaded.'
 
 # Client Settings
 
@@ -22,6 +22,32 @@ The `Enable Peer Expose` toggle allows peers to expose local HTTP services throu
 When enabled, you must select at least one peer group under `Allowed peer groups`. Only peers in the selected groups can expose services.
 
 See [Expose Services from the CLI](/manage/reverse-proxy/expose-from-cli) for command usage and examples.
+
+## Debug Bundle Upload
+
+`Debug Bundle Upload` sets the upload service your peers send debug bundles to. A bundle carries the peer's logs, routes, DNS configuration and firewall state, so this setting decides whose infrastructure that data lands on. It applies to every path that uploads a bundle without someone typing a destination: [remote jobs](/manage/peers/remote-jobs), the mobile clients, the desktop client, and `netbird debug bundle -U`.
+
+Enter the upload service's URL, for example `https://upload.example.com/upload-url`. The URL must use `https`: the peer asks this endpoint for an upload URL and then uploads the bundle to whatever it returns, so a plaintext hop would expose both. Self-hosted deployments can run the [upload server](https://github.com/netbirdio/netbird/tree/main/upload-server) that ships with NetBird, or point this at any service exposing the same endpoint.
+
+Leaving it empty means the account publishes no destination, and peers upload to the service NetBird runs — on a self-hosted deployment as much as on NetBird Cloud. That keeps the everyday flow working: collect a bundle, get an upload key, share it with support. If the bundles must not leave your own infrastructure, set this to your own upload service; until you do, they go to NetBird.
+
+A self-hosted deployment can set the destination for every account at once with `DebugUpload.URL` in `management.json`:
+
+```json
+{
+  "DebugUpload": {
+    "URL": "https://upload.example.com/upload-url"
+  }
+}
+```
+
+The account setting overrides that value when set. An MDM-managed client overrides both, through the `debugBundleUploadURL` policy key — see [MDM integration](/client/mdm-integration). So the order is:
+
+```text
+MDM policy  >  --upload-bundle-url (or a remote job's Upload URL)  >  account setting  >  management.json  >  NetBird's service
+```
+
+`netbird debug bundle` without `-U` never uploads at all: it writes the bundle locally and prints the path.
 
 ## Lazy Connections
 

--- a/src/pages/manage/settings/clients.mdx
+++ b/src/pages/manage/settings/clients.mdx
@@ -41,11 +41,15 @@ A self-hosted deployment can set the destination for every account at once with 
 }
 ```
 
-The account setting overrides that value when set. An MDM-managed client overrides both, through the `debugBundleUploadURL` policy key — see [MDM integration](/client/mdm-integration). So the order is:
+Several places can name a destination. The client walks this list and uses **the first one that is set**, ignoring the rest:
 
-```text
-MDM policy  >  --upload-bundle-url (or a remote job's Upload URL)  >  account setting  >  management.json  >  NetBird's service
-```
+1. The `debugBundleUploadURL` MDM policy on the device — see [MDM integration](/client/mdm-integration).
+2. A destination named for this one bundle: `--upload-bundle-url` on the CLI, or the `Upload URL` field of a remote job.
+3. This account setting.
+4. `DebugUpload.URL` in the management server's `management.json`.
+5. The upload service NetBird runs.
+
+So the device's own policy beats everything, a destination typed for a single bundle beats the account's, and the account setting beats the deployment-wide default. Whoever is further down only gets a say when nobody above them said anything.
 
 `netbird debug bundle` without `-U` never uploads at all: it writes the bundle locally and prints the path.
 


### PR DESCRIPTION
Documents the account setting and the management-server knob that decide where peers send debug bundles, from netbirdio/netbird#7514.

- **Client Settings** (`manage/settings/clients`): new `Debug Bundle Upload` section — the setting, the `DebugUpload.URL` fallback in `management.json`, the https requirement, the full precedence order, and the fact that an unset destination means the upload service NetBird runs, self-hosted included.
- **Remote Jobs** (`manage/peers/remote-jobs`): note where a remotely collected bundle goes.

Touches `remote-jobs.mdx` away from the lines netbirdio/docs#914 edits, but that PR is still open — worth merging in order.

Pairs with netbirdio/netbird#7514 and netbirdio/dashboard#800; merge alongside them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified the precedence used to determine where debug bundles are uploaded, including peer policy, remote job settings, account settings, management server defaults, and NetBird’s upload service.
  - Documented how empty account-level settings affect destination selection and when the default upload service is used.
  - Updated the Clients settings description to mention debug bundle upload destinations and related client behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
