### PR TITLE
[doc] Explain custom domain deletion requirements

### DIFF
--- a/src/pages/manage/reverse-proxy/custom-domains.mdx
+++ b/src/pages/manage/reverse-proxy/custom-domains.mdx
@@ -134,11 +134,11 @@ If a custom domain returns to **Pending Verification** status - for example, aft
 
 ### Deleting a custom domain
 
-To remove a custom domain, click the delete action next to the domain in the list. Deleting a custom domain removes it from your account and makes it unavailable for any new services. Built-in domains (Free or Cluster) cannot be deleted.
+Before removing a custom domain, delete or move every service that uses the domain or any of its subdomains. Disabled services also count as dependencies. For example, a service using `app.proxy.example.com` prevents deletion of `proxy.example.com`.
 
-<Note>
-    Before deleting a custom domain, make sure no active services are using it. Services referencing a deleted domain will no longer route traffic correctly.
-</Note>
+Once no services depend on the domain, click the delete action next to it in the list. Built-in domains (Free or Cluster) cannot be deleted.
+
+If services still reference the domain, NetBird refuses deletion and the API returns HTTP `412 Precondition Failed`. The domain and its services remain unchanged, and no domain deletion activity event is recorded.
 
 ## Using domains with services
 


### PR DESCRIPTION
Custom domains now remain registered while services depend on them. Explain that administrators must delete or move every dependent service, including disabled services and services using subdomains, before removing the domain.

Document the HTTP 412 response and that a refused deletion preserves the domain and services without recording a deletion event.

Validation: `npm run lint:mdx` passed for all 296 pages and `npm run build` completed successfully.

Companion implementation PR: https://github.com/netbirdio/netbird/pull/7515


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated custom-domain deletion guidance to clarify that all services using the domain or its subdomains—including disabled services—must be deleted or moved first.
  - Documented that deletion is refused with an HTTP 412 error while services still reference the domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->